### PR TITLE
fixed 1.4.22 metadata search that errors on "stageposition"

### DIFF
--- a/waveorder/io/multipagetiff.py
+++ b/waveorder/io/multipagetiff.py
@@ -56,16 +56,19 @@ class MicromanagerOmeTiffReader:
         with TiffFile(self.master_ome_tiff) as tif:
             self.mm_meta = tif.micromanager_metadata
 
-            if 'beta' in self.mm_meta['Summary']['MicroManagerVersion']:
-
+            mm_version = self.mm_meta['Summary']['MicroManagerVersion']
+            if 'beta' in mm_version:
                 if self.mm_meta['Summary']['Positions'] > 1:
                     self.stage_positions = []
 
                     for p in range(len(self.mm_meta['Summary']['StagePositions'])):
                         pos = self._simplify_stage_position_beta(self.mm_meta['Summary']['StagePositions'][p])
                         self.stage_positions.append(pos)
-
                 # self.channel_names = 'Not Listed'
+
+            elif mm_version == '1.4.22':
+                for ch in self.mm_meta['Summary']['ChNames']:
+                    self.channel_names.append(ch)
 
             else:
                 if self.mm_meta['Summary']['Positions'] > 1:

--- a/waveorder/io/reader.py
+++ b/waveorder/io/reader.py
@@ -116,60 +116,60 @@ class MicromanagerReader:
         return self.frames, self.slices, self.channels, self.height, self.width
 
 
-def main():
-    no_positions = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/image_files_tpzc_200tp_1p_5z_3c_2k_1'
-    multipositions = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/image_stack_tpzc_50tp_4p_5z_3c_2k_1'
-
-    master_new_folder = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/test_1/'
-    non_master_new_folder = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/test_1/'
-    non_master_new_large_folder = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/image_stack_tpzc_50tp_4p_5z_3c_2k_1/'
-    # non_master_old_large_folder = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_50tp_4p_5z_3c_2k_1/'
-
-    master_old_folder = '/Volumes/comp_micro/rawdata/hummingbird/Janie/2021_02_03_40x_04NA_A549/48hr_RSV_IFN/Coverslip_1/C1_MultiChan_Stack_1/'
-    non_master_old_folder = '/Volumes/comp_micro/rawdata/hummingbird/Janie/2021_02_03_40x_04NA_A549/48hr_RSV_IFN/Coverslip_1/C1_MultiChan_Stack_1/'
-
-    ivan_dataset = '/Volumes/comp_micro/rawdata/falcon/Ivan/20210128 HEK CAAX SiRActin/FOV1_1'
-    ivan_file = 'FOV1_1_MMStack_Default_23.ome.tif'
-
-    # singlepage tiffs (1422)
-    mm1_single = '/Users/bryant.chhun/Desktop/mm2_sampledata/packaged for gdd/mm1422_kazansky_one_position/mm1422_kazansky_one_position'
-    mm1_multi_snake = '/Users/bryant.chhun/Desktop/mm2_sampledata/packaged for gdd/mm1422_kazansky_HCS_snake/mm1422_kazansky_HCS_snake'
-    mm1_multi_grid = '/Users/bryant.chhun/Desktop/mm2_sampledata/packaged for gdd/mm1422_kazansky_grid/mm1422_kazansky_grid'
-
-    # ome tiffs (1422)
-    mm1_multi_pos = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm1422/ome-tiffs/mm1422_4p_2t_5z_3c_512_1'
-
-    # ome tiffs (2.0)
-    # with position
-    mm2_p_t_z_c = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_4p_2t_5z_1c_2k_1'
-    mm2_p_t_z = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_4p_2t_5z_2k_1'
-    mm2_p_t_c = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_4p_2t_3c_2k_1'
-    mm2_p_z_c = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_4p_5z_3c_2k_1'
-    mm2_p_t = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_4p_2t_2k_1'
-    mm2_p_c = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_4p_3c_2k_1'
-    mm2_p_z = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_4p_5z_2k_1'
-
-    # without position
-    mm2_t_z_c = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_1t_5z_3c_2k_1'
-    mm2_t_z = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_1t_5z_2k_1'
-    mm2_t_c = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_50tp_2c_2k_1'
-    mm2_z_c = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_5z_3c_2k_1'
-
-    # without three
-    mm2_p = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_4p_2k_1'
-    mm2_t = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_1t_2k_1'
-    mm2_c = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_1c_2k_1'
-    mm2_z = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_5z_2k_1'
-
-    r = MicromanagerReader(multipositions,
-                           # data_type='singlepagetiff',
-                           data_type='ometiff',
-                           extract_data=True)
-    print(r.get_zarr(0))
-    # print(r.get_zarr(1))
-    # print(r.get_master_ome())
-    print(r.get_num_positions())
-
-
-if __name__ == "__main__":
-    main()
+# def main():
+#     no_positions = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/image_files_tpzc_200tp_1p_5z_3c_2k_1'
+#     multipositions = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/image_stack_tpzc_50tp_4p_5z_3c_2k_1'
+#
+#     master_new_folder = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/test_1/'
+#     non_master_new_folder = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/test_1/'
+#     non_master_new_large_folder = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/image_stack_tpzc_50tp_4p_5z_3c_2k_1/'
+#     # non_master_old_large_folder = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_50tp_4p_5z_3c_2k_1/'
+#
+#     master_old_folder = '/Volumes/comp_micro/rawdata/hummingbird/Janie/2021_02_03_40x_04NA_A549/48hr_RSV_IFN/Coverslip_1/C1_MultiChan_Stack_1/'
+#     non_master_old_folder = '/Volumes/comp_micro/rawdata/hummingbird/Janie/2021_02_03_40x_04NA_A549/48hr_RSV_IFN/Coverslip_1/C1_MultiChan_Stack_1/'
+#
+#     ivan_dataset = '/Volumes/comp_micro/rawdata/falcon/Ivan/20210128 HEK CAAX SiRActin/FOV1_1'
+#     ivan_file = 'FOV1_1_MMStack_Default_23.ome.tif'
+#
+#     # singlepage tiffs (1422)
+#     mm1_single = '/Users/bryant.chhun/Desktop/mm2_sampledata/packaged for gdd/mm1422_kazansky_one_position/mm1422_kazansky_one_position'
+#     mm1_multi_snake = '/Users/bryant.chhun/Desktop/mm2_sampledata/packaged for gdd/mm1422_kazansky_HCS_snake/mm1422_kazansky_HCS_snake'
+#     mm1_multi_grid = '/Users/bryant.chhun/Desktop/mm2_sampledata/packaged for gdd/mm1422_kazansky_grid/mm1422_kazansky_grid'
+#
+#     # ome tiffs (1422)
+#     mm1_multi_pos = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm1422/ome-tiffs/mm1422_4p_2t_5z_3c_512_1'
+#
+#     # ome tiffs (2.0)
+#     # with position
+#     mm2_p_t_z_c = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_4p_2t_5z_1c_2k_1'
+#     mm2_p_t_z = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_4p_2t_5z_2k_1'
+#     mm2_p_t_c = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_4p_2t_3c_2k_1'
+#     mm2_p_z_c = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_4p_5z_3c_2k_1'
+#     mm2_p_t = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_4p_2t_2k_1'
+#     mm2_p_c = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_4p_3c_2k_1'
+#     mm2_p_z = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_4p_5z_2k_1'
+#
+#     # without position
+#     mm2_t_z_c = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_1t_5z_3c_2k_1'
+#     mm2_t_z = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_1t_5z_2k_1'
+#     mm2_t_c = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_50tp_2c_2k_1'
+#     mm2_z_c = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_5z_3c_2k_1'
+#
+#     # without three
+#     mm2_p = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_4p_2k_1'
+#     mm2_t = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_1t_2k_1'
+#     mm2_c = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_1c_2k_1'
+#     mm2_z = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_5z_2k_1'
+#
+#     r = MicromanagerReader(multipositions,
+#                            # data_type='singlepagetiff',
+#                            data_type='ometiff',
+#                            extract_data=True)
+#     print(r.get_zarr(0))
+#     # print(r.get_zarr(1))
+#     # print(r.get_master_ome())
+#     print(r.get_num_positions())
+#
+#
+# if __name__ == "__main__":
+#     main()

--- a/waveorder/io/reader.py
+++ b/waveorder/io/reader.py
@@ -116,58 +116,60 @@ class MicromanagerReader:
         return self.frames, self.slices, self.channels, self.height, self.width
 
 
-# def main():
-#     no_positions = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/image_files_tpzc_200tp_1p_5z_3c_2k_1'
-#     multipositions = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/image_stack_tpzc_50tp_4p_5z_3c_2k_1'
-#
-#     master_new_folder = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/test_1/'
-#     non_master_new_folder = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/test_1/'
-#     non_master_new_large_folder = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/image_stack_tpzc_50tp_4p_5z_3c_2k_1/'
-#     # non_master_old_large_folder = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_50tp_4p_5z_3c_2k_1/'
-#
-#     master_old_folder = '/Volumes/comp_micro/rawdata/hummingbird/Janie/2021_02_03_40x_04NA_A549/48hr_RSV_IFN/Coverslip_1/C1_MultiChan_Stack_1/'
-#     non_master_old_folder = '/Volumes/comp_micro/rawdata/hummingbird/Janie/2021_02_03_40x_04NA_A549/48hr_RSV_IFN/Coverslip_1/C1_MultiChan_Stack_1/'
-#
-#     ivan_dataset = '/Volumes/comp_micro/rawdata/falcon/Ivan/20210128 HEK CAAX SiRActin/FOV1_1'
-#     ivan_file = 'FOV1_1_MMStack_Default_23.ome.tif'
-#
-#     # singlepage tiffs
-#     mm1_single = '/Users/bryant.chhun/Desktop/mm2_sampledata/packaged for gdd/mm1422_kazansky_one_position/mm1422_kazansky_one_position'
-#     mm1_multi_snake = '/Users/bryant.chhun/Desktop/mm2_sampledata/packaged for gdd/mm1422_kazansky_HCS_snake/mm1422_kazansky_HCS_snake'
-#     mm1_multi_grid = '/Users/bryant.chhun/Desktop/mm2_sampledata/packaged for gdd/mm1422_kazansky_grid/mm1422_kazansky_grid'
-#     mm1_multi_large = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm1422/autosave_mm1422_50tp_4p_3c_2k_1'
-#
-#     # ome tiffs
-#     # with position
-#     mm2_p_t_z_c = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_4p_2t_5z_1c_2k_1'
-#     mm2_p_t_z = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_4p_2t_5z_2k_1'
-#     mm2_p_t_c = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_4p_2t_3c_2k_1'
-#     mm2_p_z_c = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_4p_5z_3c_2k_1'
-#     mm2_p_t = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_4p_2t_2k_1'
-#     mm2_p_c = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_4p_3c_2k_1'
-#     mm2_p_z = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_4p_5z_2k_1'
-#
-#     # without position
-#     mm2_t_z_c = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_1t_5z_3c_2k_1'
-#     mm2_t_z = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_1t_5z_2k_1'
-#     mm2_t_c = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_50tp_2c_2k_1'
-#     mm2_z_c = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_5z_3c_2k_1'
-#
-#     # without three
-#     mm2_p = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_4p_2k_1'
-#     mm2_t = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_1t_2k_1'
-#     mm2_c = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_1c_2k_1'
-#     mm2_z = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_5z_2k_1'
-#
-#     r = MicromanagerReader(mm1_multi_large,
-#                            data_type='singlepagetiff',
-#                            # data_type='ometiff',
-#                            extract_data=True)
-#     print(r.get_zarr(0))
-#     # print(r.get_zarr(1))
-#     # print(r.get_master_ome())
-#     print(r.get_num_positions())
-#
-#
-# if __name__ == "__main__":
-#     main()
+def main():
+    no_positions = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/image_files_tpzc_200tp_1p_5z_3c_2k_1'
+    multipositions = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/image_stack_tpzc_50tp_4p_5z_3c_2k_1'
+
+    master_new_folder = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/test_1/'
+    non_master_new_folder = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/test_1/'
+    non_master_new_large_folder = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/image_stack_tpzc_50tp_4p_5z_3c_2k_1/'
+    # non_master_old_large_folder = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_50tp_4p_5z_3c_2k_1/'
+
+    master_old_folder = '/Volumes/comp_micro/rawdata/hummingbird/Janie/2021_02_03_40x_04NA_A549/48hr_RSV_IFN/Coverslip_1/C1_MultiChan_Stack_1/'
+    non_master_old_folder = '/Volumes/comp_micro/rawdata/hummingbird/Janie/2021_02_03_40x_04NA_A549/48hr_RSV_IFN/Coverslip_1/C1_MultiChan_Stack_1/'
+
+    ivan_dataset = '/Volumes/comp_micro/rawdata/falcon/Ivan/20210128 HEK CAAX SiRActin/FOV1_1'
+    ivan_file = 'FOV1_1_MMStack_Default_23.ome.tif'
+
+    # singlepage tiffs (1422)
+    mm1_single = '/Users/bryant.chhun/Desktop/mm2_sampledata/packaged for gdd/mm1422_kazansky_one_position/mm1422_kazansky_one_position'
+    mm1_multi_snake = '/Users/bryant.chhun/Desktop/mm2_sampledata/packaged for gdd/mm1422_kazansky_HCS_snake/mm1422_kazansky_HCS_snake'
+    mm1_multi_grid = '/Users/bryant.chhun/Desktop/mm2_sampledata/packaged for gdd/mm1422_kazansky_grid/mm1422_kazansky_grid'
+
+    # ome tiffs (1422)
+    mm1_multi_pos = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm1422/ome-tiffs/mm1422_4p_2t_5z_3c_512_1'
+
+    # ome tiffs (2.0)
+    # with position
+    mm2_p_t_z_c = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_4p_2t_5z_1c_2k_1'
+    mm2_p_t_z = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_4p_2t_5z_2k_1'
+    mm2_p_t_c = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_4p_2t_3c_2k_1'
+    mm2_p_z_c = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_4p_5z_3c_2k_1'
+    mm2_p_t = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_4p_2t_2k_1'
+    mm2_p_c = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_4p_3c_2k_1'
+    mm2_p_z = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_4p_5z_2k_1'
+
+    # without position
+    mm2_t_z_c = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_1t_5z_3c_2k_1'
+    mm2_t_z = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_1t_5z_2k_1'
+    mm2_t_c = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_50tp_2c_2k_1'
+    mm2_z_c = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_5z_3c_2k_1'
+
+    # without three
+    mm2_p = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_4p_2k_1'
+    mm2_t = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_1t_2k_1'
+    mm2_c = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_1c_2k_1'
+    mm2_z = '/Users/bryant.chhun/Desktop/Data/reconstruct-order-2/mm2.0_20201113_5z_2k_1'
+
+    r = MicromanagerReader(multipositions,
+                           # data_type='singlepagetiff',
+                           data_type='ometiff',
+                           extract_data=True)
+    print(r.get_zarr(0))
+    # print(r.get_zarr(1))
+    # print(r.get_master_ome())
+    print(r.get_num_positions())
+
+
+if __name__ == "__main__":
+    main()

--- a/waveorder/io/singlepagetiff.py
+++ b/waveorder/io/singlepagetiff.py
@@ -52,21 +52,7 @@ class MicromanagerSequenceReader:
         else:
             raise AttributeError("supplied folder does not contain position or default subdirectories")
 
-        # pull one metadata sample and extract experiment dimensions
-        metadata_path = os.path.join(pos_path, 'metadata.txt')
-        with open(metadata_path, 'r') as f:
-            self.mm_meta = json.load(f)
-
-        self.mm_version = self.mm_meta['Summary']['MicroManagerVersion']
-        if self.mm_version == '1.4.22':
-            self._mm1_meta_parser()
-        elif 'beta' in self.mm_version:
-            self._mm2beta_meta_parser()
-        elif 'gamma' in self.mm_version:
-            self._mm2gamma_meta_parser()
-        else:
-            raise NotImplementedError(
-                f'Current MicroManager reader only supports version 1.4.22 and 2.0 but {self.mm_version} was detected')
+        self._set_mm_meta(pos_path)
 
         # create coordinate to filename maps
         self.coord_to_filename = self.read_tiff_series(folder)
@@ -74,6 +60,34 @@ class MicromanagerSequenceReader:
         # todo: consider iterating over all positions.  Doable once we add a metadata search for stage positions
         if extract_data:
             self._create_stores(0)
+
+    def _set_mm_meta(self, one_pos):
+        """
+        assign image metadata from summary metadata
+
+        Parameters
+        ----------
+        one_pos:        (str) path to one position subfolder
+
+        Returns
+        -------
+
+        """
+        # pull one metadata sample and extract experiment dimensions
+        metadata_path = os.path.join(one_pos, 'metadata.txt')
+        with open(metadata_path, 'r') as f:
+            self.mm_meta = json.load(f)
+
+        mm_version = self.mm_meta['Summary']['MicroManagerVersion']
+        if mm_version == '1.4.22':
+            self._mm1_meta_parser()
+        elif 'beta' in mm_version:
+            self._mm2beta_meta_parser()
+        elif 'gamma' in mm_version:
+            self._mm2gamma_meta_parser()
+        else:
+            raise NotImplementedError(
+                f'Current MicroManager reader only supports version 1.4.22 and 2.0 but {mm_version} was detected')
 
     def get_zarr(self, position):
         """


### PR DESCRIPTION
**condition**
ome-tiff images acquired in 1.4.22 do not have "stageposition" key in their metadata

**solution**
changed the metadata assignment for 1.4.22 to exclude "stageposition" search

Additionally ...
I made a small refactor to match singlepage-multipage tiff class structures (created a `_set_mm_meta` method for singlepage-tiff reader.)