### PR TITLE
Denoise padding

### DIFF
--- a/tests/reader/test_reader.py
+++ b/tests/reader/test_reader.py
@@ -27,6 +27,7 @@ def test_ometiff_constructor_mm2gamma(setup_mm2gamma_ome_tiffs):
 
     assert(mmr.mm_meta is not None)
     assert(mmr.stage_positions is not None)
+    assert(mmr.z_step_size is not None)
     assert(mmr.width is not 0)
     assert(mmr.height is not 0)
     assert(mmr.frames is not 0)
@@ -64,6 +65,7 @@ def test_sequence_constructor_mm2gamma(setup_mm2gamma_singlepage_tiffs):
                              'singlepagetiff',
                              extract_data=False)
     assert(mmr.mm_meta is not None)
+    assert(mmr.z_step_size is not None)
     assert(mmr.width is not 0)
     assert(mmr.height is not 0)
     assert(mmr.frames is not 0)
@@ -103,6 +105,7 @@ def test_ometiff_constructor_mm1422(setup_mm1422_ome_tiffs):
 
     assert(mmr.mm_meta is not None)
     assert(mmr.stage_positions is not None)
+    assert(mmr.z_step_size is not None)
     assert(mmr.width is not 0)
     assert(mmr.height is not 0)
     assert(mmr.frames is not 0)
@@ -140,6 +143,7 @@ def test_sequence_constructor_mm1422(setup_mm1422_singlepage_tiffs):
                              'singlepagetiff',
                              extract_data=False)
     assert(mmr.mm_meta is not None)
+    assert(mmr.z_step_size is not None)
     assert(mmr.width is not 0)
     assert(mmr.height is not 0)
     assert(mmr.frames is not 0)
@@ -247,3 +251,10 @@ def test_stage_positions(setup_mm2gamma_ome_tiffs):
     with pytest.raises(AssertionError):
         mmr.stage_positions = 1
 
+def test_z_step_size(setup_mm2gamma_ome_tiffs):
+    _, _, rand_folder = setup_mm2gamma_ome_tiffs
+    mmr = MicromanagerReader(rand_folder,
+                             'ometiff',
+                             extract_data=False)
+    mmr.z_step_size = 1.75
+    assert (mmr.z_step_size == mmr.reader.z_step_size)

--- a/waveorder/io/reader.py
+++ b/waveorder/io/reader.py
@@ -125,6 +125,14 @@ class MicromanagerReader:
         self.reader.stage_positions = value
 
     @property
+    def z_step_size(self):
+        return self.reader.z_step_size
+
+    @z_step_size.setter
+    def z_step_size(self, value):
+        self.reader.z_step_size = value
+
+    @property
     def height(self):
         return self.reader.height
 

--- a/waveorder/util.py
+++ b/waveorder/util.py
@@ -340,8 +340,28 @@ def wavelet_softThreshold(img, wavelet, threshold, level = 1):
                     denoised image or volume in nD space
     
     '''
+
+    shape = np.shape(img)
+    padding = []
+    unpadding = []
+
+    for dim in shape:
+        # No padding
+        if dim % 2 == 0:
+            padding.append((0, 0))
+            unpadding.append(slice(None))
+
+        # pad dimension
+        else:
+            padding.append((0, 1))
+            unpadding.append(slice(0, -1))
+
+    padding = tuple(padding)
+    unpadding = tuple(unpadding)
+
+    img_padded = np.pad(img, padding, 'edge')
     
-    coeffs = pywt.wavedecn(img, wavelet, level=level)
+    coeffs = pywt.wavedecn(img_padded, wavelet, level=level)
     
     for i in range(level+1):
         if i == 0:
@@ -352,7 +372,7 @@ def wavelet_softThreshold(img, wavelet, threshold, level = 1):
 
     img_thres = pywt.waverecn(coeffs, wavelet)
     
-    return img_thres
+    return img_thres[unpadding]
 
 
 def array_based_4x4_det(a):


### PR DESCRIPTION
pywt denoising only works on even dimensions, and will return an array of different dimensions to the input if the input has odd dimensions.  This PR implements padding of the odd dimension and has the function then return the unpadded denoised array.