### PR TITLE
UPTI File Reader

### DIFF
--- a/tests/reader/test_zarrfile.py
+++ b/tests/reader/test_zarrfile.py
@@ -1,6 +1,7 @@
 import pytest
 from waveorder.io.zarrfile import ZarrReader
 import zarr
+import numpy as np
 
 def test_constructor_mm2gamma(setup_mm2gamma_zarr):
     """
@@ -55,7 +56,7 @@ def test_get_zarr_mm2gamma(setup_mm2gamma_zarr):
 
     for i in range(mmr.get_num_positions()):
         z = mmr.get_zarr(i)
-        assert(isinstance(z, zarr.Group))
+        assert(isinstance(z, zarr.core.Array))
 
 def test_get_array_mm2gamma(setup_mm2gamma_zarr):
 
@@ -65,7 +66,7 @@ def test_get_array_mm2gamma(setup_mm2gamma_zarr):
     for i in range(mmr.get_num_positions()):
         z = mmr.get_array(i)
         assert(z.shape == mmr.shape)
-        assert(isinstance(z, zarr.core.Array))
+        assert(isinstance(z, np.ndarray))
 
 def test_get_num_positions_mm2gamma(setup_mm2gamma_zarr):
 

--- a/waveorder/io/reader.py
+++ b/waveorder/io/reader.py
@@ -1,9 +1,9 @@
 
 from waveorder.io.singlepagetiff import MicromanagerSequenceReader
 from waveorder.io.multipagetiff import MicromanagerOmeTiffReader
+from waveorder.io.upti import UPTIReader
 from waveorder.io.zarrfile import ZarrReader
 import logging
-
 
 # replicate from aicsimageio logging mechanism
 ###############################################################################
@@ -56,6 +56,8 @@ class WaveorderReader:
             self.reader = MicromanagerSequenceReader(src, extract_data)
         elif data_type == 'zarr':
             self.reader = ZarrReader(src)
+        elif data_type == 'upti':
+            self.reader = UPTIReader(src, extract_data)
         else:
             raise NotImplementedError(f"reader of type {data_type} is not implemented")
 

--- a/waveorder/io/reader.py
+++ b/waveorder/io/reader.py
@@ -23,7 +23,7 @@ import logging
 
 ###############################################################################
 
-
+#todo: add dim_order to all reader objects
 class WaveorderReader:
 
     def __init__(self,

--- a/waveorder/io/upti.py
+++ b/waveorder/io/upti.py
@@ -1,0 +1,121 @@
+import numpy as np
+import os
+import re
+from copy import copy
+import tifffile as tiff
+import glob
+from waveorder.io.reader_interface import ReaderInterface
+
+
+class UPTIReader(ReaderInterface):
+
+    """
+    Reader for HCS ome-zarr arrays.  OME-zarr structure can be found here: https://ngff.openmicroscopy.org/0.1/
+    Also collects the HCS metadata so it can be later copied.
+    """
+
+    def __init__(self, folder: str, extract_data: bool = False):
+
+        # zarr files (.zarr) are directories
+        if not os.path.isdir(folder):
+            raise ValueError("folder does not exist")
+
+        self.data_folder = folder
+        self.files = glob.glob(os.path.join(folder, '*.tif'))
+        info_img = tiff.imread(self.files[0]).dtype
+        self.dtype = info_img.dtype
+        (self.height, self.width) = info_img.shape
+        self.positions = 1
+        self.frames = 1
+        self.patterns = 0
+        self.states = 0
+        self.slices = 0
+        self.channel_names = []
+        self._map_files()
+        self.channels = len(self.channel_names)
+
+        # structure of zarr array
+        self.stage_positions = 1
+        self.z_step_size = None
+        self.position_map = ()
+
+        # initialize metadata
+        self.mm_meta = None
+        if extract_data:
+            self._create
+
+
+    def _map_files(self):
+        self.file_map = dict()
+
+        states = True if 'State' in self.files[0] else False
+        for file in self.files:
+            pattern = re.search('pattern_\d\d\d', file).group(0)
+            pattern_idx = int(pattern.strip('pattern_'))
+            z = int(re.search('z_\d\d\d', file).group(0).strip('z_'))
+            state_idx = 0
+
+            if pattern_idx > self.patterns:
+                self.patterns = pattern_idx
+
+            if z > self.slices:
+                self.slices = z
+
+            if states:
+                state = re.search('State_\d\d\d', file).group(0)
+                state_idx = int(state.strip('State_'))
+
+                if f'{pattern}_{state}' not in self.channel_names:
+                    self.channel_names.append(pattern)
+            else:
+                if pattern not in self.channel_names:
+                    self.channel_names.append(pattern)
+
+            self.file_map[(pattern_idx, state_idx, z)] = file
+
+            self.channel_names.sort(key=lambda x: re.sub('State_\d\d\d', '', x)) # sorts pattern first
+
+    def get_zarr(self, position=0):
+        """
+        Returns the position-level zarr group
+
+        Parameters
+        ----------
+        position:       (int) position index
+
+        Returns
+        -------
+        (ZarrGroup) Position subgroup containing the array group+data
+
+        """
+        if position > self.positions - 1:
+            raise ValueError('Entered position is greater than the number of positions in the data')
+
+        pos_info = self.position_map[position]
+        well = pos_info['well']
+        pos = pos_info['name']
+        return self.store[well][pos]
+
+    def get_array(self, position):
+        """
+        Gets the (T, C, Z, Y, X) array at given position
+
+        Parameters
+        ----------
+        position:       (int) position index
+
+        Returns
+        -------
+        (ZarrArray) Zarr array of size (T, C, Z, Y, X) at specified position
+
+        """
+        pos = self.get_zarr(position)
+        return pos['array']
+
+    def get_num_positions(self) -> int:
+        return self.positions
+
+    @property
+    def shape(self):
+        return self.frames, self.channels, self.slices, self.height, self.width
+

--- a/waveorder/io/upti.py
+++ b/waveorder/io/upti.py
@@ -58,18 +58,23 @@ class UPTIReader(ReaderInterface):
         self.file_map = dict()
 
         states = True if 'State' in self.files[0] else False
+
+        # Loop through the files and use regex to grab patterns and states,
+        # **hardcoded file name structure**
         for file in self.files:
             pattern = re.search('pattern_\d\d\d', file).group(0)
             pattern_idx = int(pattern.strip('pattern_'))
             z = int(re.search('z_\d\d\d', file).group(0).strip('z_'))
             state_idx = 0
 
+            # update dimensionality as we read the file names
             if pattern_idx + 1 > self.patterns:
                 self.patterns = pattern_idx + 1
 
             if z + 1 > self.slices:
                 self.slices = z + 1
 
+            # if live upti, grab the states, otherwise just use patterns
             if states:
                 state = re.search('State_\d\d\d', file).group(0)
                 state_idx = int(state.strip('State_'))

--- a/waveorder/io/zarrfile.py
+++ b/waveorder/io/zarrfile.py
@@ -44,8 +44,13 @@ class ZarrReader(ReaderInterface):
 
         # initialize metadata
         self.mm_meta = None
-        self._set_mm_meta()
+        if self.store.attrs.get('Summary'):
+            self._set_mm_meta()
         self._generate_hcs_meta()
+
+        # get channel names from omero metadata if no MM meta present
+        if len(self.channel_names) == 0:
+            self._get_channel_names()
 
     def _get_rows(self):
         """
@@ -141,9 +146,9 @@ class ZarrReader(ReaderInterface):
                     pos = self._simplify_stage_position_beta(self.mm_meta['StagePositions'][p])
                     self.stage_positions.append(pos)
 
-        elif mm_version == '1.4.22':
-            for ch in self.mm_meta['ChNames']:
-                self.channel_names.append(ch)
+        # elif mm_version == '1.4.22':
+        #     for ch in self.mm_meta['ChNames']:
+        #         self.channel_names.append(ch)
         else:
             if self.mm_meta['Positions'] > 1:
                 self.stage_positions = []
@@ -152,10 +157,20 @@ class ZarrReader(ReaderInterface):
                     pos = self._simplify_stage_position(self.mm_meta['StagePositions'][p])
                     self.stage_positions.append(pos)
 
-            for ch in self.mm_meta['ChNames']:
-                self.channel_names.append(ch)
+            # for ch in self.mm_meta['ChNames']:
+            #     self.channel_names.append(ch)
 
         self.z_step_size = self.mm_meta['z-step_um']
+
+    def _get_channel_names(self):
+
+        well = self.hcs_meta['plate']['wells'][0]['path']
+        pos = self.hcs_meta['well'][0]['images'][0]['path']
+
+        omero_meta = self.store[well][pos].attrs.asdict()['omero']
+
+        for chan in omero_meta['channels']:
+            self.channel_names.append(chan['label'])
 
     def _simplify_stage_position(self, stage_pos: dict):
         """
@@ -244,7 +259,7 @@ class ZarrReader(ReaderInterface):
         pos_info = self.position_map[position]
         well = pos_info['well']
         pos = pos_info['name']
-        return self.store[well][pos]
+        return self.store[well][pos]['array']
 
     def get_array(self, position):
         """
@@ -260,7 +275,7 @@ class ZarrReader(ReaderInterface):
 
         """
         pos = self.get_zarr(position)
-        return pos['array']
+        return pos[:]
 
     def get_num_positions(self) -> int:
         return self.positions

--- a/waveorder/io/zarrfile.py
+++ b/waveorder/io/zarrfile.py
@@ -245,7 +245,7 @@ class ZarrReader(ReaderInterface):
 
     def get_zarr(self, position):
         """
-        Returns the position-level zarr group
+        Returns the position-level zarr group array (not in memory)
 
         Parameters
         ----------
@@ -253,7 +253,7 @@ class ZarrReader(ReaderInterface):
 
         Returns
         -------
-        (ZarrGroup) Position subgroup containing the array group+data
+        (ZarrArray) Zarr array containing the (T, C, Z, Y, X) array at given position
 
         """
         pos_info = self.position_map[position]
@@ -271,7 +271,7 @@ class ZarrReader(ReaderInterface):
 
         Returns
         -------
-        (ZarrArray) Zarr array of size (T, C, Z, Y, X) at specified position
+        (nd-Array) numpy array of size (T, C, Z, Y, X) at specified position
 
         """
         pos = self.get_zarr(position)


### PR DESCRIPTION
This creates a reader subclass that allows for reading of UPTI files.

Creates a lazy zarr store in memory with the UPTI channels (patterns, states)

Works with both live upti and original upti which has states present or not present.

I have it hardcoded right now that the channels will always go pattern then state. i.e. an acquisition with 9 patterns and 4 states would have the following channel order and channel names:
```
channel_names = ['pattern_000_state_000',
                 'pattern_000_state_001',
                 'pattern_000_state_002',
                 'pattern_000_state_003',
                 'pattern_001_state_000',
                 ...]
```

the placement of the channel in the array corresponds to the order of the list.

This reader will be used for the zarr converter and UPTI can now be converted to a zarr store on disk