### PR TITLE
Pin pywavelets version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,10 +35,10 @@ python_requires = >3.7
 setup_requires = setuptools_scm
 # add your package requirements here
 install_requires =
+    pywavelets==1.1.1
     numpy>=1.17.4
     matplotlib>=3.1.1
     scipy>=1.3.0
-    pywavelets>=1.1.1
     ipywidgets>=7.5.1
     opencv-python>=3.4.1
     tifffile>=2021.11.2


### PR DESCRIPTION
`pywavelets` latest release doesn't have working wheels, which is interrupting my testing. I'm pinning `pywavelets` for now so that we can continue. 

When this `pywavelets` issue is resolved we can consider unpinning: 
https://github.com/PyWavelets/pywt/issues/656