### PR TITLE
Make "Stokes transform" consistent between full (used by QLIPP) and linear (used by PTI) Stokes polarimeters

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,8 @@ import shutil
 import os
 import random
 from wget import download
+import numpy as np
+import waveorder as wo
 
 MM2GAMMA_OMETIFF_SUBFOLDERS = \
     {
@@ -174,3 +176,8 @@ def setup_pycromanager_test_data():
     first_dir, rand_dir, ptcz_dir = (dataset_dirs[0], random.choice(dataset_dirs), dataset_dirs[3])
 
     yield first_dir, rand_dir, ptcz_dir
+
+@pytest.fixture(scope="function")
+def setup_single_voxel_recon():
+    recon = wo.waveorder_microscopy(img_dim=(1,1), lambda_illu=500, ps=1, NA_obj=0, NA_illu=0, z_defocus=[0], chi=2*np.pi*0.1, cali=True)
+    yield recon

--- a/tests/reconstructor/test_stokes_recon.py
+++ b/tests/reconstructor/test_stokes_recon.py
@@ -1,0 +1,20 @@
+import numpy as np
+
+def test_stokes_recon(setup_single_voxel_recon):
+    recon = setup_single_voxel_recon
+
+    # NOTE: skip retardance = 0 because orientation is not defined
+    for retardance in np.linspace(1e-3, 1.0, 25): # fractions of a wave
+        for orientation in np.linspace(0, np.pi-0.01, 25): # radians
+            
+            stokes = np.array([1,
+                               -np.sin(retardance)*np.sin(2*orientation),
+                               -np.sin(retardance)*np.cos(2*orientation),
+                               np.cos(retardance)
+                               ])[:, np.newaxis, np.newaxis]
+
+            norm_stokes = recon.Stokes_transform(stokes)
+            recon_params = recon.Polarization_recon(norm_stokes)
+
+            assert retardance - recon_params[0] < 1e-8
+            assert orientation - recon_params[1] < 1e-8

--- a/waveorder/waveorder_reconstructor.py
+++ b/waveorder/waveorder_reconstructor.py
@@ -1144,8 +1144,8 @@ class waveorder_microscopy:
         S_transformed[0] = S_image_recon[0]
         
         if self.N_Stokes == 4:
-            S_transformed[1] = S_image_recon[1] / S_image_recon[3]
-            S_transformed[2] = S_image_recon[2] / S_image_recon[3]
+            S_transformed[1] = S_image_recon[1] / S_image_recon[0]
+            S_transformed[2] = S_image_recon[2] / S_image_recon[0]
             S_transformed[3] = S_image_recon[3]
             S_transformed[4] = (S_image_recon[1]**2 + S_image_recon[2]**2 + S_image_recon[3]**2)**(1/2) / S_image_recon[0] # DoP
         elif self.N_Stokes == 3:
@@ -1287,13 +1287,7 @@ class waveorder_microscopy:
             Recon_para = np.zeros((self.N_Stokes,)+S_image_recon.shape[1:])
 
         if self.use_gpu:
-            
-            if self.N_Stokes == 4:
-                ret_wrapped = cp.arctan2((S_image_recon[1]**2 + S_image_recon[2]**2)**(1/2) * \
-                                         S_image_recon[3], S_image_recon[3])  # retardance
-            elif self.N_Stokes == 3:
-                ret_wrapped = cp.arcsin(cp.minimum((S_image_recon[1]**2 + S_image_recon[2]**2)**(0.5),1))
-
+            ret_wrapped = cp.arcsin(cp.minimum((S_image_recon[1]**2 + S_image_recon[2]**2)**(0.5),1))
             
             if self.cali == True:
                 sa_wrapped = 0.5*cp.arctan2(-S_image_recon[1], -S_image_recon[2]) % np.pi # slow-axis
@@ -1301,14 +1295,7 @@ class waveorder_microscopy:
                 sa_wrapped = 0.5*cp.arctan2(-S_image_recon[1], S_image_recon[2]) % np.pi # slow-axis
         
         else:
-            
-            if self.N_Stokes == 4:
-                ret_wrapped = np.arctan2((S_image_recon[1]**2 + S_image_recon[2]**2)**(1/2) * \
-                                           S_image_recon[3], S_image_recon[3])  # retardance
-            elif self.N_Stokes == 3:
-                ret_wrapped = np.arcsin(np.minimum((S_image_recon[1]**2 + S_image_recon[2]**2)**(0.5),1))
-            
-            
+            ret_wrapped = np.arcsin(np.minimum((S_image_recon[1]**2 + S_image_recon[2]**2)**(0.5),1))
             
             if self.cali == True:
                 sa_wrapped = 0.5*np.arctan2(-S_image_recon[1], -S_image_recon[2]) % np.pi # slow-axis


### PR DESCRIPTION
During development of the background corrections I've repeatedly run into the following questions:
1. why does the Stokes transform normalize S1 & S2 by S3 for QLIPP and S0 for PTI?
2. why are the retardance calculations for QLIPP (`arctan2(sqrt(s1**2 + s2**2)*s3, s3)`) and PTI (`arcsin(sqrt(s1**2 + s2**2))`) different?

The first question is particularly important if we're hoping to background correct and use S1, S2, and S3 downstream. For example, if we put in a unit-intensity, purely polarized Stokes vector `[1, 1/sqrt(2), 1/2, 1/2]` (note that `S1**2 + S2**2 + S3**2 = 1`) into the QLIPP path of `Stokes_transform`, we receive `[S0, S1/S3, S2/S3,  S3] = [1, sqrt(2), 1, 1/2]` which yields a different retardance than the raw (already normalized) initial Stokes vector would. It seems that the QLIPP "Stokes transform" does more than just normalize...

I've realized that the two questions above are coupled, and this PR makes the "Stokes transform" and retardance calculation consistent between QLIPP and PTI. 

On closer inspection, I found that the s3 normalization *together with* the arctan calculation gives the same retardance as an s0 normalization together with the arcsin calculation. Mathematically, 
$$\tan^{-1}\left(\sqrt{(s_1^2 + s_2^2)/s_3^2}\right) = \sin^{-1}(\sqrt{s_1^2 + s_2^2})$$ when $s_1^2 + s_2^2 + s_3^2 = 1$. 

This equivalence allows us to always normalize by s0 and always use $\sin^{-1}(\sqrt{s_1^2 + s_2^2})$ to calculate retardance.

----- 

My first commit adds a simple test for a large range of retardances and orientations. I confirmed that these tests passed before and after the main changes in this PR: always normalize by S0, and always use the $\sin^{-1}(\sqrt{s_1^2 + s_2^2})$ to calculate retardance. 

I will test this change experimentally with recOrder before merging, and I invite discussion before then. 
