### PR TITLE
New Stokes and Mueller module

### DIFF
--- a/tests/test_stokes.py
+++ b/tests/test_stokes.py
@@ -40,47 +40,45 @@ def test_stokes_recon():
 
                 # Test attenuating retarder (AR) functions
                 AR = (ret, ori, tra)
-                s012 = stokes.s012_CPL_after_AR(*AR)
-                AR1 = stokes.inverse_s012_CPL_after_AR(*s012)
+                s012 = stokes.stokes012_after_AR(*AR)
+                AR1 = stokes.estimate_AR_from_stokes012(*s012)
                 for i in range(3):
                     assert AR[i] - AR1[i] < 1e-8
 
                 # Test attenuating depolarizing retarder (ADR) functions
                 for dop in np.arange(1e-3, 1, 0.1):
                     ADR = (ret, ori, tra, dop)
-                    s0123 = stokes.s0123_CPL_after_ADR(*ADR)
-                    ADR1 = stokes.inverse_s0123_CPL_after_ADR(*s0123)
+                    s0123 = stokes.stokes_after_ADR(*ADR)
+                    ADR1 = stokes.estimate_ADR_from_stokes(*s0123)
 
                     for i in range(4):
                         assert ADR[i] - ADR1[i] < 1e-8
 
 
-def test_s0123_CPL_after_ADR_usage():
-    x = stokes.s0123_CPL_after_ADR(1, 1, 1, 1)
+def test_stokes_after_ADR_usage():
+    x = stokes.stokes_after_ADR(1, 1, 1, 1)
 
     ret = np.ones((2, 3, 4, 5))
     ori = np.ones((2, 3, 4, 5))
     tra = np.ones((2, 3, 4, 5))
     dop = np.ones((2, 3, 4, 5))
-    x2 = stokes.s0123_CPL_after_ADR(ret, ori, tra, dop)
+    x2 = stokes.stokes_after_ADR(ret, ori, tra, dop)
 
     ADR_params = np.ones(
         (4, 2, 3, 4, 5)
     )  # first axis contains the Stokes indices
-    stokes.s0123_CPL_after_ADR(*ADR_params)  # * expands along the first axis
+    stokes.stokes_after_ADR(*ADR_params)  # * expands along the first axis
 
 
-def test_AR_mueller_from_CPL_projection():
+def test_mueller_from_stokes():
     # Check thank inv(M) == M.T, (only true when
 
-    M = stokes.AR_mueller_from_CPL_projection(
+    M = stokes.mueller_from_stokes(
         1, 1 / np.sqrt(3), 1 / np.sqrt(3), 1 / np.sqrt(3)
     )
     assert np.max(np.linalg.inv(M) - M.T) < 1e-8
 
-    M2 = stokes.AR_mueller_from_CPL_projection(
-        1, 1 / np.sqrt(2), 1 / np.sqrt(2), 0
-    )
+    M2 = stokes.mueller_from_stokes(1, 1 / np.sqrt(2), 1 / np.sqrt(2), 0)
     assert np.max(np.linalg.inv(M2) - M2.T) < 1e-8
 
 

--- a/tests/test_stokes.py
+++ b/tests/test_stokes.py
@@ -4,17 +4,25 @@ import pytest
 import numpy.testing as npt
 
 
-def test_A_matrix():
-    A5 = stokes.A_matrix(0.1)
-    assert A5.shape == (5, 4)
+def test_S2I_matrix():
+    S2I5 = stokes.S2I_matrix(0.1)
+    assert S2I5.shape == (5, 4)
 
-    A4 = stokes.A_matrix(0.1, scheme="4-State")
-    assert A4.shape == (4, 4)
+    S2I4 = stokes.S2I_matrix(0.1, scheme="4-State")
+    assert S2I4.shape == (4, 4)
 
-    npt.assert_almost_equal(stokes.A_matrix(0), stokes.A_matrix(1))
+    npt.assert_almost_equal(stokes.S2I_matrix(0), stokes.S2I_matrix(1))
 
     with pytest.raises(ValueError):
-        Ax = stokes.A_matrix(0.1, scheme="3-State")
+        A2Ix = stokes.S2I_matrix(0.1, scheme="3-State")
+
+
+def test_I2S_matrix():
+    I2S5 = stokes.I2S_matrix(0.1)
+    assert I2S5.shape == (4, 5)
+
+    I = np.matmul(stokes.I2S_matrix(0.1), stokes.S2I_matrix(0.1))
+    npt.assert_almost_equal(I, np.eye(I.shape[0]))
 
 
 def test_s12_to_ori():

--- a/tests/test_stokes.py
+++ b/tests/test_stokes.py
@@ -85,7 +85,3 @@ def test_mmul():
     with pytest.raises(ValueError):
         M2 = np.ones((3, 4, 1))
         y2 = stokes.mmul(M2, x)
-
-    with pytest.raises(ValueError):
-        M3 = np.ones((3, 2, 1, 2))
-        y3 = stokes.mmul(M3, x)

--- a/tests/test_stokes.py
+++ b/tests/test_stokes.py
@@ -10,6 +10,8 @@ def test_A_matrix():
     A4 = stokes.A_matrix(0.1, scheme="4-State")
     assert A4.shape == (4, 4)
 
+    assert np.max(stokes.A_matrix(0) - stokes.A_matrix(1)) < 1e-8
+
     with pytest.raises(KeyError):
         Ax = stokes.A_matrix(0.1, scheme="3-State")
 
@@ -42,6 +44,21 @@ def test_stokes_recon():
 
                     for i in range(4):
                         assert ADR[i] - ADR1[i] < 1e-8
+
+
+def test_s0123_CPL_after_ADR_usage():
+    x = stokes.s0123_CPL_after_ADR(1, 1, 1, 1)
+
+    ret = np.ones((2, 3, 4, 5))
+    ori = np.ones((2, 3, 4, 5))
+    tra = np.ones((2, 3, 4, 5))
+    dop = np.ones((2, 3, 4, 5))
+    x2 = stokes.s0123_CPL_after_ADR(ret, ori, tra, dop)
+
+    ADR_params = np.ones(
+        (4, 2, 3, 4, 5)
+    )  # first axis contains the Stokes indices
+    stokes.s0123_CPL_after_ADR(*ADR_params)  # * expands along the first axis
 
 
 def test_AR_mueller_from_CPL_projection():

--- a/tests/test_stokes.py
+++ b/tests/test_stokes.py
@@ -12,7 +12,7 @@ def test_A_matrix():
 
     assert np.max(stokes.A_matrix(0) - stokes.A_matrix(1)) < 1e-8
 
-    with pytest.raises(KeyError):
+    with pytest.raises(ValueError):
         Ax = stokes.A_matrix(0.1, scheme="3-State")
 
 

--- a/tests/test_stokes.py
+++ b/tests/test_stokes.py
@@ -92,3 +92,17 @@ def test_mmul():
     with pytest.raises(ValueError):
         M2 = np.ones((3, 4, 1))
         y2 = stokes.mmul(M2, x)
+
+
+def test_copying():
+    a = np.array([1, 1])
+    b = np.array([1, 1])
+    c = np.array([1, 1])
+    d = np.array([1, 1])
+    s0, s1, s2, s3 = stokes.stokes_after_ADR(a, b, c, d)
+    s0[0] = 2  # modify the output
+    assert c[0] == 1  # check that the input hasn't changed
+
+    M = stokes.mueller_from_stokes(a, b, c, d)
+    M[0, 0, 0] = -1  # modify the output
+    assert a[0] == 1

--- a/tests/test_stokes.py
+++ b/tests/test_stokes.py
@@ -1,5 +1,17 @@
 import numpy as np
 from waveorder import stokes
+import pytest
+
+
+def test_A_matrix():
+    A5 = stokes.A_matrix(0.1)
+    assert A5.shape == (5, 4)
+
+    A4 = stokes.A_matrix(0.1, scheme="4-State")
+    assert A4.shape == (4, 4)
+
+    with pytest.raises(KeyError):
+        Ax = stokes.A_matrix(0.1, scheme="3-State")
 
 
 def test_s12_to_ori():
@@ -30,3 +42,17 @@ def test_stokes_recon():
 
                     for i in range(4):
                         assert ADR[i] - ADR1[i] < 1e-8
+
+
+def test_AR_mueller_from_CPL_projection():
+    # Check thank inv(M) == M.T, (only true when
+
+    M = stokes.AR_mueller_from_CPL_projection(
+        1, 1 / np.sqrt(3), 1 / np.sqrt(3), 1 / np.sqrt(3)
+    )
+    assert np.max(np.linalg.inv(M) - M.T) < 1e-8
+
+    M2 = stokes.AR_mueller_from_CPL_projection(
+        1, 1 / np.sqrt(2), 1 / np.sqrt(2), 0
+    )
+    assert np.max(np.linalg.inv(M2) - M2.T) < 1e-8

--- a/tests/test_stokes.py
+++ b/tests/test_stokes.py
@@ -1,6 +1,7 @@
 import numpy as np
 from waveorder import stokes
 import pytest
+import numpy.testing as npt
 
 
 def test_A_matrix():
@@ -10,7 +11,7 @@ def test_A_matrix():
     A4 = stokes.A_matrix(0.1, scheme="4-State")
     assert A4.shape == (4, 4)
 
-    assert np.max(stokes.A_matrix(0) - stokes.A_matrix(1)) < 1e-8
+    npt.assert_almost_equal(stokes.A_matrix(0), stokes.A_matrix(1))
 
     with pytest.raises(ValueError):
         Ax = stokes.A_matrix(0.1, scheme="3-State")

--- a/tests/test_stokes.py
+++ b/tests/test_stokes.py
@@ -1,0 +1,32 @@
+import numpy as np
+from waveorder import stokes
+
+
+def test_s12_to_ori():
+    for ori in np.linspace(0, np.pi, 25, endpoint=False):
+        ori1 = stokes._s12_to_ori(np.sin(2 * ori), -np.cos(2 * ori))
+        assert ori - ori1 < 1e-8
+
+
+def test_stokes_recon():
+
+    # NOTE: skip retardance = 0 and dop = 0 because orientation is not defined
+    for ret in np.arange(1e-3, 1, 0.1):  # fractions of a wave
+        for ori in np.arange(0, np.pi, np.pi / 10):  # radians
+            for tra in [0.1, 10]:
+
+                # Test attenuating retarder (AR) functions
+                AR = (ret, ori, tra)
+                s012 = stokes.s012_CPL_after_AR(*AR)
+                AR1 = stokes.inverse_s012_CPL_after_AR(*s012)
+                for i in range(3):
+                    assert AR[i] - AR1[i] < 1e-8
+
+                # Test attenuating depolarizing retarder (ADR) functions
+                for dop in np.arange(1e-3, 1, 0.1):
+                    ADR = (ret, ori, tra, dop)
+                    s0123 = stokes.s0123_CPL_after_ADR(*ADR)
+                    ADR1 = stokes.inverse_s0123_CPL_after_ADR(*s0123)
+
+                    for i in range(4):
+                        assert ADR[i] - ADR1[i] < 1e-8

--- a/tests/test_stokes.py
+++ b/tests/test_stokes.py
@@ -73,3 +73,19 @@ def test_AR_mueller_from_CPL_projection():
         1, 1 / np.sqrt(2), 1 / np.sqrt(2), 0
     )
     assert np.max(np.linalg.inv(M2) - M2.T) < 1e-8
+
+
+def test_mmul():
+
+    M = np.ones((3, 2, 1))
+    x = np.ones((2, 1))
+
+    y = stokes.mmul(M, x)  # should pass
+
+    with pytest.raises(ValueError):
+        M2 = np.ones((3, 4, 1))
+        y2 = stokes.mmul(M2, x)
+
+    with pytest.raises(ValueError):
+        M3 = np.ones((3, 2, 1, 2))
+        y3 = stokes.mmul(M3, x)

--- a/waveorder/stokes.py
+++ b/waveorder/stokes.py
@@ -102,9 +102,7 @@ def S2I_matrix(swing, scheme="5-State"):
             ]
         )
     else:
-        raise ValueError(
-            f"{scheme} is not implemented, use 4-State or 5-State"
-        )
+        raise ValueError(f"{scheme} is not implemented, use 4-State or 5-State")
     return S2I
 
 
@@ -314,7 +312,7 @@ def mueller_from_stokes(
     s3,
     input="CPL",
     model="AR",
-    direction="forward",
+    direction="inverse",
 ):
     """
     When light with input polarization state (default = circularly polarized

--- a/waveorder/stokes.py
+++ b/waveorder/stokes.py
@@ -1,9 +1,73 @@
 import numpy as np
 
+"""
+This module collects Stokes- and Mueller-related calculations. 
+
+The functions are organized into three groups:
+
+1) A forward function group: 
+
+A = A_matrix(swing, scheme="5-State")
+s0, s1, s3, s3 = s0123_CPL_after_ADR(ret, ori, tra, dop)
+s0, s1, s2 = s012_CPL_after_AR(ret, ori, dop)
+
+2) An inverse function group:
+
+inverse_s0123_CPL_after_ADR(s0, s1, s2, s3)
+inverse s012_CPL_after_AR(s0, s1, s2)
+AR_mueller_from_CPL_projection(s0, s1, s2, s3)
+
+3) A convenience function group:
+
+M = inv_AR_mueller_from_CPL_projection(s0, s1, s2, s3)
+y = matmul(A, x)
+
+----------
+
+Usage: 
+
+All functions (except A_matrix) are intended to be used with ND-arrays with
+Stokes- or Mueller-indices as the first axes. 
+
+For example, the following usage modes of s0123_CPL_after_ADR are valid:
+
+>>> s0123_CPL_after_ADR(1, 1, 1, 1)
+
+>>> ret = np.ones((2,3,4,5))
+>>> ori = np.ones((2,3,4,5))
+>>> tra = np.ones((2,3,4,5))
+>>> dop = np.ones((2,3,4,5))
+>>> s0123_CPL_after_ADR(ret, ori, tra, dop)
+
+>>> ADR_params = np.ones((4,2,3,4,5)) # first axis contains the Stokes indices
+>>> s0123_CPL_after_ADR(*ADR_params) # * expands along the first axis
+
+"""
+
+
 # Forward function group
 
 
 def A_matrix(swing, scheme="5-State"):
+    """
+    Calculate the polarimeter system matrix for a swing and calibration scheme.
+
+    Parameters
+    ----------
+    swing : float
+        Result is periodic on the integers, e.g. A_matrix(0.1) = A_matrix(1.1)
+    scheme : str, "4-State" or "5-State"
+        Corresponds to the calibration scheme used to acquire data,
+        by default "5-State"
+
+    Returns
+    -------
+    ArrayLike
+        Returns different shapes depending on the scheme
+
+        A.shape = (5, 4) for scheme = "5-State"
+        A.shape = (4, 4) for scheme = "4-state"
+    """
     chi = 2 * np.pi * swing
     if scheme == "5-State":
         A = np.array(
@@ -41,6 +105,33 @@ def A_matrix(swing, scheme="5-State"):
 
 
 def s0123_CPL_after_ADR(ret, ori, tra, dop):
+    """
+    Returns the Stokes parameters of circularly polarized light (CPL) that
+    has passed through an attenuating depolarizing retarder (ADR) parametrized
+    by its retardance (ret), slow-axis orientation (ori), transmittance (tra),
+    and depolarization (dop).
+
+    Note: all four parameters can be ndarrays, but they must be the same size.
+    If your parameters are in an ndarray with array.shape = (4, ...), use
+    the * operator to expand over the first dimension.
+
+    e.g. s0123_CPL_after_ADR(*array) is identical to
+    s0123_CPL_after_ADR(array[0], array[1], array[2], array[3]).
+
+    Parameters
+    ----------
+    ret, ori, tra, dop : ArrayLike, float
+        ret: retardance of ADR, 2*pi periodic
+        ori: slow-axis orientation of ADR, 2*pi periodic
+        tra: transmittance of ADR, 0 <= tra <= 1
+        dop: depolarization of ADR, 0 <= dop <= 1
+
+    Returns
+    -------
+    s0, s1, s2, s3: ArrayLike, float
+        Stokes parameters
+
+    """
     s0 = tra
     s1 = tra * dop * np.sin(ret) * np.sin(2 * ori)
     s2 = tra * dop * -np.sin(ret) * np.cos(2 * ori)
@@ -49,6 +140,28 @@ def s0123_CPL_after_ADR(ret, ori, tra, dop):
 
 
 def s012_CPL_after_AR(ret, ori, tra):
+    """
+    Returns the first three Stokes parameters of circularly polarized light
+    (CPL) that has passed through an attenuating retarder [AR] parametrized by
+    its retardance (ret), slow-axis orientation (ori), and transmittance (tra).
+
+    This model is used to model non-depolarizing samples, or situations where
+    depolarization information is unavailable...e.g. when only a linear Stokes
+    polarimeter is available.
+
+    Parameters
+    ----------
+    ret, ori, tra: ArrayLike, float
+        ret: retardance of ADR, 2*pi periodic
+        ori: slow-axis orientation of ADR, 2*pi periodic
+        tra: transmittance of ADR, 0 <= tra <= 1
+
+    Returns
+    -------
+    s0, s1, s2: ArrayLike, float
+        First three Stokes parameters
+
+    """
     s0 = tra
     s1 = tra * np.sin(ret) * np.sin(2 * ori)
     s2 = tra * -np.sin(ret) * np.cos(2 * ori)
@@ -59,10 +172,53 @@ def s012_CPL_after_AR(ret, ori, tra):
 
 
 def _s12_to_ori(s1, s2):
+    """
+    Converts s1 and s1 into a slow-axis orientation.
+
+    This functions matches the sign convention used in s0123_CPL_after_ADR and
+    s012_CPL_after_AR (see tests for examples), and matches the orientation
+    range convention used in comp-micro: 0 <= ori < pi.
+
+    Parameters
+    ----------
+    s1, s2: ArrayLike, float
+        Stokes parameters
+
+    Returns
+    -------
+    ArrayLike, float
+        Slow-axis orientation with 0 <= ori < pi.
+    """
     return (np.arctan2(s1, -s2) % (2 * np.pi)) / 2
 
 
 def inverse_s0123_CPL_after_ADR(s0, s1, s2, s3):
+    """
+    Inverse of s0123_CPL_after_ADR.
+
+    Given the Stokes parameters of circularly polarized light (CPL) that has
+    passed through an attenuating depolarizing retarder (ADR), this function
+    returns the parameters of the ADR, specifically its retardance (ret),
+    slow-axis orientation (ori), transmittance (tra), and depolarization (dop).
+
+    Note: this function is commonly used in QLIPP-type reconstructions. After
+    converting raw intensities into Stokes parameters by applying A_inv, the
+    Stokes parameters are uses to estimate the parameters of the sample ADR in
+    a single step with this function.
+
+    Parameters
+    ----------
+    s0, s1, s2, s3: ArrayLike, float
+        Stokes parameters
+
+    Returns
+    ----------
+    ret, ori, tra, dop: ArrayLike, float
+        ret: retardance of ADR, 2*pi periodic
+        ori: slow-axis orientation of ADR, 2*pi periodic
+        tra: transmittance of ADR, 0 <= tra <= 1
+        dop: depolarization of ADR, 0 <= dop <= 1
+    """
     len_pol = (s1**2 + s2**2 + s3**2) ** 0.5
     ret = np.arcsin(((s1**2 + s2**2) ** 0.5) / len_pol)
     ori = _s12_to_ori(s1, s2)
@@ -72,6 +228,26 @@ def inverse_s0123_CPL_after_ADR(s0, s1, s2, s3):
 
 
 def inverse_s012_CPL_after_AR(s0, s1, s2):
+    """
+    Inverse of s012_CPL_after_ADR.
+
+    Given the Stokes parameters of circularly polarized light (CPL) that has
+    passed through an attenuating retarder (AR), this function returns the
+    parameters of the ADR, specifically its retardance (ret), slow-axis
+    orientation (ori), and transmittance (tra).
+
+    Parameters
+    ----------
+    s0, s1, s2: ArrayLike, float
+        First three Stokes parameters
+
+    Returns
+    ----------
+    ret, ori, tra: ArrayLike, float
+        ret: retardance of ADR, 2*pi periodic
+        ori: slow-axis orientation of ADR, 2*pi periodic
+        tra: transmittance of ADR, 0 <= tra <= 1
+    """
     ret = np.arcsin(((s1**2 + s2**2) ** 0.5) / s0)
     ori = _s12_to_ori(s1, s2)
     tra = s0
@@ -79,6 +255,21 @@ def inverse_s012_CPL_after_AR(s0, s1, s2):
 
 
 def AR_mueller_from_CPL_projection(s0, s1, s2, s3):
+    """
+    Given the Stokes parameters of circularly polarized light (CPL) that has
+    passed through an attenuating retarder (AR), this function returns the
+    complete Mueller matrix of the AR.
+
+    Parameters
+    ----------
+    s0, s1, s2, s3 : ArrayLike, float, identical shapes
+        Stokes parameters
+
+    Returns
+    -------
+    ArrayLike, float, M.shape = (4, 4,) + s0.shape
+        Mueller matrix
+    """
     M = np.zeros((4, 4) + np.array(s0).shape)
     denom = s1**2 + s2**2
     M[0, 0] = s0
@@ -99,13 +290,49 @@ def AR_mueller_from_CPL_projection(s0, s1, s2, s3):
 
 
 def inv_AR_mueller_from_CPL_projection(s0, s1, s2, s3):
+    """
+    Given the Stokes parameters of circularly polarized light (CPL) that has
+    passed through an attenuating retarder (AR), this function returns the
+    complete *INVERSE* Mueller matrix of the AR.
+
+    Parameters
+    ----------
+    s0, s1, s2, s3 : ArrayLike, float, identical shapes
+        Stokes parameters
+
+    Returns
+    -------
+    ArrayLike, float, M.shape = (4, 4,) + s0.shape
+        inverse Mueller matrix
+
+    NOTE: this implementation calculates the full matrix then inverts it.
+    TODO: (medium) Calculate the inverse matrix directly here and exploit the
+    block-diagonal structure.
+    TODO: (harder) Instead of calculating the entire inverse matrix and using
+    matrix multiplication to apply the correction, only calculate the unique
+    terms (exploit the fact that the lower block is a scaled rotation matrix)
+    and write a function that applies the correction directly.
+
+    """
     M = AR_mueller_from_CPL_projection(s0, s1, s2, s3)
     M_flip = np.moveaxis(M, (0, 1), (-2, -1))
     M_inv_flip = np.linalg.inv(M_flip)  # applied over the last two axes
     M_inv = np.moveaxis(M_inv_flip, (-2, -1), (0, 1))
-    # M_inv = np.linalg.inv(M.transpose((2, 3, 0, 1))).transpose((2, 3, 0, 1))
     return M_inv
 
 
-def matmul(A, x):
-    return np.einsum("ij...,j...->i...", A, x)
+def mmul(mueller, stokes):
+    """Mueller-multiply --- apply Mueller matrices to Stokes vectors.
+
+    Parameters
+    ----------
+    mueller : ArrayLike, shape = (4, 4, ...)
+    stokes : ArrayLike, shape = (4, ...)
+
+    where (...) shapes must be identical.
+
+    Returns
+    -------
+    ArrayLike, shape = (4, ...)
+    """
+    return np.einsum("ij...,j...->i...", mueller, stokes)

--- a/waveorder/stokes.py
+++ b/waveorder/stokes.py
@@ -79,15 +79,14 @@ def inverse_s012_CPL_after_AR(s0, s1, s2):
 
 
 def AR_mueller_from_CPL_projection(s0, s1, s2, s3):
-    M = np.zeros((4, 4))
-    num = s0  # (s1**2 + s2**2 + s3**2) ** 0.5 for ADR
+    M = np.zeros((4, 4) + np.array(s0).shape)
     denom = s1**2 + s2**2
     M[0, 0] = s0
-    M[1, 1] = (s1**2 * s3 + s2**2) * num / denom
-    M[1, 2] = s1 * s2 * (s3 - 1) * num / denom
+    M[1, 1] = (s0 * s2**2 + s1**2 * s3) / denom
+    M[1, 2] = s1 * s2 * (s3 - s0) / denom
     M[1, 3] = s1
     M[2, 1] = M[1, 2]
-    M[2, 2] = (s1**2 + s2**2 * s3) * num / denom
+    M[2, 2] = (s0 * s1**2 + s2**2 * s3) / denom
     M[2, 3] = s2
     M[3, 1] = -M[1, 3]
     M[3, 2] = -M[2, 3]

--- a/waveorder/stokes.py
+++ b/waveorder/stokes.py
@@ -93,3 +93,16 @@ def AR_mueller_from_CPL_projection(s0, s1, s2, s3):
     M[3, 3] = s3
 
     return M
+
+
+# Convenience function group
+
+
+def inv_AR_mueller_from_CPL_projection(s0, s1, s2, s3):
+    M = AR_mueller_from_CPL_projection(s0, s1, s2, s3)
+    M_inv = np.linalg.inv(M.transpose((2, 3, 0, 1))).transpose((2, 3, 0, 1))
+    return M_inv
+
+
+def matmul(A, x):
+    return np.einsum("ij...,j...->i...", A, x)

--- a/waveorder/stokes.py
+++ b/waveorder/stokes.py
@@ -334,16 +334,11 @@ def mmul(matrix, vector):
     matrix : NDArray, shape = (N, M, ...)
     vector : NDArray, shape = (M, ...)
 
-    where (...) shapes must be identical.
-
     Returns
     -------
     NDArray, shape = (N, ...)
     """
     if matrix.shape[1] != vector.shape[0]:
         ValueError("matrix.shape[1] is not equal to vector.shape[0]")
-
-    if np.not_equal(matrix.shape[2:], vector.shape[1:]):
-        ValueError("matrix.shape[2:] is not equal to vector.shape[1:]")
 
     return np.einsum("NM...,M...->N...", matrix, vector)

--- a/waveorder/stokes.py
+++ b/waveorder/stokes.py
@@ -3,6 +3,43 @@ import numpy as np
 # Forward function group
 
 
+def A_matrix(swing, scheme="5-State"):
+    chi = 2 * np.pi * swing
+    if scheme == "5-State":
+        A = np.array(
+            [
+                [1, 0, 0, -1],
+                [1, np.sin(chi), 0, -np.cos(chi)],
+                [1, 0, np.sin(chi), -np.cos(chi)],
+                [1, -np.sin(chi), 0, -np.cos(chi)],
+                [1, 0, -np.sin(chi), -np.cos(chi)],
+            ]
+        )
+
+    elif scheme == "4-State":
+        A = np.array(
+            [
+                [1, 0, 0, -1],
+                [1, np.sin(chi), 0, -np.cos(chi)],
+                [
+                    1,
+                    -0.5 * np.sin(chi),
+                    np.sqrt(3) * np.cos(chi / 2) * np.sin(chi / 2),
+                    -np.cos(chi),
+                ],
+                [
+                    1,
+                    -0.5 * np.sin(chi),
+                    -np.sqrt(3) * np.cos(chi / 2) * np.sin(chi / 2),
+                    -np.cos(chi),
+                ],
+            ]
+        )
+    else:
+        raise KeyError(f"{scheme} is not implemented, use 4-State or 5-State")
+    return A
+
+
 def s0123_CPL_after_ADR(ret, ori, tra, dop):
     s0 = tra
     s1 = tra * dop * np.sin(ret) * np.sin(2 * ori)
@@ -39,3 +76,21 @@ def inverse_s012_CPL_after_AR(s0, s1, s2):
     ori = _s12_to_ori(s1, s2)
     tra = s0
     return ret, ori, tra
+
+
+def AR_mueller_from_CPL_projection(s0, s1, s2, s3):
+    M = np.zeros((4, 4))
+    num = s0  # (s1**2 + s2**2 + s3**2) ** 0.5 for ADR
+    denom = s1**2 + s2**2
+    M[0, 0] = s0
+    M[1, 1] = (s1**2 * s3 + s2**2) * num / denom
+    M[1, 2] = s1 * s2 * (s3 - 1) * num / denom
+    M[1, 3] = s1
+    M[2, 1] = M[1, 2]
+    M[2, 2] = (s1**2 + s2**2 * s3) * num / denom
+    M[2, 3] = s2
+    M[3, 1] = -M[1, 3]
+    M[3, 2] = -M[2, 3]
+    M[3, 3] = s3
+
+    return M

--- a/waveorder/stokes.py
+++ b/waveorder/stokes.py
@@ -10,7 +10,7 @@ The functions are organized into three groups:
 
 A = A_matrix(swing, scheme="5-State")
 s0, s1, s3, s3 = s0123_CPL_after_ADR(ret, ori, tra, dop)
-s0, s1, s2 = s012_CPL_after_AR(ret, ori, dop)
+s0, s1, s2 = s012_CPL_after_AR(ret, ori, tra)
 
 2) An inverse function group:
 
@@ -176,7 +176,7 @@ def s012_CPL_after_AR(ret, ori, tra):
 
 def _s12_to_ori(s1, s2):
     """
-    Converts s1 and s1 into a slow-axis orientation.
+    Converts s1 and s2 into a slow-axis orientation.
 
     This functions matches the sign convention used in s0123_CPL_after_ADR and
     s012_CPL_after_AR (see tests for examples), and matches the orientation

--- a/waveorder/stokes.py
+++ b/waveorder/stokes.py
@@ -270,7 +270,7 @@ def AR_mueller_from_CPL_projection(s0, s1, s2, s3):
 
     Returns
     -------
-    NDArray, float, M.shape = (4, 4,) + s0.shape
+    NDArray, M.shape = (4, 4,) + s0.shape
         Mueller matrix
     """
     M = np.zeros((4, 4) + np.array(s0).shape)

--- a/waveorder/stokes.py
+++ b/waveorder/stokes.py
@@ -1,0 +1,41 @@
+import numpy as np
+
+# Forward function group
+
+
+def s0123_CPL_after_ADR(ret, ori, tra, dop):
+    s0 = tra
+    s1 = tra * dop * np.sin(ret) * np.sin(2 * ori)
+    s2 = tra * dop * -np.sin(ret) * np.cos(2 * ori)
+    s3 = tra * dop * np.cos(ret)
+    return s0, s1, s2, s3
+
+
+def s012_CPL_after_AR(ret, ori, tra):
+    s0 = tra
+    s1 = tra * np.sin(ret) * np.sin(2 * ori)
+    s2 = tra * -np.sin(ret) * np.cos(2 * ori)
+    return s0, s1, s2
+
+
+# Inverse function group
+
+
+def _s12_to_ori(s1, s2):
+    return (np.arctan2(s1, -s2) % (2 * np.pi)) / 2
+
+
+def inverse_s0123_CPL_after_ADR(s0, s1, s2, s3):
+    len_pol = (s1**2 + s2**2 + s3**2) ** 0.5
+    ret = np.arcsin(((s1**2 + s2**2) ** 0.5) / len_pol)
+    ori = _s12_to_ori(s1, s2)
+    tra = s0
+    dop = len_pol / s0
+    return ret, ori, tra, dop
+
+
+def inverse_s012_CPL_after_AR(s0, s1, s2):
+    ret = np.arcsin(((s1**2 + s2**2) ** 0.5) / s0)
+    ori = _s12_to_ori(s1, s2)
+    tra = s0
+    return ret, ori, tra

--- a/waveorder/stokes.py
+++ b/waveorder/stokes.py
@@ -101,7 +101,9 @@ def A_matrix(swing, scheme="5-State"):
             ]
         )
     else:
-        raise KeyError(f"{scheme} is not implemented, use 4-State or 5-State")
+        raise ValueError(
+            f"{scheme} is not implemented, use 4-State or 5-State"
+        )
     return A
 
 

--- a/waveorder/stokes.py
+++ b/waveorder/stokes.py
@@ -8,12 +8,13 @@ The functions are organized into three groups:
 
 1) A forward function group: 
 
-A = A_matrix(swing, scheme="5-State")
+S2I = S2I_matrix(swing, scheme="5-State")
 s0, s1, s3, s3 = s0123_CPL_after_ADR(ret, ori, tra, dop)
 s0, s1, s2 = s012_CPL_after_AR(ret, ori, tra)
 
 2) An inverse function group:
 
+I2S = I2S_matrix(swing, scheme="5-State")
 ret, ori, tra, dop = inverse_s0123_CPL_after_ADR(s0, s1, s2, s3)
 ret, ori, tra = inverse_s012_CPL_after_AR(s0, s1, s2)
 M = AR_mueller_from_CPL_projection(s0, s1, s2, s3)
@@ -49,14 +50,14 @@ import numpy as np
 # Forward function group
 
 
-def A_matrix(swing, scheme="5-State"):
+def S2I_matrix(swing, scheme="5-State"):
     """
     Calculate the polarimeter system matrix for a swing and calibration scheme.
 
     Parameters
     ----------
     swing : float
-        Result is periodic on the integers, e.g. A_matrix(0.1) = A_matrix(1.1)
+        Result is periodic on the integers, e.g. S2I_matrix(0.1) = S2I_matrix(1.1)
     scheme : "4-State" or "5-State"
         Corresponds to the calibration scheme used to acquire data,
         by default "5-State"
@@ -66,12 +67,12 @@ def A_matrix(swing, scheme="5-State"):
     NDArray
         Returns different shapes depending on the scheme
 
-        A.shape = (5, 4) for scheme = "5-State"
-        A.shape = (4, 4) for scheme = "4-state"
+        S2I.shape = (5, 4) for scheme = "5-State"
+        S2I.shape = (4, 4) for scheme = "4-state"
     """
     chi = 2 * np.pi * swing
     if scheme == "5-State":
-        A = np.array(
+        S2I = np.array(
             [
                 [1, 0, 0, -1],
                 [1, np.sin(chi), 0, -np.cos(chi)],
@@ -82,7 +83,7 @@ def A_matrix(swing, scheme="5-State"):
         )
 
     elif scheme == "4-State":
-        A = np.array(
+        S2I = np.array(
             [
                 [1, 0, 0, -1],
                 [1, np.sin(chi), 0, -np.cos(chi)],
@@ -104,7 +105,7 @@ def A_matrix(swing, scheme="5-State"):
         raise ValueError(
             f"{scheme} is not implemented, use 4-State or 5-State"
         )
-    return A
+    return S2I
 
 
 def s0123_CPL_after_ADR(ret, ori, tra, dop):
@@ -172,6 +173,29 @@ def s012_CPL_after_AR(ret, ori, tra):
 
 
 # Inverse function group
+
+
+def I2S_matrix(swing, scheme="5-State"):
+    """
+    Calculate the inverse polarimeter system matrix for a swing and calibration scheme.
+
+    Parameters
+    ----------
+    swing : float
+        Result is periodic on the integers, e.g. I2S_matrix(0.1) = I2S_matrix(1.1)
+    scheme : "4-State" or "5-State"
+        Corresponds to the calibration scheme used to acquire data,
+        by default "5-State"
+
+    Returns
+    -------
+    NDArray
+        Returns different shapes depending on the scheme
+
+        I2S.shape = (5, 4) for scheme = "5-State"
+        I2S.shape = (4, 4) for scheme = "4-state"
+    """
+    return np.linalg.pinv(S2I_matrix(swing, scheme=scheme))
 
 
 def _s12_to_ori(s1, s2):

--- a/waveorder/stokes.py
+++ b/waveorder/stokes.py
@@ -4,50 +4,49 @@ Overview
 
 This module collects Stokes- and Mueller-related calculations. 
 
-The functions are organized into three groups:
+The functions are roughly organized into groups:
 
-1) A forward function group: 
-
+1) Polarimeter instrument matrix functions
 S2I = S2I_matrix(swing, scheme="5-State")
-s0, s1, s3, s3 = s0123_CPL_after_ADR(ret, ori, tra, dop)
-s0, s1, s2 = s012_CPL_after_AR(ret, ori, tra)
-
-2) An inverse function group:
-
 I2S = I2S_matrix(swing, scheme="5-State")
-ret, ori, tra, dop = inverse_s0123_CPL_after_ADR(s0, s1, s2, s3)
-ret, ori, tra = inverse_s012_CPL_after_AR(s0, s1, s2)
-M = AR_mueller_from_CPL_projection(s0, s1, s2, s3)
 
-3) A convenience function group:
+2) Forward functions (Stokes parameters following a optical element)
+s0, s1, s2, s3 = stokes_after_ADR(ret, ori, tra, dop, input="CPL")
+s0, s1, s2 = stokes012_after_AR(ret, ori, tra, input="CPL")
 
-M = inv_AR_mueller_from_CPL_projection(s0, s1, s2, s3)
+3) Inverse functions (optical elements from Stokes parameters)
+ret, ori, tra, dop = estimate_ADR_from_stokes(s0, s1, s2, s3, input="CPL")
+ret, ori, tra = estimate_AR_from_stokes012(s0, s1, s2, input="CPL")
+
+4) A function for recovering Mueller matrices from Stokes vector
+M = mueller_from_stokes(
+    s0, s1, s2, s3, model="AR", direction="forward", input="CPL"
+)
+
+5) A convenience function for applying Mueller and instrument matrices
 y = mmul(A, x)
 
 Usage
 -----
 
-All functions (except A_matrix) are intended to be used with ND-arrays with
-Stokes- or Mueller-indices as the first axes. 
+All functions are intended to be used with ND-arrays with Stokes- or 
+Mueller-indices as the first axes. 
 
-For example, the following usage modes of s0123_CPL_after_ADR are valid:
+For example, the following usage modes of stokes_after_ADR are valid:
 
->>> s0123_CPL_after_ADR(1, 1, 1, 1)
+>>> stokes_after_ADR(1, 1, 1, 1)
 
 >>> ret = np.ones((2,3,4,5))
 >>> ori = np.ones((2,3,4,5))
 >>> tra = np.ones((2,3,4,5))
 >>> dop = np.ones((2,3,4,5))
->>> s0123_CPL_after_ADR(ret, ori, tra, dop)
+>>> stokes_after_ADR(ret, ori, tra, dop)
 
 >>> ADR_params = np.ones((4,2,3,4,5)) # first axis contains the Stokes indices
->>> s0123_CPL_after_ADR(*ADR_params) # * expands along the first axis
+>>> stokes_after_ADR(*ADR_params) # * expands along the first axis
 
 """
 import numpy as np
-
-
-# Forward function group
 
 
 def S2I_matrix(swing, scheme="5-State"):
@@ -57,7 +56,8 @@ def S2I_matrix(swing, scheme="5-State"):
     Parameters
     ----------
     swing : float
-        Result is periodic on the integers, e.g. S2I_matrix(0.1) = S2I_matrix(1.1)
+        Result is periodic on the integers,
+        e.g. S2I_matrix(0.1) = S2I_matrix(1.1)
     scheme : "4-State" or "5-State"
         Corresponds to the calibration scheme used to acquire data,
         by default "5-State"
@@ -108,76 +108,10 @@ def S2I_matrix(swing, scheme="5-State"):
     return S2I
 
 
-def s0123_CPL_after_ADR(ret, ori, tra, dop):
-    """
-    Returns the Stokes parameters of circularly polarized light (CPL) that
-    has passed through an attenuating depolarizing retarder (ADR) parametrized
-    by its retardance (ret), slow-axis orientation (ori), transmittance (tra),
-    and depolarization (dop).
-
-    Note: all four parameters can be ndarrays, but they must be the same size.
-    If your parameters are in an ndarray with array.shape = (4, ...), use
-    the * operator to expand over the first dimension.
-
-    e.g. s0123_CPL_after_ADR(*array) is identical to
-    s0123_CPL_after_ADR(array[0], array[1], array[2], array[3]).
-
-    Parameters
-    ----------
-    ret, ori, tra, dop : NDArray, identical shapes
-        ret: retardance of ADR, 2*pi periodic
-        ori: slow-axis orientation of ADR, 2*pi periodic
-        tra: transmittance of ADR, 0 <= tra <= 1
-        dop: depolarization of ADR, 0 <= dop <= 1
-
-    Returns
-    -------
-    s0, s1, s2, s3: NDArray, identical shapes
-        Stokes parameters
-
-    """
-    s0 = tra
-    s1 = tra * dop * np.sin(ret) * np.sin(2 * ori)
-    s2 = tra * dop * -np.sin(ret) * np.cos(2 * ori)
-    s3 = tra * dop * np.cos(ret)
-    return s0, s1, s2, s3
-
-
-def s012_CPL_after_AR(ret, ori, tra):
-    """
-    Returns the first three Stokes parameters of circularly polarized light
-    (CPL) that has passed through an attenuating retarder (AR) parametrized by
-    its retardance (ret), slow-axis orientation (ori), and transmittance (tra).
-
-    This model is used to model non-depolarizing samples, or situations where
-    depolarization information is unavailable...e.g. when only a linear Stokes
-    polarimeter is available.
-
-    Parameters
-    ----------
-    ret, ori, tra: NDArray, identical shapes
-        ret: retardance of ADR, 2*pi periodic
-        ori: slow-axis orientation of ADR, 2*pi periodic
-        tra: transmittance of ADR, 0 <= tra <= 1
-
-    Returns
-    -------
-    s0, s1, s2: NDArray
-        First three Stokes parameters
-
-    """
-    s0 = tra
-    s1 = tra * np.sin(ret) * np.sin(2 * ori)
-    s2 = tra * -np.sin(ret) * np.cos(2 * ori)
-    return s0, s1, s2
-
-
-# Inverse function group
-
-
 def I2S_matrix(swing, scheme="5-State"):
     """
-    Calculate the inverse polarimeter system matrix for a swing and calibration scheme.
+    Calculate the inverse polarimeter system matrix for a swing and calibration
+    scheme.
 
     Parameters
     ----------
@@ -198,6 +132,83 @@ def I2S_matrix(swing, scheme="5-State"):
     return np.linalg.pinv(S2I_matrix(swing, scheme=scheme))
 
 
+def stokes_after_ADR(ret, ori, tra, dop, input="CPL"):
+    """
+    Returns the Stokes parameters of the input polarization state (default =
+    circularly polarized light = "CPL") that has passed through an attenuating
+    depolarizing retarder (ADR) parametrized by its retardance (ret), slow-axis
+    orientation (ori), transmittance (tra), and depolarization (dop).
+
+    Note: all four parameters can be array_like, but they must be the same size.
+    If your parameters are in an ndarray with array.shape = (4, ...), use
+    the * operator to expand over the first dimension.
+
+    e.g. stokes_after_ADR(*array) is identical to
+    stokes_after_ADR(array[0], array[1], array[2], array[3]).
+
+    Parameters
+    ----------
+    ret, ori, tra, dop : array_like, identical shapes
+        ret: retardance of ADR, 2*pi periodic
+        ori: slow-axis orientation of ADR, 2*pi periodic
+        tra: transmittance of ADR, 0 <= tra <= 1
+        dop: depolarization of ADR, 0 <= dop <= 1
+
+    input : "CPL"
+        Input polarization state
+
+    Returns
+    -------
+    s0, s1, s2, s3: array_like, identical shapes
+        Stokes parameters
+
+    """
+    if input != "CPL":
+        NotImplementedError("input != CPL")
+
+    s0 = tra
+    s1 = tra * dop * np.sin(ret) * np.sin(2 * ori)
+    s2 = tra * dop * -np.sin(ret) * np.cos(2 * ori)
+    s3 = tra * dop * np.cos(ret)
+    return s0, s1, s2, s3
+
+
+def stokes012_after_AR(ret, ori, tra, input="CPL"):
+    """
+    Returns the first three Stokes parameters of the input polarization state
+    (default = circularly polarized light = "CPL") that has passed through an
+    attenuating retarder (AR) parametrized by its retardance (ret), slow-axis
+    orientation (ori), and transmittance (tra).
+
+    This model is used to model non-depolarizing samples, or situations where
+    depolarization information is unavailable...e.g. when only a linear Stokes
+    polarimeter is available.
+
+    Parameters
+    ----------
+    ret, ori, tra: array_like, identical shapes
+        ret: retardance of AR, 2*pi periodic
+        ori: slow-axis orientation of AR, 2*pi periodic
+        tra: transmittance of AR, 0 <= tra <= 1
+
+    input : "CPL"
+        Input polarization state
+
+    Returns
+    -------
+    s0, s1, s2: array_like
+        First three Stokes parameters
+
+    """
+    if input != "CPL":
+        NotImplementedError("input != CPL")
+
+    s0 = tra
+    s1 = tra * np.sin(ret) * np.sin(2 * ori)
+    s2 = tra * -np.sin(ret) * np.cos(2 * ori)
+    return s0, s1, s2
+
+
 def _s12_to_ori(s1, s2):
     """
     Converts s1 and s2 into a slow-axis orientation.
@@ -208,44 +219,51 @@ def _s12_to_ori(s1, s2):
 
     Parameters
     ----------
-    s1, s2: NDArray, identical shapes
+    s1, s2: array_like, identical shapes
         Stokes parameters
 
     Returns
     -------
-    NDArray
+    array_like
         Slow-axis orientation with 0 <= ori < pi.
     """
     return (np.arctan2(s1, -s2) % (2 * np.pi)) / 2
 
 
-def inverse_s0123_CPL_after_ADR(s0, s1, s2, s3):
+def estimate_ADR_from_stokes(s0, s1, s2, s3, input="CPL"):
     """
-    Inverse of s0123_CPL_after_ADR.
+    Inverse of stokes_after_ADR.
 
-    Given the Stokes parameters of circularly polarized light (CPL) that has
-    passed through an attenuating depolarizing retarder (ADR), this function
-    returns the parameters of the ADR, specifically its retardance (ret),
-    slow-axis orientation (ori), transmittance (tra), and depolarization (dop).
+    When light with input polarization state (default = circularly polarized
+    light = "CPL") has passed through an attenuating depolarizing retarder
+    (ADR), its Stokes parameters can be passed to this function to estimate
+    the parameters of the ADR, specifically its retardance (ret), slow-axis
+    orientation (ori), transmittance (tra), and depolarization (dop).
 
     Note: this function is commonly used in QLIPP-type reconstructions. After
-    converting raw intensities into Stokes parameters by applying A_inv, the
-    Stokes parameters are uses to estimate the parameters of the sample ADR in
-    a single step with this function.
+    converting raw intensities into Stokes parameters by applying an
+    I2S_matrix, the Stokes parameters are used to estimate the parameters of
+    the sample ADR in a single step with this function.
 
     Parameters
     ----------
-    s0, s1, s2, s3: NDArray, identical shapes
+    s0, s1, s2, s3: array_like, identical shapes
         Stokes parameters
+
+    input : "CPL"
+        Input polarization state
 
     Returns
     ----------
-    ret, ori, tra, dop: NDArray
+    ret, ori, tra, dop: array_like
         ret: retardance of ADR, 2*pi periodic
         ori: slow-axis orientation of ADR, 2*pi periodic
         tra: transmittance of ADR, 0 <= tra <= 1
         dop: depolarization of ADR, 0 <= dop <= 1
     """
+    if input != "CPL":
+        NotImplementedError("input != CPL")
+
     len_pol = (s1**2 + s2**2 + s3**2) ** 0.5
     ret = np.arcsin(((s1**2 + s2**2) ** 0.5) / len_pol)
     ori = _s12_to_ori(s1, s2)
@@ -254,113 +272,129 @@ def inverse_s0123_CPL_after_ADR(s0, s1, s2, s3):
     return ret, ori, tra, dop
 
 
-def inverse_s012_CPL_after_AR(s0, s1, s2):
+def estimate_AR_from_stokes012(s0, s1, s2, input="CPL"):
     """
-    Inverse of s012_CPL_after_ADR.
+    Inverse of stokes012_after_ADR.
 
-    Given the Stokes parameters of circularly polarized light (CPL) that has
-    passed through an attenuating retarder (AR), this function returns the
-    parameters of the ADR, specifically its retardance (ret), slow-axis
-    orientation (ori), and transmittance (tra).
+    When light with input polarization state (default = circularly polarized
+    light = "CPL") has passed through an attenuating retarder (AR), its Stokes
+    parameters can be passed to this function to estimate the parameters of
+    the AR, specifically its retardance (ret), slow-axis orientation (ori), and
+    transmittance (tra).
 
     Parameters
     ----------
-    s0, s1, s2: NDArray, identical shapes
+    s0, s1, s2: array_like, identical shapes
         First three Stokes parameters
 
     Returns
     ----------
-    ret, ori, tra: NDArray, identical shapes
-        ret: retardance of ADR, 2*pi periodic
-        ori: slow-axis orientation of ADR, 2*pi periodic
-        tra: transmittance of ADR, 0 <= tra <= 1
+    ret, ori, tra: array_like, identical shapes
+        ret: retardance of AR, 2*pi periodic
+        ori: slow-axis orientation of AR, 2*pi periodic
+        tra: transmittance of AR, 0 <= tra <= 1
     """
+    if input != "CPL":
+        NotImplementedError("input != CPL")
+
     ret = np.arcsin(((s1**2 + s2**2) ** 0.5) / s0)
     ori = _s12_to_ori(s1, s2)
     tra = s0
     return ret, ori, tra
 
 
-def AR_mueller_from_CPL_projection(s0, s1, s2, s3):
+def mueller_from_stokes(
+    s0,
+    s1,
+    s2,
+    s3,
+    input="CPL",
+    model="AR",
+    direction="forward",
+):
     """
-    Given the Stokes parameters of circularly polarized light (CPL) that has
-    passed through an attenuating retarder (AR), this function returns the
-    complete Mueller matrix of the AR.
+    When light with input polarization state (default = circularly polarized
+    light = "CPL") has passed through a polarization element of a specific type
+    (default = attenuating retarder = "AR"), its Stokes parameters can be
+    passed to this function to estimate the complete Mueller matrix of the
+    polarization element.
 
     Parameters
     ----------
-    s0, s1, s2, s3 : NDArray, identical shapes
+    s0, s1, s2, s3 : array_like, identical shapes
         Stokes parameters
+
+    input : "CPL"
+        Input polarization state
+
+    model : "AR"
+        The type of polarization element
+
+    direction : "forward" or "inverse"
+        Return the Mueller matrix (forward) or its inverse
 
     Returns
     -------
-    NDArray, float, M.shape = (4, 4,) + s0.shape
+    array_like, float, M.shape = (4, 4,) + s0.shape
         Mueller matrix
     """
-    M = np.zeros((4, 4) + np.array(s0).shape)
-    denom = s1**2 + s2**2
-    M[0, 0] = s0
-    M[1, 1] = (s0 * s2**2 + s1**2 * s3) / denom
-    M[1, 2] = s1 * s2 * (s3 - s0) / denom
-    M[1, 3] = s1
-    M[2, 1] = M[1, 2]
-    M[2, 2] = (s0 * s1**2 + s2**2 * s3) / denom
-    M[2, 3] = s2
-    M[3, 1] = -M[1, 3]
-    M[3, 2] = -M[2, 3]
-    M[3, 3] = s3
+    if input != "CPL":
+        NotImplementedError("input != CPL")
 
-    return M
+    if model != "AR":
+        NotImplementedError("input != AR")
 
+    if not (direction == "forward" or direction == "inverse"):
+        NotImplementedError("direction must be `forward` or `inverse`")
 
-# Convenience function group
+    if direction == "forward":
+        M = np.zeros((4, 4) + np.array(s0).shape)
+        denom = s1**2 + s2**2
+        M[0, 0] = s0
+        M[1, 1] = (s0 * s2**2 + s1**2 * s3) / denom
+        M[1, 2] = s1 * s2 * (s3 - s0) / denom
+        M[1, 3] = s1
+        M[2, 1] = M[1, 2]
+        M[2, 2] = (s0 * s1**2 + s2**2 * s3) / denom
+        M[2, 3] = s2
+        M[3, 1] = -M[1, 3]
+        M[3, 2] = -M[2, 3]
+        M[3, 3] = s3
+        return M
 
-
-def inv_AR_mueller_from_CPL_projection(s0, s1, s2, s3):
-    """
-    Given the Stokes parameters of circularly polarized light (CPL) that has
-    passed through an attenuating retarder (AR), this function returns the
-    complete *INVERSE* Mueller matrix of the AR.
-
-    Parameters
-    ----------
-    s0, s1, s2, s3 : NDArray, identical shapes
-        Stokes parameters
-
-    Returns
-    -------
-    NDArray with shape = (4, 4,) + s0.shape
-        inverse Mueller matrix
-
-    NOTE: this implementation calculates the full matrix then inverts it.
-    TODO: (medium) Calculate the inverse matrix directly here and exploit the
-    block-diagonal structure.
-    TODO: (harder) Instead of calculating the entire inverse matrix and using
-    matrix multiplication to apply the correction, only calculate the unique
-    terms (exploit the fact that the lower block is a scaled rotation matrix)
-    and write a function that applies the correction directly.
-
-    """
-    M = AR_mueller_from_CPL_projection(s0, s1, s2, s3)
-    M_flip = np.moveaxis(M, (0, 1), (-2, -1))
-    M_inv_flip = np.linalg.inv(M_flip)  # applied over the last two axes
-    M_inv = np.moveaxis(M_inv_flip, (-2, -1), (0, 1))
-    return M_inv
+    elif direction == "inverse":
+        """
+        NOTE: this implementation calculates the full matrix then inverts it.
+        TODO: (medium) Calculate the inverse matrix directly here and exploit
+        the block-diagonal structure.
+        TODO: (harder) Instead of calculating the entire inverse matrix and
+        using matrix multiplication to apply the correction, only calculate the
+        unique terms (exploit the fact that the lower block is a scaled
+        rotation matrix) and write a function that applies the correction
+        directly.
+        """
+        M = mueller_from_stokes(
+            s0, s1, s2, s3, input=input, model=model, direction="forward"
+        )
+        M_flip = np.moveaxis(M, (0, 1), (-2, -1))
+        M_inv_flip = np.linalg.inv(M_flip)  # applied over the last two axes
+        M_inv = np.moveaxis(M_inv_flip, (-2, -1), (0, 1))
+        return M_inv
 
 
 def mmul(matrix, vector):
     """Convenient matrix-multiply used for
         - applying Mueller matrices to Stokes vectors
-        - applying A_inv to intensities
+        - applying S2I matrices to intensities
 
     Parameters
     ----------
-    matrix : NDArray, shape = (N, M, ...)
-    vector : NDArray, shape = (M, ...)
+    matrix : array_like, shape = (N, M, ...)
+    vector : array_like, shape = (M, ...)
 
     Returns
     -------
-    NDArray, shape = (N, ...)
+    array_like, shape = (N, ...)
     """
     if matrix.shape[1] != vector.shape[0]:
         ValueError("matrix.shape[1] is not equal to vector.shape[0]")

--- a/waveorder/stokes.py
+++ b/waveorder/stokes.py
@@ -166,7 +166,8 @@ def stokes_after_ADR(ret, ori, tra, dop, input="CPL"):
     if input != "CPL":
         NotImplementedError("input != CPL")
 
-    s0 = tra
+    # without copying tra, downstream changes to s0 will affect tra
+    s0 = tra.copy()
     s1 = tra * dop * np.sin(ret) * np.sin(2 * ori)
     s2 = tra * dop * -np.sin(ret) * np.cos(2 * ori)
     s3 = tra * dop * np.cos(ret)
@@ -203,7 +204,8 @@ def stokes012_after_AR(ret, ori, tra, input="CPL"):
     if input != "CPL":
         NotImplementedError("input != CPL")
 
-    s0 = tra
+    # without copying tra, downstream changes to s0 will affect tra
+    s0 = tra.copy()
     s1 = tra * np.sin(ret) * np.sin(2 * ori)
     s2 = tra * -np.sin(ret) * np.cos(2 * ori)
     return s0, s1, s2
@@ -267,7 +269,8 @@ def estimate_ADR_from_stokes(s0, s1, s2, s3, input="CPL"):
     len_pol = (s1**2 + s2**2 + s3**2) ** 0.5
     ret = np.arcsin(((s1**2 + s2**2) ** 0.5) / len_pol)
     ori = _s12_to_ori(s1, s2)
-    tra = s0
+    # without copying s0, downstream changes to tra will affect s0
+    tra = s0.copy()
     dop = len_pol / s0
     return ret, ori, tra, dop
 
@@ -299,7 +302,8 @@ def estimate_AR_from_stokes012(s0, s1, s2, input="CPL"):
 
     ret = np.arcsin(((s1**2 + s2**2) ** 0.5) / s0)
     ori = _s12_to_ori(s1, s2)
-    tra = s0
+    # without copying s0, downstream changes to tra will affect s0
+    tra = s0.copy()
     return ret, ori, tra
 
 

--- a/waveorder/stokes.py
+++ b/waveorder/stokes.py
@@ -1,6 +1,7 @@
-import numpy as np
-
 """
+Overview
+--------
+
 This module collects Stokes- and Mueller-related calculations. 
 
 The functions are organized into three groups:
@@ -13,18 +14,17 @@ s0, s1, s2 = s012_CPL_after_AR(ret, ori, dop)
 
 2) An inverse function group:
 
-inverse_s0123_CPL_after_ADR(s0, s1, s2, s3)
-inverse s012_CPL_after_AR(s0, s1, s2)
-AR_mueller_from_CPL_projection(s0, s1, s2, s3)
+ret, ori, tra, dop = inverse_s0123_CPL_after_ADR(s0, s1, s2, s3)
+ret, ori, tra = inverse_s012_CPL_after_AR(s0, s1, s2)
+M = AR_mueller_from_CPL_projection(s0, s1, s2, s3)
 
 3) A convenience function group:
 
 M = inv_AR_mueller_from_CPL_projection(s0, s1, s2, s3)
 y = matmul(A, x)
 
-----------
-
-Usage: 
+Usage
+-----
 
 All functions (except A_matrix) are intended to be used with ND-arrays with
 Stokes- or Mueller-indices as the first axes. 
@@ -43,6 +43,7 @@ For example, the following usage modes of s0123_CPL_after_ADR are valid:
 >>> s0123_CPL_after_ADR(*ADR_params) # * expands along the first axis
 
 """
+import numpy as np
 
 
 # Forward function group

--- a/waveorder/stokes.py
+++ b/waveorder/stokes.py
@@ -167,7 +167,7 @@ def stokes_after_ADR(ret, ori, tra, dop, input="CPL"):
         NotImplementedError("input != CPL")
 
     # without copying tra, downstream changes to s0 will affect tra
-    s0 = tra.copy()
+    s0 = np.array(tra).copy()
     s1 = tra * dop * np.sin(ret) * np.sin(2 * ori)
     s2 = tra * dop * -np.sin(ret) * np.cos(2 * ori)
     s3 = tra * dop * np.cos(ret)
@@ -205,7 +205,7 @@ def stokes012_after_AR(ret, ori, tra, input="CPL"):
         NotImplementedError("input != CPL")
 
     # without copying tra, downstream changes to s0 will affect tra
-    s0 = tra.copy()
+    s0 = np.array(tra).copy()
     s1 = tra * np.sin(ret) * np.sin(2 * ori)
     s2 = tra * -np.sin(ret) * np.cos(2 * ori)
     return s0, s1, s2
@@ -270,7 +270,7 @@ def estimate_ADR_from_stokes(s0, s1, s2, s3, input="CPL"):
     ret = np.arcsin(((s1**2 + s2**2) ** 0.5) / len_pol)
     ori = _s12_to_ori(s1, s2)
     # without copying s0, downstream changes to tra will affect s0
-    tra = s0.copy()
+    tra = np.array(s0).copy()
     dop = len_pol / s0
     return ret, ori, tra, dop
 
@@ -303,7 +303,7 @@ def estimate_AR_from_stokes012(s0, s1, s2, input="CPL"):
     ret = np.arcsin(((s1**2 + s2**2) ** 0.5) / s0)
     ori = _s12_to_ori(s1, s2)
     # without copying s0, downstream changes to tra will affect s0
-    tra = s0.copy()
+    tra = np.array(s0).copy()
     return ret, ori, tra
 
 

--- a/waveorder/stokes.py
+++ b/waveorder/stokes.py
@@ -100,7 +100,10 @@ def AR_mueller_from_CPL_projection(s0, s1, s2, s3):
 
 def inv_AR_mueller_from_CPL_projection(s0, s1, s2, s3):
     M = AR_mueller_from_CPL_projection(s0, s1, s2, s3)
-    M_inv = np.linalg.inv(M.transpose((2, 3, 0, 1))).transpose((2, 3, 0, 1))
+    M_flip = np.moveaxis(M, (0, 1), (-2, -1))
+    M_inv_flip = np.linalg.inv(M_flip)  # applied over the last two axes
+    M_inv = np.moveaxis(M_inv_flip, (-2, -1), (0, 1))
+    # M_inv = np.linalg.inv(M.transpose((2, 3, 0, 1))).transpose((2, 3, 0, 1))
     return M_inv
 
 

--- a/waveorder/stokes.py
+++ b/waveorder/stokes.py
@@ -270,7 +270,7 @@ def AR_mueller_from_CPL_projection(s0, s1, s2, s3):
 
     Returns
     -------
-    NDArray, M.shape = (4, 4,) + s0.shape
+    NDArray, float, M.shape = (4, 4,) + s0.shape
         Mueller matrix
     """
     M = np.zeros((4, 4) + np.array(s0).shape)


### PR DESCRIPTION
This PR adds a completely rewritten version of all Stokes- and Mueller-related calculations in `waveorder`.

This rewrite was motived by the following questions:
- Q: how should we handle background correction of S3 to prepare it for deconvolution? A: keep track of S3 and use Mueller matrices to correct backgrounds. 
- how should we handle normalization (see the closed #103 for an earlier discussion)? A: no need to normalize in a separate step. 
- can we handle larger background retardances? A: yes, by estimating Mueller matrices. 

**Highlight improvements:**
- removal of normalization steps...instead of a two step reconstruction with a normalization followed by reconstruction, this implementation goes straight from Stokes parameters to (retardance, orientation, transmittance, depolarization). 
- a natively ND implementation...the Stokes and Mueller indices go in the first/second axes, and the remaining indices are arbitrary. A convenience `mmul` (Mueller multiply) function that uses `einsum` is the key simplifying design choice. 
- A Mueller-matrix based reconstruction scheme that can handle larger background retardances. 

**What does the new API look like?** Here's an example snippet from `/hpc/projects/compmicro/projects/infected_cell_imaging/Image_preprocessing/Exp_2023_02_07_A549MemNucl_PolPhase3D/Background_correction_trial/bg-corr-with-mask.py`
```
# Calculate A and A_inv
A = stokes.A_matrix(swing=0.1, scheme="5-State")
A_inv = np.linalg.pinv(A)

# Apply A_inv to background and sample data
S_bg = stokes.mmul(A_inv, cyx_bg_data)
S_sm = stokes.mmul(A_inv, czyx_data)

# Calculate background correction matrix from S_bg
M_inv = stokes.inv_AR_mueller_from_CPL_projection(*S_bg)

# Apply background correction to sample data
bg_corr_S_sm = stokes.mmul(M_inv, S_sm)

# Reconstruct parameters
ret, ori, tra, dop = stokes.inverse_s0123_CPL_after_ADR(*bg_corr_S_sm)
```

**Limitations compared to the current `waveorder_reconstructor` implementation:**
- No GPU implementation. @ziw-liu maybe you have ideas for flipping a gpu switch for this whole module? The `waveorder_reconstructor` class' parallel `np` and `cp` implementations seem clunky. 
- Not yet optimized...instead of using differences and ratios to apply background corrections, this implementation uses Mueller matrices and their inverses. This implementation is not slower than the phase reconstructions, and I've added comments in the places where further optimization can improve performance. 

I have not removed the existing implementation in the `waveorder_reconstructor` class. My current plan is to discuss the technical parts of this reimplementation and compare with the existing implementation here, then later I can complete the refactor by removing the Stokes parts of the `waveorder_reconstructor` class and updating the `recOrder` calls. 

Note: this PR is to merge into `alg-dev`, so we have a bit more flexibility in the changes. Temporarily breaking changes/suggestions are okay while we iterate. 

**Specific feedback requests:** 
- @ziw-liu your comments on a gpu switch, and on documentation+testing practice is very welcome. I wasn't sure if I should use type annotations & numpy-style docstrings? I stayed with only docstrings for now. 
- @mattersoflight I'm particularly interested in your thoughts on naming. For example, `inverse_s0123_CPL_after_ADR` doesn't roll off the tongue like the earlier `Polarization_recon`, but I think it's important to be very specific at this level. Later layers of abstraction can reintroduce more abstract names likes `Polarization_recon` if we think they're helpful.