### PR TITLE
Pin README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ PTI provides volumetric reconstructions of mean permittivity ($\propto$ material
 
 ![Data_flow](https://github.com/mehta-lab/waveorder/blob/main/Fig_Readme.png?raw=true)
 
-The [example notebooks](examples/) illustrate simulations and reconstruction for 2D QLIPP, 3D PODT, and 2D/3D PTI methods.
+The [example notebooks](https://github.com/mehta-lab/waveorder/tree/main/examples) illustrate simulations and reconstruction for 2D QLIPP, 3D PODT, and 2D/3D PTI methods.
 
 If you are interested in deploying QLIPP or PODT for label-free imaging at scale, checkout our [napari plugin](https://www.napari-hub.org/plugins/recOrder-napari),  [`recOrder-napari`](https://github.com/mehta-lab/recOrder).
 
@@ -39,7 +39,7 @@ In addition to label-free reconstruction algorithms, `waveorder` also implements
 
 1. Correlative measurements of biomolecular density and orientation from polarization-diverse widefield imaging ([multimodal Instant PolScope](https://opg.optica.org/boe/fulltext.cfm?uri=boe-13-5-3102&id=472350))
 
-We provide an [example notebook](examples/experimental_reconstructions/fluorescence_deconvolution/) for widefield fluorescence deconvolution.
+We provide an [example notebook](https://github.com/mehta-lab/waveorder/blob/main/examples/experimental_reconstructions/fluorescence_deconvolution/fluorescence_deconv.ipynb) for widefield fluorescence deconvolution.
 
 ## Citation
 


### PR DESCRIPTION
I just did test release of `1.0.0rc2` and found that the relative link in the README were broken on PyPI. This PR pins those links directly to github. 