### PR TITLE
Remove kwargs from reconstructions

### DIFF
--- a/waveorder/models/inplane_anisotropic_thin_pol3d.py
+++ b/waveorder/models/inplane_anisotropic_thin_pol3d.py
@@ -78,7 +78,7 @@ def apply_inverse_transfer_function(
         estimator = background_estimator.BackgroundEstimator2D()
         for stokes_index in range(background_corrected_stokes.shape[0]):
             z_projection = torch.mean(
-                background_corrected_stokes[stokes_index], dim=1
+                background_corrected_stokes[stokes_index], dim=0
             )
             background_corrected_stokes[
                 stokes_index

--- a/waveorder/models/isotropic_thin_3d.py
+++ b/waveorder/models/isotropic_thin_3d.py
@@ -145,8 +145,9 @@ def apply_inverse_transfer_function(
     method="Tikhonov",
     reg_u=1e-6,
     reg_p=1e-6,
+    rho=1e-3,
+    itr=10,
     bg_filter=True,
-    **kwargs
 ):
     zyx_data_normalized = util.inten_normalization(
         zyx_data, bg_filter=bg_filter
@@ -203,7 +204,7 @@ def apply_inverse_transfer_function(
     # ADMM deconvolution with anisotropic TV regularization
     elif method == "TV":
         absorption, phase = util.dual_variable_admm_tv_deconv_2d(
-            AHA, b_vec, **kwargs
+            AHA, b_vec, rho=rho, itr=itr
         )
 
     phase -= torch.mean(phase)

--- a/waveorder/models/phase_thick_3d.py
+++ b/waveorder/models/phase_thick_3d.py
@@ -146,7 +146,9 @@ def apply_inverse_transfer_function(
     illumination_wavelength,  # TOOD: MOVE THIS PARAM TO OTF? (leaky param)
     absorption_ratio=0.0,
     method="Tikhonov",
-    **kwargs
+    reg_re=1e-3,
+    rho=1e-3,
+    itr=10,
 ):
     # Handle padding
     if z_padding < 0:
@@ -180,12 +182,12 @@ def apply_inverse_transfer_function(
     # Reconstruct
     if method == "Tikhonov":
         f_real = util.single_variable_tikhonov_deconvolution_3D(
-            zyx, effective_transfer_function, **kwargs
+            zyx, effective_transfer_function, reg_re=reg_re
         )
 
     elif method == "TV":
         f_real = util.single_variable_admm_tv_deconvolution_3D(
-            zyx, effective_transfer_function, **kwargs
+            zyx, effective_transfer_function, reg_re=reg_re, rho=rho, itr=itr
         )
 
     # Unpad


### PR DESCRIPTION
I'm documenting this change in its own PR for @edyoshikun, since it may affect his WIP. Tested with `recOrder`s `connect-reg-params` branch.