### PR TITLE
Add optional parameters `plot_path` and `threshold_FWHM` to `focus_from_transverse_band` 

### DIFF
--- a/tests/test_focus_estimator.py
+++ b/tests/test_focus_estimator.py
@@ -3,8 +3,7 @@ import numpy as np
 from waveorder import focus
 
 
-def test_focus_estimator():
-
+def test_focus_estimator(tmp_path):
     ps = 6.5 / 100
     lambda_ill = 0.532
     NA_det = 1.4
@@ -37,7 +36,40 @@ def test_focus_estimator():
             np.zeros((2, 3, 4)), NA_det, lambda_ill, ps, mode="maxx"
         )
 
+    plot_path = tmp_path.joinpath("test.pdf")
     data3D = np.random.random((11, 256, 256))
-    slice = focus.focus_from_transverse_band(data3D, ps, lambda_ill, NA_det)
+    slice = focus.focus_from_transverse_band(
+        data3D, ps, lambda_ill, NA_det, plot_path=str(plot_path)
+    )
     assert slice >= 0
     assert slice <= data3D.shape[0]
+    assert plot_path.exists()
+
+
+def test_focus_estimator_snr(tmp_path):
+    ps = 6.5 / 100
+    lambda_ill = 0.532
+    NA_det = 1.4
+
+    x = np.linspace(-1, 1, 256)
+    y = np.linspace(-1, 1, 256)
+    z = np.linspace(-1, 1, 21)
+    zz, yy, xx = np.meshgrid(z, y, x, indexing="ij")
+    phantom = (np.sqrt(xx**2 + yy**2 + zz**2) < 0.5).astype(np.uint16)
+
+    for snr in [1000, 100, 10, 1, 0.1]:
+        np.random.seed(1)
+        data = np.random.poisson(
+            phantom * np.sqrt(snr), size=phantom.shape
+        ) + np.random.normal(loc=0, scale=3, size=phantom.shape)
+
+        slice = focus.focus_from_transverse_band(
+            data,
+            ps,
+            lambda_ill,
+            NA_det,
+            plot_path=f"./test-{snr}.pdf",#tmp_path / 
+            peak_width_threshold=5,
+        )
+        if slice is not None:
+            assert np.abs(slice - 10) <= 2

--- a/tests/test_focus_estimator.py
+++ b/tests/test_focus_estimator.py
@@ -63,13 +63,15 @@ def test_focus_estimator_snr(tmp_path):
             phantom * np.sqrt(snr), size=phantom.shape
         ) + np.random.normal(loc=0, scale=3, size=phantom.shape)
 
+        plot_path = tmp_path / f"test-{snr}.pdf"
         slice = focus.focus_from_transverse_band(
             data,
             ps,
             lambda_ill,
             NA_det,
-            plot_path=f"./test-{snr}.pdf",#tmp_path / 
-            peak_width_threshold=5,
+            plot_path=plot_path,
+            threshold_FWHM=5,
         )
+        assert plot_path.exists()
         if slice is not None:
             assert np.abs(slice - 10) <= 2

--- a/waveorder/focus.py
+++ b/waveorder/focus.py
@@ -13,7 +13,7 @@ def focus_from_transverse_band(
     midband_fractions=(0.125, 0.25),
     mode: Literal["min" "max"] = "max",
     plot_path: Optional[str] = None,
-    peak_width_threshold: float = 0,
+    threshold_FWHM: float = 0,
 ):
     """Estimates the in-focus slice from a 3D stack by optimizing a transverse spatial frequency band.
 
@@ -38,10 +38,10 @@ def focus_from_transverse_band(
     plot_path: str or None, optional
         File name for a diagnostic plot (supports matplotlib filetypes .png, .pdf, .svg, etc.).
         Use None to skip.
-    peak_width_threshold: float, optional
-        Threshold width for a peak to be considered in focus.
-        The default value, 0, applies no threshold, and the maximum midband power is considered in focus.
-        For values >0, the peak's FWHM must be greater than the threshold for the slice to be considered in focus.
+    threshold_FWHM: float, optional
+        Threshold full-width half max for a peak to be considered in focus.
+        The default value, 0, applies no threshold, and the maximum midband power is always considered in focus.
+        For values > 0, the peak's FWHM must be greater than the threshold for the slice to be considered in focus.
         If the peak does not meet this threshold, the function returns None.
 
     Returns
@@ -60,8 +60,48 @@ def focus_from_transverse_band(
     >>> slice = focus_from_transverse_band(zyx_array, NA_det=0.55, lambda_ill=0.532, pixel_size=6.5/20)
     >>> in_focus_data = data[slice,:,:]
     """
+    minmaxfunc = _check_focus_inputs(
+        zyx_array, NA_det, lambda_ill, pixel_size, midband_fractions, mode
+    )
 
-    # Check inputs
+    # Calculate coordinates
+    _, Y, X = zyx_array.shape
+    _, _, fxx, fyy = util.gen_coordinate((Y, X), pixel_size)
+    frr = np.sqrt(fxx**2 + fyy**2)
+
+    # Calculate fft
+    xy_abs_fft = np.abs(np.fft.fftn(zyx_array, axes=(1, 2)))
+
+    # Calculate midband mask
+    cutoff = 2 * NA_det / lambda_ill
+    midband_mask = np.logical_and(
+        frr > cutoff * midband_fractions[0],
+        frr < cutoff * midband_fractions[1],
+    )
+
+    # Find slice index with min/max power in midband
+    midband_sum = np.sum(xy_abs_fft[:, midband_mask], axis=1)
+    peak_index = minmaxfunc(midband_sum)
+
+    peak_results = peak_widths(midband_sum, [peak_index])
+    FWHM = peak_results[0][0]
+    if FWHM > threshold_FWHM:
+        in_focus_index = peak_index
+    else:
+        in_focus_index = None
+
+    # Plot
+    if plot_path is not None:
+        _plot_focus_metric(
+            plot_path, midband_sum, peak_index, in_focus_index, peak_results, threshold_FWHM
+        )
+
+    return in_focus_index
+
+
+def _check_focus_inputs(
+    zyx_array, NA_det, lambda_ill, pixel_size, midband_fractions, mode
+):
     N = len(zyx_array.shape)
     if N != 3:
         raise ValueError(
@@ -99,65 +139,40 @@ def focus_from_transverse_band(
         minmaxfunc = np.argmax
     else:
         raise ValueError("mode must be either `min` or `max`")
+    return minmaxfunc
 
-    # Calculate coordinates
-    _, Y, X = zyx_array.shape
-    _, _, fxx, fyy = util.gen_coordinate((Y, X), pixel_size)
-    frr = np.sqrt(fxx**2 + fyy**2)
 
-    # Calculate fft
-    xy_abs_fft = np.abs(np.fft.fftn(zyx_array, axes=(1, 2)))
+def _plot_focus_metric(
+    plot_path, midband_sum, peak_index, in_focus_index, peak_results, threshold_FWHM
+):
+    _, ax = plt.subplots(1, 1, figsize=(4, 4))
+    ax.plot(midband_sum, "-k")
+    ax.plot(
+        peak_index,
+        midband_sum[peak_index],
+        "go" if in_focus_index is not None else "ro",
+    )
+    ax.hlines(*peak_results[1:], color="k", linestyles="dashed")
 
-    # Calculate midband mask
-    cutoff = 2 * NA_det / lambda_ill
-    midband_mask = np.logical_and(
-        frr > cutoff * midband_fractions[0],
-        frr < cutoff * midband_fractions[1],
+    ax.set_xlabel("Slice index")
+    ax.set_ylabel("Midband power")
+
+    ax.annotate(
+        f"In-focus slice = {in_focus_index}\n Peak width = {peak_results[0][0]:.2f}\n Peak width threshold = {threshold_FWHM}",
+        xy=(1, 1),
+        xytext=(1.0, 1.1),
+        textcoords="axes fraction",
+        xycoords="axes fraction",
+        ha="right",
+        va="center",
+        annotation_clip=False,
     )
 
-    # Find slice index with min/max power in midband
-    midband_sum = np.sum(xy_abs_fft[:, midband_mask], axis=1)
-    peak_index = minmaxfunc(midband_sum)
+    ax.spines["right"].set_visible(False)
+    ax.spines["top"].set_visible(False)
+    ax.spines["left"].set_position(("outward", 10))
+    ax.spines["bottom"].set_position(("outward", 10))
+    ax.ticklabel_format(style="sci", scilimits=(-2, 2))
 
-    peak_results = peak_widths(midband_sum, [peak_index])
-    width = peak_results[0][0]
-    if width > peak_width_threshold:
-        in_focus_index = peak_index
-    else:
-        in_focus_index = None
-
-    # Plot
-    if plot_path is not None:
-        _, ax = plt.subplots(1, 1, figsize=(4, 4))
-        ax.plot(midband_sum, "-k")
-        ax.plot(
-            peak_index,
-            midband_sum[peak_index],
-            "go" if in_focus_index is not None else "ro",
-        )
-        ax.hlines(*peak_results[1:], color="k", linestyles="dashed")
-
-        ax.set_xlabel("Slice index")
-        ax.set_ylabel("Midband power")
-
-        ax.annotate(
-            f"In-focus slice = {in_focus_index}\n Peak width = {width:.2f}\n Peak width threshold = {peak_width_threshold}",
-            xy=(1, 1),
-            xytext=(1.0, 1.1),
-            textcoords="axes fraction",
-            xycoords="axes fraction",
-            ha="right",
-            va="center",
-            annotation_clip=False,
-        )
-
-        ax.spines["right"].set_visible(False)
-        ax.spines["top"].set_visible(False)
-        ax.spines["left"].set_position(("outward", 10))
-        ax.spines["bottom"].set_position(("outward", 10))
-        ax.ticklabel_format(style="sci", scilimits=(-2, 2))
-
-        print(f"Saving plot to {plot_path}")
-        plt.savefig(plot_path, bbox_inches="tight", dpi=300)
-
-    return in_focus_index
+    print(f"Saving plot to {plot_path}")
+    plt.savefig(plot_path, bbox_inches="tight", dpi=300)

--- a/waveorder/focus.py
+++ b/waveorder/focus.py
@@ -11,7 +11,7 @@ def focus_from_transverse_band(
     lambda_ill,
     pixel_size,
     midband_fractions=(0.125, 0.25),
-    mode: Literal["min" "max"] = "max",
+    mode: Literal["min", "max"] = "max",
     plot_path: Optional[str] = None,
     threshold_FWHM: float = 0,
 ):

--- a/waveorder/focus.py
+++ b/waveorder/focus.py
@@ -84,8 +84,9 @@ def focus_from_transverse_band(
     peak_index = minmaxfunc(midband_sum)
 
     peak_results = peak_widths(midband_sum, [peak_index])
-    FWHM = peak_results[0][0]
-    if FWHM > threshold_FWHM:
+    peak_FWHM = peak_results[0][0]
+
+    if peak_FWHM > threshold_FWHM:
         in_focus_index = peak_index
     else:
         in_focus_index = None

--- a/waveorder/focus.py
+++ b/waveorder/focus.py
@@ -15,27 +15,38 @@ def focus_from_transverse_band(
 
     Parameters
     ----------
-    zyx_array : np.array
+    zyx_array: np.array
         Data stack in (Z, Y, X) order.
-        Requires len(3d_array.shape) == 3.
-    NA_det : float
+        Requires len(zyx_array.shape) == 3.
+    NA_det: float
         Detection NA.
-    lambda_ill : float
+    lambda_ill: float
         Illumination wavelength
         Units are arbitrary, but must match [pixel_size]
-    pixel_size : float
+    pixel_size: float
         Object-space pixel size = camera pixel size / magnification.
         Units are arbitrary, but must match [lambda_ill]
     midband_fractions: Tuple[float, float], optional
         The minimum and maximum fraction of the cutoff frequency that define the midband.
         Requires: 0 <= midband_fractions[0] < midband_fractions[1] <= 1.
     mode: {'max', 'min'}, optional
-        Option to choose the in-focus slice my minimizing or maximizing the midband frequency.
+        Option to choose the in-focus slice by minimizing or maximizing the midband frequency.
+    plot_path: str or None, optional
+        File name for a diagnostic plot (supports matplotlib filetypes .png, .pdf, .svg, etc.).
+        Use None to skip.
+    peak_width_threshold: float, optional
+        Threshold width for a peak to be considered in focus.
+        The default value, 0, applies no threshold, and the maximum midband power is considered in focus.
+        For values >0, the peak's FWHM must be greater than the threshold for the slice to be considered in focus.
+        If the peak does not meet this threshold, the function returns None.
 
     Returns
     ------
-    slice : int
-        The index of the in-focus slice.
+    slice : int or None
+        If peak's FWHM > peak_width_threshold:
+            return the index of the in-focus slice
+        else:
+            return None
 
     Example
     ------


### PR DESCRIPTION
**Summary**
This PR fixes #129 and adds:
- an optional `plot_path` option...passing a path string will save a diagnostic plot to that path (`.png`, `.svg`, `.pdf` etc)
- an optional `threshold_FWHM` option (default 0) will make the function return an in-focus slice if the mid-band power peak has a FWHM larger than the threshold...otherwise the function will return `None`. 

**Rationale:**
After my initial conversation with @ieivanov, I looked for a way to "normalize" the mid-band power metric so that we could try using an absolute threshold. I ended up convincing myself that finding an absolute threshold would be challenging. 

For example, consider an in-focus object that fills the FOV then the same object that fills a small part of the FOV (padded with zeros/noise). If we normalize by the number of pixels in the FOV then the mid-band power appears to change between these two objects, when we'd like to focus on them both equally well. I played with a few alternative normalizations, and ultimately decide to try a different approach. 

I ended up settling on the `threshold_FWHM` approach implemented here. The rationale is that noise will typically have peaks with smaller FWHM than real axially-extended in-focus objects, so we can reject "in-focus noise" by thresholding on the FWHM. Larger FWHM peaks are also associated with peaks that have tighter sampling (i.e. we have more confidence that the object is there) and that are away from the edges (a peak at the very edge has zero FWHM by definition in the current implementation). 

**Performance on real data**
Caption: four focus-finding diagnostic plots generated with real data (2023-07-03). Rows: two positions. Columns: whole FOV and a hand-selected background region filled with noise. Green dots indicate an in-focus peak returned by the function, while red dots indicate a rejected peak (the function returns `None`). 
<img width="1693" alt="Screenshot 2023-07-11 at 11 03 31 AM" src="https://github.com/mehta-lab/waveorder/assets/9554101/01055195-b8f2-482e-bc57-ae07efcf5aed">

**Performance on synthetic data**
Caption: an SNR sweep on simulated data. On average, the peak width for an in-focus object decreases as the SNR decreases, so thresholding on the peak width is an appropriate strategy. 
<img width="1890" alt="Screenshot 2023-07-11 at 11 06 29 AM" src="https://github.com/mehta-lab/waveorder/assets/9554101/24ca428a-9580-422f-bb7a-e7b41ec17d1e">

**Comment on (lack of) danger to hardware**
This approach uses data that's already been acquired to estimate in-focus positions, so it does not introduce any additional danger of crashing. Increasing the `threshold_FWHM` increases the safety since it reduces the likelihood of choosing slices that are at the edge of the axial FOV, which reduces the chance of repeated run leading to a crash. 

**Next steps**
@ieivanov if you find that `threshold_FWHM` does not provide the discriminatory power you need, we can iterate and try different threshold/peak finders. 
