### PR TITLE
Fix threshold-free focus-finding edge case 

### DIFF
--- a/waveorder/focus.py
+++ b/waveorder/focus.py
@@ -86,7 +86,7 @@ def focus_from_transverse_band(
     peak_results = peak_widths(midband_sum, [peak_index])
     peak_FWHM = peak_results[0][0]
 
-    if peak_FWHM > threshold_FWHM:
+    if peak_FWHM >= threshold_FWHM:
         in_focus_index = peak_index
     else:
         in_focus_index = None


### PR DESCRIPTION
**Before this PR:** if `threshold_FWHM = 0` (the default) and `peak_FWHM = 0` (a possibility with a noisy input), the focus finding algorithm will return `None`. This is a bug because it changes the previous behavior of the algorithm, and the documentation states that a slice will be returned if `threshold_FWHM = 0`. 

**After this PR:** if `threshold_FWHM = 0` and `peak_FWHM = 0`, the algorithm returns the peak's slice. 

Failing tests helped me catch this bug (:raised_hands:). @ieivanov the failure after several passing runs was due to random numbers in this test---thanks for flagging this. 
