### PR TITLE
close figure after saving

### DIFF
--- a/waveorder/focus.py
+++ b/waveorder/focus.py
@@ -177,3 +177,4 @@ def _plot_focus_metric(
 
     print(f"Saving plot to {plot_path}")
     plt.savefig(plot_path, bbox_inches="tight", dpi=300)
+    plt.close()


### PR DESCRIPTION
`matplotlib.pyplot` figures remain open until explicitly closed. Calling `focus_from_transverse_band` multiple times keeps open figures in memory - we should close them after saving