### PR TITLE
Simplify dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,10 +42,6 @@ install_requires =
     scipy>=1.3.0
     pywavelets>=1.1.1
     ipywidgets>=7.5.1
-    tifffile>=2021.11.2
-    zarr>=2.6.1
-    natsort>=7.1.1
-    pycromanager>=0.13.2
     torch>=2.0.0
 
 [options.extras_require]


### PR DESCRIPTION
Fixes #146. 

Removes dependencies that moved to `iohub`. 

See also: https://github.com/conda-forge/waveorder-feedstock/pull/9