### PR TITLE
Add rotate and flip orientation options to `waveorder` options

### DIFF
--- a/tests/models/test_inplane_oriented_thick_pol3D.py
+++ b/tests/models/test_inplane_oriented_thick_pol3D.py
@@ -18,7 +18,7 @@ def test_calculate_transfer_function():
 
 def test_apply_inverse_transfer_function():
     input_shape = (5, 10, 5, 5)
-    czyx_data = torch.randn(input_shape)
+    czyx_data = torch.rand(input_shape)
 
     intensity_to_stokes_matrix = (
         inplane_oriented_thick_pol3d.calculate_transfer_function(

--- a/tests/models/test_inplane_oriented_thick_pol3D.py
+++ b/tests/models/test_inplane_oriented_thick_pol3D.py
@@ -1,5 +1,6 @@
 import pytest
 import torch
+
 from waveorder import stokes
 from waveorder.models import inplane_oriented_thick_pol3d
 
@@ -13,3 +14,25 @@ def test_calculate_transfer_function():
     )
 
     assert intensity_to_stokes_matrix.shape == (4, 5)
+
+
+def test_apply_inverse_transfer_function():
+    input_shape = (5, 10, 5, 5)
+    czyx_data = torch.randn(input_shape)
+
+    intensity_to_stokes_matrix = (
+        inplane_oriented_thick_pol3d.calculate_transfer_function(
+            swing=0.1,
+            scheme="5-State",
+        )
+    )
+
+    results = inplane_oriented_thick_pol3d.apply_inverse_transfer_function(
+        czyx_data=czyx_data,
+        intensity_to_stokes_matrix=intensity_to_stokes_matrix,
+    )
+
+    assert len(results) == 4
+
+    for result in results:
+        assert result.shape == input_shape[1:]

--- a/tests/models/test_isotropic_fluorescent_thick_3d.py
+++ b/tests/models/test_isotropic_fluorescent_thick_3d.py
@@ -4,8 +4,7 @@ import torch
 from waveorder.models import isotropic_fluorescent_thick_3d
 
 
-@pytest.mark.parametrize("axial_flip", (True, False))
-def test_calculate_transfer_function(axial_flip):
+def test_calculate_transfer_function():
     z_padding = 5
     transfer_function = (
         isotropic_fluorescent_thick_3d.calculate_transfer_function(
@@ -16,7 +15,6 @@ def test_calculate_transfer_function(axial_flip):
             z_padding=z_padding,
             index_of_refraction_media=1.0,
             numerical_aperture_detection=0.55,
-            invert_phase_contrast=axial_flip,
         )
     )
 

--- a/tests/models/test_isotropic_fluorescent_thick_3d.py
+++ b/tests/models/test_isotropic_fluorescent_thick_3d.py
@@ -1,5 +1,6 @@
 import pytest
 import torch
+
 from waveorder.models import isotropic_fluorescent_thick_3d
 
 
@@ -15,7 +16,7 @@ def test_calculate_transfer_function(axial_flip):
             z_padding=z_padding,
             index_of_refraction_media=1.0,
             numerical_aperture_detection=0.55,
-            axial_flip=axial_flip,
+            invert_phase_contrast=axial_flip,
         )
     )
 

--- a/tests/models/test_isotropic_thin_3d.py
+++ b/tests/models/test_isotropic_thin_3d.py
@@ -1,10 +1,11 @@
 import pytest
 import torch
+
 from waveorder.models import isotropic_thin_3d
 
 
-@pytest.mark.parametrize("axial_flip", (True, False))
-def test_calculate_transfer_function(axial_flip):
+@pytest.mark.parametrize("invert_phase_contrast", (True, False))
+def test_calculate_transfer_function(invert_phase_contrast):
     Hu, Hp = isotropic_thin_3d.calculate_transfer_function(
         yx_shape=(100, 101),
         yx_pixel_size=6.5 / 40,
@@ -13,7 +14,7 @@ def test_calculate_transfer_function(axial_flip):
         index_of_refraction_media=1.0,
         numerical_aperture_illumination=0.4,
         numerical_aperture_detection=0.55,
-        axial_flip=axial_flip,
+        invert_phase_contrast=invert_phase_contrast,
     )
 
     assert Hu.shape == (3, 100, 101)

--- a/tests/models/test_phase_thick_3d.py
+++ b/tests/models/test_phase_thick_3d.py
@@ -1,9 +1,10 @@
 import pytest
+
 from waveorder.models import phase_thick_3d
 
 
-@pytest.mark.parametrize("axial_flip", (True, False))
-def test_calculate_transfer_function(axial_flip):
+@pytest.mark.parametrize("invert_phase_contrast", (True, False))
+def test_calculate_transfer_function(invert_phase_contrast):
     z_padding = 5
     H_re, H_im = phase_thick_3d.calculate_transfer_function(
         zyx_shape=(20, 100, 101),
@@ -14,7 +15,7 @@ def test_calculate_transfer_function(axial_flip):
         index_of_refraction_media=1.0,
         numerical_aperture_illumination=0.45,
         numerical_aperture_detection=0.55,
-        axial_flip=axial_flip
+        invert_phase_contrast=invert_phase_contrast,
     )
 
     assert H_re.shape == (20 + 2 * z_padding, 100, 101)

--- a/tests/test_stokes.py
+++ b/tests/test_stokes.py
@@ -1,8 +1,9 @@
 import numpy as np
-from waveorder import stokes
 import pytest
 import torch
 import torch.testing as tt
+
+from waveorder import stokes
 
 
 def test_S2I_matrix():
@@ -131,3 +132,48 @@ def test_copying():
     M = stokes.mueller_from_stokes(a, b, c, d)
     M[0, 0, 0] = -1  # modify the output
     assert a[0] == 1
+
+
+def test_orientation_offset():
+    ori = torch.tensor(
+        [0, torch.pi / 4, torch.pi / 2, torch.pi - 0.01, torch.pi]
+    )
+
+    ff = stokes.apply_orientation_offset(ori, rotate=False, flip=False)
+    assert torch.allclose(
+        ff, torch.tensor([0, torch.pi / 4, torch.pi / 2, torch.pi - 0.01, 0])
+    )
+
+    tf = stokes.apply_orientation_offset(ori, rotate=True, flip=False)
+    assert torch.allclose(
+        tf,
+        torch.tensor(
+            [
+                torch.pi / 2,
+                3 * torch.pi / 4,
+                0,
+                (torch.pi / 2) - 0.01,
+                torch.pi / 2,
+            ]
+        ),
+    )
+
+    ft = stokes.apply_orientation_offset(ori, rotate=False, flip=True)
+    assert torch.allclose(
+        ft,
+        torch.tensor([0, 3 * torch.pi / 4, torch.pi / 2, 0.01, 0]),
+    )
+
+    tt = stokes.apply_orientation_offset(ori, rotate=True, flip=True)
+    assert torch.allclose(
+        tt,
+        torch.tensor(
+            [
+                torch.pi / 2,
+                torch.pi / 4,
+                0,
+                (torch.pi / 2) + 0.01,
+                torch.pi / 2,
+            ]
+        ),
+    )

--- a/waveorder/models/inplane_oriented_thick_pol3d.py
+++ b/waveorder/models/inplane_oriented_thick_pol3d.py
@@ -55,8 +55,8 @@ def apply_inverse_transfer_function(
     cyx_no_sample_data=None,  # if not None, use this data for background correction
     project_stokes_to_2d=False,
     remove_estimated_background=False,  # if True estimate background from czyx_data and remove it
-    orientation_flip=False,
-    orientation_rotate=False,
+    flip_orientation=False,
+    rotate_orientation=False,
 ):
     data_stokes = stokes.mmul(intensity_to_stokes_matrix, czyx_data)
 
@@ -103,7 +103,7 @@ def apply_inverse_transfer_function(
 
     # Apply orientation transformations
     orientation = stokes.apply_orientation_offset(
-        adr_parameters[1], rotate=orientation_rotate, flip=orientation_flip
+        adr_parameters[1], rotate=rotate_orientation, flip=flip_orientation
     )
 
     return retardance, orientation, adr_parameters[2], adr_parameters[3]

--- a/waveorder/models/inplane_oriented_thick_pol3d.py
+++ b/waveorder/models/inplane_oriented_thick_pol3d.py
@@ -55,8 +55,8 @@ def apply_inverse_transfer_function(
     cyx_no_sample_data=None,  # if not None, use this data for background correction
     project_stokes_to_2d=False,
     remove_estimated_background=False,  # if True estimate background from czyx_data and remove it
-    orientation_flip=False,  # TODO implement
-    orientation_rotate=False,  # TODO implement
+    orientation_flip=False,
+    orientation_rotate=False,
 ):
     data_stokes = stokes.mmul(intensity_to_stokes_matrix, czyx_data)
 

--- a/waveorder/models/inplane_oriented_thick_pol3d.py
+++ b/waveorder/models/inplane_oriented_thick_pol3d.py
@@ -1,5 +1,6 @@
 import numpy as np
 import torch
+
 from waveorder import background_estimator, stokes, util
 
 
@@ -100,4 +101,9 @@ def apply_inverse_transfer_function(
     # Return retardance in distance units (matching wavelength_illumination)
     retardance = adr_parameters[0] * wavelength_illumination / (2 * np.pi)
 
-    return retardance, adr_parameters[1], adr_parameters[2], adr_parameters[3]
+    # Apply orientation transformations
+    orientation = stokes.apply_orientation_offset(
+        adr_parameters[1], rotate=orientation_rotate, flip=orientation_flip
+    )
+
+    return retardance, orientation, adr_parameters[2], adr_parameters[3]

--- a/waveorder/models/isotropic_fluorescent_thick_3d.py
+++ b/waveorder/models/isotropic_fluorescent_thick_3d.py
@@ -24,7 +24,6 @@ def calculate_transfer_function(
     z_padding,
     index_of_refraction_media,
     numerical_aperture_detection,
-    invert_phase_contrast=False,
 ):
     radial_frequencies = util.generate_radial_frequencies(
         zyx_shape[1:], yx_pixel_size
@@ -34,9 +33,7 @@ def calculate_transfer_function(
     z_position_list = torch.fft.ifftshift(
         (torch.arange(z_total) - z_total // 2) * z_pixel_size
     )
-    if invert_phase_contrast:
-        z_position_list = torch.flip(z_position_list, dims=(0,))
-
+    
     det_pupil = optics.generate_pupil(
         radial_frequencies,
         numerical_aperture_detection,

--- a/waveorder/models/isotropic_fluorescent_thick_3d.py
+++ b/waveorder/models/isotropic_fluorescent_thick_3d.py
@@ -1,4 +1,5 @@
 import torch
+
 from waveorder import optics, util
 
 
@@ -23,7 +24,7 @@ def calculate_transfer_function(
     z_padding,
     index_of_refraction_media,
     numerical_aperture_detection,
-    axial_flip=False,
+    invert_phase_contrast=False,
 ):
     radial_frequencies = util.generate_radial_frequencies(
         zyx_shape[1:], yx_pixel_size
@@ -33,7 +34,7 @@ def calculate_transfer_function(
     z_position_list = torch.fft.ifftshift(
         (torch.arange(z_total) - z_total // 2) * z_pixel_size
     )
-    if axial_flip:
+    if invert_phase_contrast:
         z_position_list = torch.flip(z_position_list, dims=(0,))
 
     det_pupil = optics.generate_pupil(

--- a/waveorder/models/isotropic_thin_3d.py
+++ b/waveorder/models/isotropic_thin_3d.py
@@ -1,5 +1,6 @@
-import torch
 import numpy as np
+import torch
+
 from waveorder import optics, util
 
 
@@ -38,9 +39,9 @@ def calculate_transfer_function(
     index_of_refraction_media,
     numerical_aperture_illumination,
     numerical_aperture_detection,
-    axial_flip=False,
+    invert_phase_contrast=False,
 ):
-    if axial_flip:
+    if invert_phase_contrast:
         z_position_list = torch.flip(torch.tensor(z_position_list), dims=(0,))
 
     radial_frequencies = util.generate_radial_frequencies(

--- a/waveorder/models/phase_thick_3d.py
+++ b/waveorder/models/phase_thick_3d.py
@@ -1,5 +1,6 @@
 import numpy as np
 import torch
+
 from waveorder import optics, util
 from waveorder.models import isotropic_fluorescent_thick_3d
 
@@ -39,7 +40,7 @@ def calculate_transfer_function(
     index_of_refraction_media,
     numerical_aperture_illumination,
     numerical_aperture_detection,
-    axial_flip=False,
+    invert_phase_contrast=False,
 ):
     radial_frequencies = util.generate_radial_frequencies(
         zyx_shape[1:], yx_pixel_size
@@ -48,7 +49,7 @@ def calculate_transfer_function(
     z_position_list = torch.fft.ifftshift(
         (torch.arange(z_total) - z_total // 2) * z_pixel_size
     )
-    if axial_flip:
+    if invert_phase_contrast:
         z_position_list = torch.flip(z_position_list, dims=(0,))
 
     ill_pupil = optics.generate_pupil(

--- a/waveorder/stokes.py
+++ b/waveorder/stokes.py
@@ -426,7 +426,7 @@ def mmul(matrix, vector):
 
 def apply_orientation_offset(orientation, rotate, flip):
     """
-    Applies an in-place rotation and/or flip to an orientation map while
+    Applies a rotation and/or flip to an orientation map while
     keeping the output range within 0 <= orientation < pi.
 
     Parameters

--- a/waveorder/stokes.py
+++ b/waveorder/stokes.py
@@ -426,7 +426,7 @@ def mmul(matrix, vector):
 
 def apply_orientation_offset(orientation, rotate, flip):
     """
-    Applies a rotation and/or flip to an orientation map while
+    Applies a rotation and/or flip to each voxel of an  orientation map while
     keeping the output range within 0 <= orientation < pi.
 
     Parameters

--- a/waveorder/stokes.py
+++ b/waveorder/stokes.py
@@ -29,7 +29,7 @@ y = mmul(A, x)
 Usage
 -----
 
-All functions are intended to be used with ND-arrays with Stokes- or 
+All functions are intended to be used with torch.Tensors with Stokes- or 
 Mueller-indices as the first axes. 
 
 For example, the following usage modes of stokes_after_adr are valid:
@@ -66,7 +66,7 @@ def calculate_stokes_to_intensity_matrix(swing, scheme="5-State"):
 
     Returns
     -------
-    torch.tensor
+    torch.Tensor
         Returns different shapes depending on the scheme
 
         S2I.shape = (5, 4) for scheme = "5-State"
@@ -127,7 +127,7 @@ def calculate_intensity_to_stokes_matrix(swing, scheme="5-State"):
 
     Returns
     -------
-    torch.tensor
+    torch.Tensor
         Returns different shapes depending on the scheme
 
         I2S.shape = (5, 4) for scheme = "5-State"
@@ -147,7 +147,7 @@ def stokes_after_adr(
     depolarizing retarder (adr) parametrized by its retardance, slow-axis
     orientation, transmittance, and depolarization.
 
-    Note: all four parameters can be torch.tensor, but they must be the same size.
+    Note: all four parameters can be torch.Tensor, but they must be the same size.
     If your parameters are in a tensor with shape = (4, ...), use
     the * operator to expand over the first dimension.
 
@@ -156,7 +156,7 @@ def stokes_after_adr(
 
     Parameters
     ----------
-    retardance, orientation, transmittance, depolarization : torch.tensor, identical shapes
+    retardance, orientation, transmittance, depolarization : torch.Tensor, identical shapes
         retardance: retardance of adr, 2*pi periodic
         orientation: slow-axis orientation of adr, 2*pi periodic
         transmittance: transmittance of adr, 0 <= transmittance <= 1
@@ -167,7 +167,7 @@ def stokes_after_adr(
 
     Returns
     -------
-    s0, s1, s2, s3: torch.tensor, identical shapes
+    s0, s1, s2, s3: torch.Tensor, identical shapes
         Stokes parameters
 
     """
@@ -205,7 +205,7 @@ def stokes012_after_ar(retardance, orientation, transmittance, input="cpl"):
 
     Parameters
     ----------
-    retardance, orientation, transmittance: torch.tensor, identical shapes
+    retardance, orientation, transmittance: torch.Tensor, identical shapes
         retardance: retardance of ar, 2*pi periodic
         orientation: slow-axis orientation of ar, 2*pi periodic
         transmittance: transmittance of ar, 0 <= transmittance <= 1
@@ -215,7 +215,7 @@ def stokes012_after_ar(retardance, orientation, transmittance, input="cpl"):
 
     Returns
     -------
-    s0, s1, s2: torch.tensor
+    s0, s1, s2: torch.Tensor
         First three Stokes parameters
 
     """
@@ -239,12 +239,12 @@ def _s12_to_orientation(s1, s2):
 
     Parameters
     ----------
-    s1, s2: torch.tensor, identical shapes
+    s1, s2: torch.Tensor, identical shapes
         Stokes parameters
 
     Returns
     -------
-    torch.tensor
+    torch.Tensor
         Slow-axis orientation with 0 <= orientation < pi.
     """
     return (torch.arctan2(s1, -s2) % (2 * np.pi)) / 2
@@ -267,7 +267,7 @@ def estimate_adr_from_stokes(s0, s1, s2, s3, input="cpl"):
 
     Parameters
     ----------
-    s0, s1, s2, s3: torch.tensor, identical shapes
+    s0, s1, s2, s3: torch.Tensor, identical shapes
         Stokes parameters
 
     input : "cpl"
@@ -275,7 +275,7 @@ def estimate_adr_from_stokes(s0, s1, s2, s3, input="cpl"):
 
     Returns
     ----------
-    retardance, orientation, transmittance, depolarization: torch.tensor
+    retardance, orientation, transmittance, depolarization: torch.Tensor
         retardance: retardance of adr, 2*pi periodic
         orientation: slow-axis orientation of adr, 2*pi periodic
         transmittance: transmittance of adr, 0 <= transmittance <= 1
@@ -305,12 +305,12 @@ def estimate_ar_from_stokes012(s0, s1, s2, input="cpl"):
 
     Parameters
     ----------
-    s0, s1, s2: torch.tensor, identical shapes
+    s0, s1, s2: torch.Tensor, identical shapes
         First three Stokes parameters
 
     Returns
     ----------
-    retardance, orientation, transmittance: torch.tensor, identical shapes
+    retardance, orientation, transmittance: torch.Tensor, identical shapes
         retardance: retardance of ar, 2*pi periodic
         orientation: slow-axis orientation of ar, 2*pi periodic
         transmittance: transmittance of ar, 0 <= transmittance <= 1
@@ -343,7 +343,7 @@ def mueller_from_stokes(
 
     Parameters
     ----------
-    s0, s1, s2, s3 : torch.tensor, identical shapes
+    s0, s1, s2, s3 : torch.Tensor, identical shapes
         Stokes parameters
 
     input : "cpl"
@@ -411,12 +411,12 @@ def mmul(matrix, vector):
 
     Parameters
     ----------
-    matrix : torch.tensor, shape = (N, M, ...)
-    vector : torch.tensor, shape = (M, ...)
+    matrix : torch.Tensor, shape = (N, M, ...)
+    vector : torch.Tensor, shape = (M, ...)
 
     Returns
     -------
-    torch.tensor, shape = (N, ...)
+    torch.Tensor, shape = (N, ...)
     """
     if matrix.shape[1] != vector.shape[0]:
         raise ValueError("matrix.shape[1] is not equal to vector.shape[0]")
@@ -431,7 +431,7 @@ def apply_orientation_offset(orientation, rotate, flip):
 
     Parameters
     ----------
-    orientation : torch.tensor
+    orientation : torch.Tensor
         Array of orientations measured in radians
     rotate : bool
         If True, rotate orientation pi/2 radians (90 degrees)
@@ -440,7 +440,7 @@ def apply_orientation_offset(orientation, rotate, flip):
 
     Returns
     -------
-    torch.tensor with same shape as input
+    torch.Tensor with same shape as input
 
     Transformed array of orientations measured in radians
     with range 0 <= orientation < pi

--- a/waveorder/stokes.py
+++ b/waveorder/stokes.py
@@ -147,8 +147,8 @@ def stokes_after_adr(
     depolarizing retarder (adr) parametrized by its retardance, slow-axis
     orientation, transmittance, and depolarization.
 
-    Note: all four parameters can be array_like, but they must be the same size.
-    If your parameters are in an ndarray with array.shape = (4, ...), use
+    Note: all four parameters can be torch.tensor, but they must be the same size.
+    If your parameters are in a tensor with shape = (4, ...), use
     the * operator to expand over the first dimension.
 
     e.g. stokes_after_adr(*array) is identical to
@@ -156,7 +156,7 @@ def stokes_after_adr(
 
     Parameters
     ----------
-    retardance, orientation, transmittance, depolarization : array_like, identical shapes
+    retardance, orientation, transmittance, depolarization : torch.tensor, identical shapes
         retardance: retardance of adr, 2*pi periodic
         orientation: slow-axis orientation of adr, 2*pi periodic
         transmittance: transmittance of adr, 0 <= transmittance <= 1
@@ -167,7 +167,7 @@ def stokes_after_adr(
 
     Returns
     -------
-    s0, s1, s2, s3: array_like, identical shapes
+    s0, s1, s2, s3: torch.tensor, identical shapes
         Stokes parameters
 
     """
@@ -205,7 +205,7 @@ def stokes012_after_ar(retardance, orientation, transmittance, input="cpl"):
 
     Parameters
     ----------
-    retardance, orientation, transmittance: array_like, identical shapes
+    retardance, orientation, transmittance: torch.tensor, identical shapes
         retardance: retardance of ar, 2*pi periodic
         orientation: slow-axis orientation of ar, 2*pi periodic
         transmittance: transmittance of ar, 0 <= transmittance <= 1
@@ -215,7 +215,7 @@ def stokes012_after_ar(retardance, orientation, transmittance, input="cpl"):
 
     Returns
     -------
-    s0, s1, s2: array_like
+    s0, s1, s2: torch.tensor
         First three Stokes parameters
 
     """
@@ -239,12 +239,12 @@ def _s12_to_orientation(s1, s2):
 
     Parameters
     ----------
-    s1, s2: array_like, identical shapes
+    s1, s2: torch.tensor, identical shapes
         Stokes parameters
 
     Returns
     -------
-    array_like
+    torch.tensor
         Slow-axis orientation with 0 <= orientation < pi.
     """
     return (torch.arctan2(s1, -s2) % (2 * np.pi)) / 2
@@ -267,7 +267,7 @@ def estimate_adr_from_stokes(s0, s1, s2, s3, input="cpl"):
 
     Parameters
     ----------
-    s0, s1, s2, s3: array_like, identical shapes
+    s0, s1, s2, s3: torch.tensor, identical shapes
         Stokes parameters
 
     input : "cpl"
@@ -275,7 +275,7 @@ def estimate_adr_from_stokes(s0, s1, s2, s3, input="cpl"):
 
     Returns
     ----------
-    retardance, orientation, transmittance, depolarization: array_like
+    retardance, orientation, transmittance, depolarization: torch.tensor
         retardance: retardance of adr, 2*pi periodic
         orientation: slow-axis orientation of adr, 2*pi periodic
         transmittance: transmittance of adr, 0 <= transmittance <= 1
@@ -305,12 +305,12 @@ def estimate_ar_from_stokes012(s0, s1, s2, input="cpl"):
 
     Parameters
     ----------
-    s0, s1, s2: array_like, identical shapes
+    s0, s1, s2: torch.tensor, identical shapes
         First three Stokes parameters
 
     Returns
     ----------
-    retardance, orientation, transmittance: array_like, identical shapes
+    retardance, orientation, transmittance: torch.tensor, identical shapes
         retardance: retardance of ar, 2*pi periodic
         orientation: slow-axis orientation of ar, 2*pi periodic
         transmittance: transmittance of ar, 0 <= transmittance <= 1
@@ -343,7 +343,7 @@ def mueller_from_stokes(
 
     Parameters
     ----------
-    s0, s1, s2, s3 : array_like, identical shapes
+    s0, s1, s2, s3 : torch.tensor, identical shapes
         Stokes parameters
 
     input : "cpl"
@@ -357,7 +357,7 @@ def mueller_from_stokes(
 
     Returns
     -------
-    array_like, float, M.shape = (4, 4,) + s0.shape
+    torch.tensor, float, M.shape = (4, 4,) + s0.shape
         Mueller matrix
     """
     if input != "cpl":
@@ -411,12 +411,12 @@ def mmul(matrix, vector):
 
     Parameters
     ----------
-    matrix : array_like, shape = (N, M, ...)
-    vector : array_like, shape = (M, ...)
+    matrix : torch.tensor, shape = (N, M, ...)
+    vector : torch.tensor, shape = (M, ...)
 
     Returns
     -------
-    array_like, shape = (N, ...)
+    torch.tensor, shape = (N, ...)
     """
     if matrix.shape[1] != vector.shape[0]:
         raise ValueError("matrix.shape[1] is not equal to vector.shape[0]")
@@ -431,7 +431,7 @@ def apply_orientation_offset(orientation, rotate, flip):
 
     Parameters
     ----------
-    orientation : array_like
+    orientation : torch.tensor
         Array of orientations measured in radians
     rotate : bool
         If True, rotate orientation pi/2 radians (90 degrees)
@@ -440,7 +440,7 @@ def apply_orientation_offset(orientation, rotate, flip):
 
     Returns
     -------
-    array_like with same shape as input
+    torch.tensor with same shape as input
 
     Transformed array of orientations measured in radians
     with range 0 <= orientation < pi

--- a/waveorder/stokes.py
+++ b/waveorder/stokes.py
@@ -46,8 +46,8 @@ For example, the following usage modes of stokes_after_adr are valid:
 >>> stokes_after_adr(*adr_params) # * expands along the first axis
 
 """
-import torch
 import numpy as np
+import torch
 
 
 def calculate_stokes_to_intensity_matrix(swing, scheme="5-State"):
@@ -422,3 +422,37 @@ def mmul(matrix, vector):
         raise ValueError("matrix.shape[1] is not equal to vector.shape[0]")
 
     return torch.einsum("NM...,M...->N...", matrix, vector)
+
+
+def apply_orientation_offset(orientation, rotate, flip):
+    """
+    Applies an in-place rotation and/or flip to an orientation map while
+    keeping the output range within 0 <= orientation < pi.
+
+    Parameters
+    ----------
+    orientation : array_like
+        Array of orientations measured in radians
+    rotate : bool
+        If True, rotate orientation pi/2 radians (90 degrees)
+    flip : bool
+        If True, flip the orientation
+
+    Returns
+    -------
+    array_like with same shape as input
+
+    Transformed array of orientations measured in radians
+    with range 0 <= orientation < pi
+
+    Note
+    ----
+    rotate=False and flip=False leaves the effective orientation unchanged
+    while changing the output range to 0 <= orientation < pi
+    """
+    out_orientation = torch.clone(orientation)
+    if rotate:
+        out_orientation += torch.pi / 2
+    if flip:
+        out_orientation *= -1
+    return torch.remainder(out_orientation, torch.pi)

--- a/waveorder/stokes.py
+++ b/waveorder/stokes.py
@@ -426,7 +426,7 @@ def mmul(matrix, vector):
 
 def apply_orientation_offset(orientation, rotate, flip):
     """
-    Applies a rotation and/or flip to each voxel of an  orientation map while
+    Applies a rotation and/or flip to each voxel of an orientation map while
     keeping the output range within 0 <= orientation < pi.
 
     Parameters


### PR DESCRIPTION
In [`recOrder` #248](https://github.com/mehta-lab/recOrder/pull/248) we added an orientation offset checkbox to `recOrder`'s GUI. 

This PR is a first step towards moving this logic to `waveorder` so that these options are more easily available. 

I've also added a `flip` option so that all combinations are covered. Following this merge, I will remove the business logic from `recOrder`, add another button to the `recOrder` GUI, then connect the `rotation` and `flip` buttons to the waveorder side.  