### PR TITLE
Update background estimation to use torch

### DIFF
--- a/tests/models/test_inplane_oriented_thick_pol3D.py
+++ b/tests/models/test_inplane_oriented_thick_pol3D.py
@@ -17,8 +17,9 @@ def test_calculate_transfer_function():
 
 
 @pytest.mark.parametrize(*_DEVICE)
-def test_apply_inverse_transfer_function(device):
-    input_shape = (5, 10, 5, 5)
+@pytest.mark.parametrize("estimate_bg", [True, False])
+def test_apply_inverse_transfer_function(device, estimate_bg):
+    input_shape = (5, 10, 100, 100)
     czyx_data = torch.rand(input_shape, device=device)
 
     intensity_to_stokes_matrix = (
@@ -31,6 +32,7 @@ def test_apply_inverse_transfer_function(device):
     results = inplane_oriented_thick_pol3d.apply_inverse_transfer_function(
         czyx_data=czyx_data,
         intensity_to_stokes_matrix=intensity_to_stokes_matrix,
+        remove_estimated_background=estimate_bg,
     )
 
     assert len(results) == 4

--- a/tests/test_correction.py
+++ b/tests/test_correction.py
@@ -1,0 +1,42 @@
+import pytest
+import torch
+
+from tests.conftest import _DEVICE
+from waveorder.correction import (
+    _fit_2d_polynomial_surface,
+    _grid_coordinates,
+    _sample_block_medians,
+    estimate_background,
+)
+
+
+def test_sample_block_medians():
+    image = torch.arange(4 * 5, dtype=torch.float).reshape(4, 5)
+    medians = _sample_block_medians(image, 2)
+    assert torch.allclose(
+        medians, torch.tensor([1, 3, 11, 13]).to(image.dtype)
+    )
+
+
+def test_grid_coordinates():
+    image = torch.ones(15, 17)
+    coords = _grid_coordinates(image, 4)
+    assert coords.shape == (3 * 4, 2)
+
+
+def test_fit_2d_polynomial_surface():
+    coords = torch.tensor([[0, 0], [0, 1], [1, 0], [1, 1]], dtype=torch.float)
+    values = torch.tensor([0, 1, 2, 3], dtype=torch.float)
+    surface = _fit_2d_polynomial_surface(coords, values, 1, (2, 2))
+    assert torch.allclose(surface, values.reshape(surface.shape), atol=1e-2)
+
+
+@pytest.mark.parametrize("order", [1, 2, 3])
+@pytest.mark.parametrize(*_DEVICE)
+def test_estimate_background(order, device):
+    image = torch.rand(200, 200).to(device)
+    image[:100, :100] += 1
+    background = estimate_background(image, order=order, block_size=32)
+    assert 2.0 > background[50, 50] > 1.0
+    assert 1.5 > background[0, 100] > 0.5
+    assert 1.0 > background[150, 150] > 0.0

--- a/waveorder/correction.py
+++ b/waveorder/correction.py
@@ -76,17 +76,22 @@ def _fit_2d_polynomial_surface(
 
 def estimate_background(image: Tensor, order: int = 2, block_size: int = 32):
     """
-
-
     Combine sampling and polynomial surface fit for background estimation.
     To background correct an image, divide it by the background.
 
-    :param np.array im:        2D image
-    :param int order:          Order of polynomial (default 2)
-    :param bool normalize:     Normalize surface by dividing by its mean
-                                for background correction (default True)
+    Parameters
+    ----------
+    image : Tensor
+        2D image
+    order : int, optional
+        Order of polynomial, by default 2
+    block_size : int, optional
+        Width and height of the blocks, by default 32
 
-    :return np.array background:    Background image
+    Returns
+    -------
+    Tensor
+        Background image
     """
     if image.ndim != 2:
         raise ValueError(f"Image must be 2D, got shape {image.shape}")

--- a/waveorder/correction.py
+++ b/waveorder/correction.py
@@ -22,6 +22,8 @@ def _sample_block_medians(image: Tensor, block_size) -> Tensor:
     Tensor
         Median intensity values for each block, flattened
     """
+    if not image.dtype.is_floating_point:
+        image.to(torch.float)
     blocks = F.unfold(image[None, None], block_size, stride=block_size)[0]
     return blocks.median(0)[0]
 

--- a/waveorder/correction.py
+++ b/waveorder/correction.py
@@ -1,0 +1,100 @@
+"""Background correction methods"""
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor, Size
+
+
+def _sample_block_medians(image: Tensor, block_size) -> Tensor:
+    """
+    Sample densely tiled square blocks from a 2D image and return their medians.
+    Incomplete blocks (overhangs) will be ignored.
+
+    Parameters
+    ----------
+    image : Tensor
+        2D image
+    block_size : int, optional
+        Width and height of the blocks
+
+    Returns
+    -------
+    Tensor
+        Median intensity values for each block, flattened
+    """
+    blocks = F.unfold(image[None, None], block_size, stride=block_size)[0]
+    return blocks.median(0)[0]
+
+
+def _grid_coordinates(image: Tensor, block_size: int) -> Tensor:
+    """Build image coordinates from the center points of square blocks"""
+    coords = torch.meshgrid(
+        [
+            torch.arange(
+                0 + block_size / 2,
+                boundary - block_size / 2 + 1,
+                block_size,
+                device=image.device,
+            )
+            for boundary in image.shape
+        ]
+    )
+    return torch.stack(coords, dim=-1).reshape(-1, 2)
+
+
+def _fit_2d_polynomial_surface(
+    coords: Tensor, values: Tensor, order: int, surface_shape: Size
+) -> Tensor:
+    """Fit a 2D polynomial to a set of coordinates and their values,
+    and return the surface evaluated at every point."""
+    n_coeffs = int((order + 1) * (order + 2) / 2)
+    if n_coeffs >= len(values):
+        raise ValueError(
+            f"Cannot fit a {order} degree 2D polynomial "
+            f"with {len(values)} sampled values"
+        )
+    orders = torch.arange(order + 1, device=coords.device)
+    order_pairs = torch.stack(torch.meshgrid(orders, orders), -1)
+    order_pairs = order_pairs[order_pairs.sum(-1) <= order].reshape(-1, 2)
+    terms = torch.stack(
+        [coords[:, 0] ** i * coords[:, 1] ** j for i, j in order_pairs], -1
+    )
+    # use "gels" driver for precision and GPU consistency
+    coeffs = torch.linalg.lstsq(terms, values, driver="gels").solution
+    dense_coords = torch.meshgrid(
+        [
+            torch.arange(s, dtype=values.dtype, device=values.device)
+            for s in surface_shape
+        ]
+    )
+    dense_terms = torch.stack(
+        [dense_coords[0] ** i * dense_coords[1] ** j for i, j in order_pairs],
+        -1,
+    )
+    return torch.matmul(dense_terms, coeffs)
+
+
+def estimate_background(image: Tensor, order: int = 2, block_size: int = 32):
+    """
+
+
+    Combine sampling and polynomial surface fit for background estimation.
+    To background correct an image, divide it by the background.
+
+    :param np.array im:        2D image
+    :param int order:          Order of polynomial (default 2)
+    :param bool normalize:     Normalize surface by dividing by its mean
+                                for background correction (default True)
+
+    :return np.array background:    Background image
+    """
+    if image.ndim != 2:
+        raise ValueError(f"Image must be 2D, got shape {image.shape}")
+    height, width = image.shape
+    if block_size > width:
+        raise ValueError("Block size larger than image height")
+    if block_size > height:
+        raise ValueError("Block size larger than image width")
+    medians = _sample_block_medians(image, block_size)
+    coords = _grid_coordinates(image, block_size)
+    return _fit_2d_polynomial_surface(coords, medians, order, image.shape)

--- a/waveorder/models/inplane_oriented_thick_pol3d.py
+++ b/waveorder/models/inplane_oriented_thick_pol3d.py
@@ -133,7 +133,9 @@ def apply_inverse_transfer_function(
             # Estimate the background and subtract
             background_corrected_stokes[
                 stokes_index
-            ] -= correction.estimate_background(z_projection, normalize=False)
+            ] -= correction.estimate_background(
+                z_projection, order=2, block_size=32
+            )
 
     # Project to 2D (typically for SNR reasons)
     if project_stokes_to_2d:

--- a/waveorder/models/inplane_oriented_thick_pol3d.py
+++ b/waveorder/models/inplane_oriented_thick_pol3d.py
@@ -4,7 +4,7 @@ import numpy as np
 import torch
 from torch import Tensor
 
-from waveorder import background_estimator, stokes, util
+from waveorder import correction, stokes, util
 
 
 def generate_test_phantom(yx_shape):
@@ -125,7 +125,6 @@ def apply_inverse_transfer_function(
 
     # Apply an "Estimated" background correction
     if remove_estimated_background:
-        estimator = background_estimator.BackgroundEstimator2D()
         for stokes_index in range(background_corrected_stokes.shape[0]):
             # Project to 2D
             z_projection = torch.mean(
@@ -134,10 +133,7 @@ def apply_inverse_transfer_function(
             # Estimate the background and subtract
             background_corrected_stokes[
                 stokes_index
-            ] -= estimator.get_background(
-                z_projection,
-                normalize=False,
-            )
+            ] -= correction.estimate_background(z_projection, normalize=False)
 
     # Project to 2D (typically for SNR reasons)
     if project_stokes_to_2d:


### PR DESCRIPTION
Introduced a new module `waveorder.correction` to replace the `waveorder.background_estimator`.

- Replaced the pseudo-OOP interface with functional API consistent with the rest of waveorder v2.
- Reduced lines of code for the same functionality from 300 to just 100.
- Enabled torch-based hardware acceleration.
- The new API is used for the `inplane_oriented_thick_pol3d` model. The waverorder reconstructor is still using the old one. Maybe they should both be moved into a `waveorder._deprecated` namespace?

### Consistency

The new method produces the same result:

```python
import matplotlib.pyplot as plt
import torch

from waveorder.background_estimator import BackgroundEstimator2D
from waveorder.correction import estimate_background

# make example image
image = torch.zeros(360, 480)
image[:180, :] += 1
image[:, 120:360] += 1
image += torch.rand_like(image) * 2
plt.imshow(image)
```

![image](https://github.com/mehta-lab/waveorder/assets/67518483/595fb7a4-d2ce-4a1e-a79f-6bdc67af9708)

```python
f, ax = plt.subplots(2, 4, figsize=(12, 6))

for i in range(4):
    new_surface = estimate_background(image, order=i + 1, block_size=32)
    old_surface = BackgroundEstimator2D(block_size=32).get_background(
        image, order=i + 1, normalize=False
    )
    ax[0, i].imshow(new_surface)
    ax[0, i].set_title(f"torch, order={i+1}")
    ax[0, i].axis("off")
    ax[1, i].imshow(old_surface)
    ax[1, i].set_title(f"numpy, order={i+1}")
    ax[1, i].axis("off")

f.tight_layout()
```

![image](https://github.com/mehta-lab/waveorder/assets/67518483/1c8ddb03-b78a-4a33-8fe4-0648cd985f78)

### Speed
Test on a large image:

```python
im = torch.rand(2048, 2048)
np_im = large_image.numpy()
cuda_im = large_image.to("cuda")
```

NumPy (AMD EPYC 7302P CPU):

```python
BackgroundEstimator2D(block_size=32).get_background(np_im, order=2, normalize=False)
# 293 ms ± 844 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

PyTorch implementation sees a 4x speed up on CPU:

```python
estimate_background(im, order=2, block_size=32)
# 68.6 ms ± 4.08 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

An NVIDIA A40 GPU can provide 8x extra acceleration, or 35x faster compared to NumPy:

```python
estimate_background(cuda_im, order=2, block_size=32)
# 8.31 ms ± 110 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```