### PR TITLE
Document order-dependent scripts

### DIFF
--- a/examples/maintenance/PTI_simulation/README.md
+++ b/examples/maintenance/PTI_simulation/README.md
@@ -1,0 +1,4 @@
+Run `PTI_Simulation_Forward_2D3D.py` first to generate example PTI data.
+
+After simulation is complete, run `PTI_Simulation_Recon2D.py` and
+`PTI_Simulation_Recon3D.py` to reconstruct. 


### PR DESCRIPTION
In preparing for a `2.0.0` release, I tried running the reconstruction before the simulation and received a cryptic error. This PR documents the intended order