### PR TITLE
Update a single PTI example notebook

### DIFF
--- a/examples/documentation/PTI_experiment/README.md
+++ b/examples/documentation/PTI_experiment/README.md
@@ -1,2 +1,6 @@
 The notebooks in this folder require data from this source:
 https://www.ebi.ac.uk/biostudies/bioimages/studies/S-BIAD1063
+
+One notebook `PTI_Experiment_Recon3D_anisotropic_target_small.ipynb` will run as is with the latest version of the code and a ~500 MB download from https://www.ebi.ac.uk/biostudies/files/S-BIAD1063/PTI-BIA/Anisotropic_target_small.zip.
+
+The remaining notebooks are not maintained, so they will require a download and an old version of this repository from https://github.com/mehta-lab/waveorder/tree/1.0.0b0.


### PR DESCRIPTION
This PR updates a single example notebook `PTI_Experiment_Recon3D_anisotropic_target_small.ipynb` so that it runs with the latest version of the waveorder. It requires a 500 MB download and a ~15-minute single-CPU reconstruction, so I have not added it to the test suite. Additionally, I have documented that this notebook now runs, while the others serve as dcoumentation. 

This updated notebook gives me high confidence that the results in the remaining notebooks are reproducible in principle, though exact reproduction will more extensive migration + computation. 

Together with the [reconstruction example scripts that are part of our automated test suit here](https://github.com/mehta-lab/waveorder/tree/main/examples/maintenance/PTI_simulation), this example notebook serves as a very good jumping-off point for PTI reconstructions. 