### PR TITLE
fix bug finding focus in stack with only one slice

### DIFF
--- a/tests/test_focus_estimator.py
+++ b/tests/test_focus_estimator.py
@@ -45,6 +45,15 @@ def test_focus_estimator(tmp_path):
     assert slice <= data3D.shape[0]
     assert plot_path.exists()
 
+    # Check single slice
+    slice = focus.focus_from_transverse_band(
+        np.random.random((1, 10, 10)),
+        NA_det,
+        lambda_ill,
+        ps,
+    )
+    assert slice == 0
+
 
 def test_focus_estimator_snr(tmp_path):
     ps = 6.5 / 100

--- a/tests/test_focus_estimator.py
+++ b/tests/test_focus_estimator.py
@@ -39,7 +39,7 @@ def test_focus_estimator(tmp_path):
     plot_path = tmp_path.joinpath("test.pdf")
     data3D = np.random.random((11, 256, 256))
     slice = focus.focus_from_transverse_band(
-        data3D, ps, lambda_ill, NA_det, plot_path=str(plot_path)
+        data3D, NA_det, lambda_ill, ps, plot_path=str(plot_path)
     )
     assert slice >= 0
     assert slice <= data3D.shape[0]
@@ -75,9 +75,9 @@ def test_focus_estimator_snr(tmp_path):
         plot_path = tmp_path / f"test-{snr}.pdf"
         slice = focus.focus_from_transverse_band(
             data,
-            ps,
-            lambda_ill,
             NA_det,
+            lambda_ill,
+            ps,
             plot_path=plot_path,
             threshold_FWHM=5,
         )

--- a/waveorder/focus.py
+++ b/waveorder/focus.py
@@ -104,7 +104,12 @@ def focus_from_transverse_band(
     # Plot
     if plot_path is not None:
         _plot_focus_metric(
-            plot_path, midband_sum, peak_index, in_focus_index, peak_results, threshold_FWHM
+            plot_path,
+            midband_sum,
+            peak_index,
+            in_focus_index,
+            peak_results,
+            threshold_FWHM,
         )
 
     return in_focus_index
@@ -152,7 +157,12 @@ def _check_focus_inputs(
 
 
 def _plot_focus_metric(
-    plot_path, midband_sum, peak_index, in_focus_index, peak_results, threshold_FWHM
+    plot_path,
+    midband_sum,
+    peak_index,
+    in_focus_index,
+    peak_results,
+    threshold_FWHM,
 ):
     _, ax = plt.subplots(1, 1, figsize=(4, 4))
     ax.plot(midband_sum, "-k")

--- a/waveorder/focus.py
+++ b/waveorder/focus.py
@@ -141,7 +141,7 @@ def _check_focus_inputs(
     if pixel_size < 0:
         raise ValueError("pixel_size must be > 0")
     if not 0.4 < lambda_ill / pixel_size < 10:
-        print(
+        warnings.warn(
             f"WARNING: lambda_ill/pixel_size = {lambda_ill/pixel_size}."
             f"Did you use the same units?"
             f"Did you enter the pixel size in (demagnified) object-space units?"

--- a/waveorder/focus.py
+++ b/waveorder/focus.py
@@ -3,6 +3,7 @@ from typing import Literal, Optional
 from waveorder import util
 import matplotlib.pyplot as plt
 import numpy as np
+import warnings
 
 
 def focus_from_transverse_band(
@@ -63,6 +64,8 @@ def focus_from_transverse_band(
     minmaxfunc = _check_focus_inputs(
         zyx_array, NA_det, lambda_ill, pixel_size, midband_fractions, mode
     )
+    if minmaxfunc is None:
+        return 0
 
     # Calculate coordinates
     _, Y, X = zyx_array.shape
@@ -109,10 +112,8 @@ def _check_focus_inputs(
             f"{N}D array supplied. `focus_from_transverse_band` only accepts 3D arrays."
         )
     if zyx_array.shape[0] == 1:
-        print(
-            "WARNING: The dataset only contained a single slice. Returning trivial slice index = 0."
-        )
-        return 0
+        warnings.warn("The dataset only contained a single slice. Returning trivial slice index = 0.")
+        return
 
     if NA_det < 0:
         raise ValueError("NA must be > 0")


### PR DESCRIPTION
Fixing bug related to focus finding in stack with only one slice. `in_focus_index=0` should be returned by `focus_from_transverse_band`, not `_check_focus_inputs`. `_check_focus_inputs` could also be refactored into two functions that 1. check the inputs and 2. determine the correct optimization function. This will remove possible confusion on `_check_focus_inputs` returning a callable.