### PR TITLE
Pin numpy <2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ classifiers = [
   "Operating System :: MacOS",
 ]
 dependencies = [
-  "numpy>=1.21",
+  "numpy>=1.21, <2",
   "matplotlib>=3.1.1",
   "scipy>=1.3.0",
   "pywavelets>=1.1.1",


### PR DESCRIPTION
Right now PyTorch doesn't work with NumPy 2.0 on Windows:
https://github.com/pytorch/pytorch/issues/128860