### PR TITLE
Wrap-safe transfer functions

### DIFF
--- a/waveorder/models/isotropic_fluorescent_thick_3d.py
+++ b/waveorder/models/isotropic_fluorescent_thick_3d.py
@@ -1,9 +1,10 @@
 from typing import Literal
 
+import numpy as np
 import torch
 from torch import Tensor
 
-from waveorder import optics, util
+from waveorder import optics, sampling, util
 
 
 def generate_test_phantom(
@@ -20,6 +21,49 @@ def generate_test_phantom(
 
 
 def calculate_transfer_function(
+    zyx_shape,
+    yx_pixel_size,
+    z_pixel_size,
+    wavelength_emission,
+    z_padding,
+    index_of_refraction_media,
+    numerical_aperture_detection,
+):
+
+    transverse_nyquist = sampling.transverse_nyquist(
+        wavelength_emission,
+        numerical_aperture_detection,  # ill = det for fluorescence
+        numerical_aperture_detection,
+    )
+    axial_nyquist = sampling.axial_nyquist(
+        wavelength_emission,
+        numerical_aperture_detection,
+        index_of_refraction_media,
+    )
+
+    yx_factor = int(np.ceil(yx_pixel_size / transverse_nyquist))
+    z_factor = int(np.ceil(z_pixel_size / axial_nyquist))
+
+    optical_transfer_function = _calculate_wrap_unsafe_transfer_function(
+        (
+            zyx_shape[0] * z_factor,
+            zyx_shape[1] * yx_factor,
+            zyx_shape[2] * yx_factor,
+        ),
+        yx_pixel_size / yx_factor,
+        z_pixel_size / z_factor,
+        wavelength_emission,
+        z_padding,
+        index_of_refraction_media,
+        numerical_aperture_detection,
+    )
+
+    return sampling.nd_fourier_central_cuboid(
+        optical_transfer_function, zyx_shape
+    )
+
+
+def _calculate_wrap_unsafe_transfer_function(
     zyx_shape,
     yx_pixel_size,
     z_pixel_size,
@@ -97,7 +141,7 @@ def apply_transfer_function(
     Returns
     -------
     Simulated data : torch.Tensor
-        
+
     """
     if (
         zyx_object.shape[0] + 2 * z_padding

--- a/waveorder/models/isotropic_fluorescent_thick_3d.py
+++ b/waveorder/models/isotropic_fluorescent_thick_3d.py
@@ -57,9 +57,9 @@ def calculate_transfer_function(
         index_of_refraction_media,
         numerical_aperture_detection,
     )
-
+    zyx_out_shape = (zyx_shape[0] + 2 * z_padding,) + zyx_shape[1:]
     return sampling.nd_fourier_central_cuboid(
-        optical_transfer_function, zyx_shape
+        optical_transfer_function, zyx_out_shape
     )
 
 

--- a/waveorder/models/phase_thick_3d.py
+++ b/waveorder/models/phase_thick_3d.py
@@ -4,7 +4,7 @@ import numpy as np
 import torch
 from torch import Tensor
 
-from waveorder import optics, util
+from waveorder import optics, sampling, util
 from waveorder.models import isotropic_fluorescent_thick_3d
 
 
@@ -31,6 +31,59 @@ def generate_test_phantom(
 
 
 def calculate_transfer_function(
+    zyx_shape,
+    yx_pixel_size,
+    z_pixel_size,
+    wavelength_illumination,
+    z_padding,
+    index_of_refraction_media,
+    numerical_aperture_illumination,
+    numerical_aperture_detection,
+    invert_phase_contrast=False,
+):
+    transverse_nyquist = sampling.transverse_nyquist(
+        wavelength_illumination,
+        numerical_aperture_illumination,
+        numerical_aperture_detection,
+    )
+    axial_nyquist = sampling.axial_nyquist(
+        wavelength_illumination,
+        numerical_aperture_detection,
+        index_of_refraction_media,
+    )
+
+    yx_factor = int(np.ceil(yx_pixel_size / transverse_nyquist))
+    z_factor = int(np.ceil(z_pixel_size / axial_nyquist))
+
+    real_potential_transfer_function, imag_potential_transfer_function = (
+        _calculate_wrap_unsafe_transfer_function(
+            (
+                zyx_shape[0] * z_factor,
+                zyx_shape[1] * yx_factor,
+                zyx_shape[2] * yx_factor,
+            ),
+            yx_pixel_size / yx_factor,
+            z_pixel_size / z_factor,
+            wavelength_illumination,
+            z_padding,
+            index_of_refraction_media,
+            numerical_aperture_illumination,
+            numerical_aperture_detection,
+            invert_phase_contrast=invert_phase_contrast,
+        )
+    )
+
+    return (
+        sampling.nd_fourier_central_cuboid(
+            real_potential_transfer_function, zyx_shape
+        ),
+        sampling.nd_fourier_central_cuboid(
+            imag_potential_transfer_function, zyx_shape
+        ),
+    )
+
+
+def _calculate_wrap_unsafe_transfer_function(
     zyx_shape,
     yx_pixel_size,
     z_pixel_size,

--- a/waveorder/models/phase_thick_3d.py
+++ b/waveorder/models/phase_thick_3d.py
@@ -73,12 +73,13 @@ def calculate_transfer_function(
         )
     )
 
+    zyx_out_shape = (zyx_shape[0] + 2 * z_padding,) + zyx_shape[1:]
     return (
         sampling.nd_fourier_central_cuboid(
-            real_potential_transfer_function, zyx_shape
+            real_potential_transfer_function, zyx_out_shape
         ),
         sampling.nd_fourier_central_cuboid(
-            imag_potential_transfer_function, zyx_shape
+            imag_potential_transfer_function, zyx_out_shape
         ),
     )
 

--- a/waveorder/sampling.py
+++ b/waveorder/sampling.py
@@ -1,0 +1,91 @@
+import numpy as np
+import torch
+
+
+def transverse_nyquist(
+    wavelength_emission,
+    numerical_aperture_illumination,
+    numerical_aperture_detection,
+):
+    """Transverse Nyquist sample spacing in `wavelength_emission` units.
+
+    For widefield label-free imaging, the transverse Nyquist sample spacing is
+    lambda / (2 * (NA_ill + NA_det)).
+
+    Perhaps surprisingly, the transverse Nyquist sample spacing for widefield
+    fluorescence is lambda / (4 * NA), which is equivalent to the above formula
+    when NA_ill = NA_det.
+
+    Parameters
+    ----------
+    wavelength_emission : float
+        Output units match these units
+    numerical_aperture_illumination : float
+        For widefield fluorescence, set to numerical_aperture_detection
+    numerical_aperture_detection : float
+
+    Returns
+    -------
+    float
+        Transverse Nyquist sample spacing
+
+    """
+    return wavelength_emission / (
+        2 * (numerical_aperture_detection + numerical_aperture_illumination)
+    )
+
+
+def axial_nyquist(
+    wavelength_emission,
+    numerical_aperture_detection,
+    index_of_refraction_media,
+):
+    """Axial Nyquist sample spacing in `wavelength_emission` units.
+
+    For widefield microscopes, the axial Nyquist sample spacing is:
+
+    (n/lambda) - sqrt( (n/lambda)^2 - (NA_det/lambda)^2 ).
+
+    Perhaps surprisingly, the axial Nyquist sample spacing is independent of
+    the illumination numerical aperture.
+
+    Parameters
+    ----------
+    wavelength_emission : float
+        Output units match these units
+    numerical_aperture_detection : float
+    index_of_refraction_media: float
+
+    Returns
+    -------
+    float
+        Axial Nyquist sample spacing
+
+    """
+    n_on_lambda = index_of_refraction_media / wavelength_emission
+    return n_on_lambda - np.sqrt(
+        n_on_lambda**2
+        - (numerical_aperture_detection / wavelength_emission) ** 2
+    )
+
+
+def nd_fourier_central_cuboid(source, target_shape):
+    """Central cuboid of an N-D Fourier transform.
+
+    Parameters
+    ----------
+    source : torch.Tensor
+        Source tensor
+    target_shape : tuple of int
+
+    Returns
+    -------
+    torch.Tensor
+        Center cuboid in Fourier space
+
+    """
+    center_slices = tuple(
+        slice((s - o) // 2, (s - o) // 2 + o)
+        for s, o in zip(source.shape, target_shape)
+    )
+    return torch.fft.ifftshift(torch.fft.fftshift(source)[center_slices])

--- a/waveorder/sampling.py
+++ b/waveorder/sampling.py
@@ -42,9 +42,11 @@ def axial_nyquist(
 ):
     """Axial Nyquist sample spacing in `wavelength_emission` units.
 
-    For widefield microscopes, the axial Nyquist sample spacing is:
+    For widefield microscopes, the axial Nyquist cutoff frequency is:
 
-    (n/lambda) - sqrt( (n/lambda)^2 - (NA_det/lambda)^2 ).
+    (n/lambda) - sqrt( (n/lambda)^2 - (NA_det/lambda)^2 ),
+
+    and the axial Nyquist sample spacing is 1 / (2 * cutoff_frequency).
 
     Perhaps surprisingly, the axial Nyquist sample spacing is independent of
     the illumination numerical aperture.
@@ -63,10 +65,11 @@ def axial_nyquist(
 
     """
     n_on_lambda = index_of_refraction_media / wavelength_emission
-    return n_on_lambda - np.sqrt(
+    cutoff_frequency = n_on_lambda - np.sqrt(
         n_on_lambda**2
         - (numerical_aperture_detection / wavelength_emission) ** 2
     )
+    return 1 / (2 * cutoff_frequency)
 
 
 def nd_fourier_central_cuboid(source, target_shape):


### PR DESCRIPTION
Fixes #152. Fixes #172. 

This PR implements wrap-safe transfer functions. After this PR, undersampled data will not create wrapped transfer functions, which should address many of the reconstruction artifacts we've seen. 

Before (e.g. phase transfer function with transverse and axial wrapping):
<img width="994" alt="Screenshot 2024-09-09 at 8 10 36 PM" src="https://github.com/user-attachments/assets/9cf438b6-6573-4e80-95d8-9f87ea772dfd">

After:
<img width="993" alt="Screenshot 2024-09-09 at 8 11 14 PM" src="https://github.com/user-attachments/assets/c65270ad-49c8-4144-96c6-27632adb1c01">

A prerequisite for this PR is a clear set of [transverse and axial Nyquist sampling rates](https://czbiohub.atlassian.net/wiki/spaces/TLG3Infect/pages/3671457799/2024-06-21+what+is+the+axial+Nyquist+sampling+rate). 

This PR redefines the `calculate_transfer_function` call so it should Just Work (™). The old calls have been renamed to `_calculate_wrap_unsafe_transfer_function`. Better naming suggestions are welcome. 

This PR implements these fixes for all of the transfer functions in the main branch: 
- [x] Widefield fluorescence
- [x] 3D phase 
- [x] 2D phase

Similar behavior for vector-optics transfer functions will follow in the `vector-prototype` branch. 

**Testing status** I'm passing automated tests, and I've tested all of the example scripts with undersampled parameters to check for wrapping. @ziw-liu I would appreciate your help with testing on real data because your use cases helped us spot these artifacts. 