### PR TITLE
Bump torch to unpin numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ classifiers = [
   "Operating System :: MacOS",
 ]
 dependencies = [
-  "numpy",
+  "numpy>=1.24",
   "matplotlib>=3.1.1",
   "scipy>=1.3.0",
   "pywavelets>=1.1.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,12 +45,12 @@ classifiers = [
   "Operating System :: MacOS",
 ]
 dependencies = [
-  "numpy>=1.21, <2",
+  "numpy",
   "matplotlib>=3.1.1",
   "scipy>=1.3.0",
   "pywavelets>=1.1.1",
   "ipywidgets>=7.5.1",
-  "torch>=2.2.1",
+  "torch>=2.4.1",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
https://github.com/pytorch/pytorch/issues/128860 has been fixed in torch 2.4.1. The temporary pin in #173 is no longer necessary.

Edit: also bump the numpy requirement as recommended in [SPEC-0](https://scientific-python.org/specs/spec-0000/#2024---quarter-4).