### PR TITLE
Calculate transfer functions on grids smaller than data  

### DIFF
--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -36,10 +36,8 @@ def test_stretched_multiply():
 
     # Test that output dims are correct
     rand_array_3x3x3 = torch.rand((3, 3, 3))
-    rand_array_100x100x100 = torch.rand((99, 99, 99))
-    result = filter.stretched_multiply(
-        rand_array_3x3x3, rand_array_100x100x100
-    )
+    rand_array_99x99x99 = torch.rand((99, 99, 99))
+    result = filter.stretched_multiply(rand_array_3x3x3, rand_array_99x99x99)
     assert result.shape == (99, 99, 99)
 
 

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -4,17 +4,19 @@ import pytest
 
 
 def test_apply_transfer_function_filter():
-    input_array = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
-    transfer_function = torch.tensor([[1, 0], [0, 0]])
-    result = filter.apply_transfer_function_filter(transfer_function, input_array)
-    expected = torch.tensor([[10, 10], [10, 10]])/4
+    input_array = torch.tensor([[[1.0, 2.0], [3.0, 4.0]]])
+    transfer_function_bank = torch.tensor([[[[1, 0], [0, 0]]]])
+    result = filter.apply_filter_bank(transfer_function_bank, input_array)
+    expected = torch.tensor([[[10, 10], [10, 10]]]) / 4
     assert torch.allclose(result, expected)
 
     # Test with incompatible shapes
-    input_array = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
-    transfer_function = torch.tensor([[0.5, 0.5, 0.5], [0.5, 0.5, 0.5]])
+    input_array = torch.tensor([[[1.0, 2.0], [3.0, 4.0]]])
+    transfer_function_bank = torch.tensor(
+        [[[[0.5, 0.5, 0.5], [0.5, 0.5, 0.5]]]]
+    )
     with pytest.raises(ValueError):
-        filter.apply_transfer_function_filter(transfer_function, input_array)
+        filter.apply_filter_bank(transfer_function_bank, input_array)
 
 
 def test_stretched_multiply():

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,0 +1,42 @@
+from waveorder import filter
+import torch
+import pytest
+
+
+def test_stretched_multiply():
+    small_array = torch.tensor([[1, 2], [3, 4]])
+    large_array = torch.tensor(
+        [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]]
+    )
+    result = filter.stretched_multiply(small_array, large_array)
+    expected = torch.tensor(
+        [[1, 2, 6, 8], [5, 6, 14, 16], [27, 30, 44, 48], [39, 42, 60, 64]]
+    )
+    assert torch.all(result == expected)
+    assert torch.all(
+        filter.stretched_multiply(large_array, large_array) == large_array**2
+    )
+
+    # Test that output dims are correct
+    rand_array_3x3x3 = torch.rand((3, 3, 3))
+    rand_array_100x100x100 = torch.rand((100, 100, 100))
+    result = filter.stretched_multiply(
+        rand_array_3x3x3, rand_array_100x100x100
+    )
+    assert result.shape == (100, 100, 100)
+
+
+def test_stretched_multiply_incompatible_dims():
+    # small_array > large_array
+    small_array = torch.tensor([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    large_array = torch.tensor([[1, 2], [3, 4]])
+    with pytest.raises(ValueError):
+        filter.stretched_multiply(small_array, large_array)
+
+    # Mismatched dims
+    small_array = torch.tensor([[1, 2], [3, 4]])
+    large_array = torch.tensor(
+        [[[1, 2], [4, 5], [7, 8]], [[10, 11], [13, 14], [16, 17]]]
+    )
+    with pytest.raises(ValueError):
+        filter.stretched_multiply(small_array, large_array)

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,6 +1,7 @@
-from waveorder import filter
-import torch
 import pytest
+import torch
+
+from waveorder import filter
 
 
 def test_apply_transfer_function_filter():

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -3,6 +3,20 @@ import torch
 import pytest
 
 
+def test_apply_transfer_function_filter():
+    input_array = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    transfer_function = torch.tensor([[1, 0], [0, 0]])
+    result = filter.apply_transfer_function_filter(transfer_function, input_array)
+    expected = torch.tensor([[10, 10], [10, 10]])/4
+    assert torch.allclose(result, expected)
+
+    # Test with incompatible shapes
+    input_array = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    transfer_function = torch.tensor([[0.5, 0.5, 0.5], [0.5, 0.5, 0.5]])
+    with pytest.raises(ValueError):
+        filter.apply_transfer_function_filter(transfer_function, input_array)
+
+
 def test_stretched_multiply():
     small_array = torch.tensor([[1, 2], [3, 4]])
     large_array = torch.tensor(

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -33,11 +33,11 @@ def test_stretched_multiply():
 
     # Test that output dims are correct
     rand_array_3x3x3 = torch.rand((3, 3, 3))
-    rand_array_100x100x100 = torch.rand((100, 100, 100))
+    rand_array_100x100x100 = torch.rand((99, 99, 99))
     result = filter.stretched_multiply(
         rand_array_3x3x3, rand_array_100x100x100
     )
-    assert result.shape == (100, 100, 100)
+    assert result.shape == (99, 99, 99)
 
 
 def test_stretched_multiply_incompatible_dims():

--- a/waveorder/filter.py
+++ b/waveorder/filter.py
@@ -33,6 +33,18 @@ def apply_transfer_function_filter(
     torch.Tensor
         The filtered output array with the same shape and dtype as input_array.
     """
+    # Ensure all dimensions of transfer_function are smaller than or equal to input_array
+    if any(t > i for t, i in zip(transfer_function.shape, input_array.shape)):
+        raise ValueError(
+            "All dimensions of transfer_function must be <= input_array"
+        )
+
+    # Ensure the number of dimensions match
+    if transfer_function.ndim != input_array.ndim:
+        raise ValueError(
+            "transfer_function and input_array must have the same number of dimensions"
+        )
+
     input_spectrum = torch.fft.fftn(input_array)
     output_spectrum = stretched_multiply(transfer_function, input_spectrum)
     return torch.fft.ifftn(output_spectrum).type(input_array.dtype)

--- a/waveorder/filter.py
+++ b/waveorder/filter.py
@@ -30,7 +30,7 @@ def apply_filter_bank(
         sample spacing of i_input_array.
 
         Leading dimensions are the input and output dimensions.
-        io_filter_bank.shape[:2] == (i, o)
+        io_filter_bank.shape[:2] == (num_input_channels, num_output_channels)
 
         Trailing dimensions are spatial frequency dimensions.
         io_filter_bank.shape[2:] == (Z', Y', X') or (Y', X')
@@ -44,12 +44,12 @@ def apply_filter_bank(
         Trailing dimensions are spatial dimensions.
         i_input_array.shape[1:] == (Z, Y, X) or (Y, X)
 
-        dtype can be real or complex, and result will match.
-
     Returns
     -------
     torch.Tensor
-        The filtered output array with the same shape and dtype as input_array.
+        The filtered real-valued output array with shape
+        (num_output_channels, Z, Y, X) or (num_output_channels, Y, X).
+
     """
 
     # Ensure all dimensions of transfer_function are smaller than or equal to input_array
@@ -105,9 +105,9 @@ def apply_filter_bank(
                 padded_input_spectrum[input_channel_idx],
             )
 
-    # Casts to input_array dtype, which typically ignores imaginary part
-    padded_result = torch.fft.ifftn(padded_output_spectrum, dim=fft_dims).type(
-        i_input_array.dtype
+    # Cast to real, ignoring imaginary part
+    padded_result = torch.real(
+        torch.fft.ifftn(padded_output_spectrum, dim=fft_dims)
     )
 
     # Remove padding and return

--- a/waveorder/filter.py
+++ b/waveorder/filter.py
@@ -3,72 +3,109 @@ import numpy as np
 import torch
 
 
-def apply_transfer_function_filter(
-    transfer_function: torch.Tensor,
-    input_array: torch.Tensor,
+def apply_filter_bank(
+    io_filter_bank: torch.Tensor,
+    i_input_array: torch.Tensor,
 ) -> torch.Tensor:
     """
-    Applies a transfer function filter to an input array.
+    Applies a filter bank to an input array.
 
-    transfer_function.shape must be smaller or equal to input_array.shape in all
-    dimensions. When transfer_function is smaller, it is effectively "stretched"
+    io_filter_bank.shape must be smaller or equal to i_input_array.shape in all
+    dimensions. When io_filter_bank is smaller, it is effectively "stretched"
     to apply the filter.
 
-    transfer_function is in "wrapped" format, i.e., the zero frequency is the
+    io_filter_bank is in "wrapped" format, i.e., the zero frequency is the
     zeroth element.
 
-    input_array and transfer_function must have inverse sample spacing, i.e.,
-    is input_array contains samples spaced by dx, then transfer_function must
-    have extent 1/dx. Note that there is no need for transfer_function to have
-    sample spacing 1/(n*dx) because transfer_function will be stretched.
+    i_input_array and io_filter_bank must have inverse sample spacing, i.e.,
+    is input_array contains samples spaced by dx, then io_filter_bank must
+    have extent 1/dx. Note that there is no need for io_filter_bank to have
+    sample spacing 1/(n*dx) because io_filter_bank will be stretched.
 
     Parameters
     ----------
-    transfer_function : torch.Tensor
-        The transfer function to be applied in the frequency domain.
-        Extent of transfer_function must be 1/dx, where dx is the sample spacing
-        of input_array.
-    input_array : torch.Tensor
-        The input array to be filtered.
+    io_filter_bank : torch.Tensor
+        The filter bank to be applied in the frequency domain.
+        The spatial extent of io_filter_bank must be 1/dx, where dx is the
+        sample spacing of i_input_array.
+
+        Leading dimensions are the input and output dimensions.
+        io_filter_bank.shape[:2] == (i, o)
+
+        Trailing dimensions are spatial frequency dimensions.
+        io_filter_bank.shape[2:] == (Z', Y', X') or (Y', X')
+
+    i_input_array : torch.Tensor
+        The input array with sample spacing dx to be filtered.
+
+        Leading dimension is the input dimension, matching the filter bank.
+        i_input_array.shape[0] == i
+
+        Trailing dimensions are spatial dimensions.
+        i_input_array.shape[1:] == (Z, Y, X) or (Y, X)
 
     Returns
     -------
     torch.Tensor
         The filtered output array with the same shape and dtype as input_array.
     """
+    
     # Ensure all dimensions of transfer_function are smaller than or equal to input_array
-    if any(t > i for t, i in zip(transfer_function.shape, input_array.shape)):
+    if any(
+        t > i
+        for t, i in zip(io_filter_bank.shape[2:], i_input_array.shape[1:])
+    ):
         raise ValueError(
-            "All dimensions of transfer_function must be <= input_array"
+            "All spatial dimensions of io_filter_bank must be <= i_input_array."
         )
 
-    # Ensure the number of dimensions match
-    if transfer_function.ndim != input_array.ndim:
+    # Ensure the number of spatial dimensions match
+    if io_filter_bank.ndim - i_input_array.ndim != 1:
         raise ValueError(
-            "transfer_function and input_array must have the same number of dimensions"
+            "io_filter_bank and i_input_array must have the same number of spatial dimensions."
         )
+
+    # Ensure the input dimensions match
+    if io_filter_bank.shape[0] != i_input_array.shape[0]:
+        raise ValueError(
+            "io_filter_bank.shape[0] and i_input_array.shape[0] must be the same."
+        )
+
+    I, O = io_filter_bank.shape[:2]
+    spatial_dims = io_filter_bank.shape[2:]
 
     # Pad input_array until each dimension is divisible by transfer_function
     pad_sizes = [
         (0, (t - (i % t)) % t)
-        for t, i in zip(transfer_function.shape[::-1], input_array.shape[::-1])
+        for t, i in zip(
+            io_filter_bank.shape[2:][::-1], i_input_array.shape[1:][::-1]
+        )
     ]
     flat_pad_sizes = list(itertools.chain(*pad_sizes))
-    padded_input_array = torch.nn.functional.pad(input_array, flat_pad_sizes)
-
+    padded_input_array = torch.nn.functional.pad(i_input_array, flat_pad_sizes)
+    
     # Apply the transfer function in the frequency domain
-    padded_input_spectrum = torch.fft.fftn(padded_input_array)
-    padded_output_spectrum = stretched_multiply(
-        transfer_function, padded_input_spectrum
-    )
+    fft_dims = [d for d in range(1, i_input_array.ndim)]
+    padded_input_spectrum = torch.fft.fftn(padded_input_array, dim=fft_dims)
+
+    # Matrix-vector multiplication over f
+    # If this is a bottleneck, consider extending `stretched_multiply` to
+    # a `stretched_matrix_multiply` that uses an call like
+    # torch.einsum('io..., i... -> o...', io_filter_bank, padded_input_spectrum)
+    padded_output_spectrum = torch.zeros((O,) + spatial_dims, dtype=padded_input_spectrum.dtype)
+    for i_idx in range(I):
+        for o_idx in range(O):
+            padded_output_spectrum[o_idx] += stretched_multiply(
+                io_filter_bank[i_idx, o_idx], padded_input_spectrum[i_idx]
+            )
 
     # Casts to input_array dtype, which typically ignores imaginary part
-    padded_result = torch.fft.ifftn(padded_output_spectrum).type(
-        input_array.dtype
+    padded_result = torch.fft.ifftn(padded_output_spectrum, dim=fft_dims).type(
+        i_input_array.dtype
     )
 
     # Remove padding and return
-    slices = tuple(slice(0, i) for i in input_array.shape)
+    slices = tuple(slice(0, i) for i in i_input_array.shape)
     return padded_result[slices]
 
 

--- a/waveorder/filter.py
+++ b/waveorder/filter.py
@@ -1,5 +1,5 @@
 import itertools
-import numpy as np
+
 import torch
 
 
@@ -49,7 +49,7 @@ def apply_filter_bank(
     torch.Tensor
         The filtered output array with the same shape and dtype as input_array.
     """
-    
+
     # Ensure all dimensions of transfer_function are smaller than or equal to input_array
     if any(
         t > i
@@ -83,7 +83,7 @@ def apply_filter_bank(
     ]
     flat_pad_sizes = list(itertools.chain(*pad_sizes))
     padded_input_array = torch.nn.functional.pad(i_input_array, flat_pad_sizes)
-    
+
     # Apply the transfer function in the frequency domain
     fft_dims = [d for d in range(1, i_input_array.ndim)]
     padded_input_spectrum = torch.fft.fftn(padded_input_array, dim=fft_dims)
@@ -92,7 +92,9 @@ def apply_filter_bank(
     # If this is a bottleneck, consider extending `stretched_multiply` to
     # a `stretched_matrix_multiply` that uses an call like
     # torch.einsum('io..., i... -> o...', io_filter_bank, padded_input_spectrum)
-    padded_output_spectrum = torch.zeros((O,) + spatial_dims, dtype=padded_input_spectrum.dtype)
+    padded_output_spectrum = torch.zeros(
+        (O,) + spatial_dims, dtype=padded_input_spectrum.dtype
+    )
     for i_idx in range(I):
         for o_idx in range(O):
             padded_output_spectrum[o_idx] += stretched_multiply(

--- a/waveorder/filter.py
+++ b/waveorder/filter.py
@@ -36,7 +36,7 @@ def apply_filter_bank(
         io_filter_bank.shape[2:] == (Z', Y', X') or (Y', X')
 
     i_input_array : torch.Tensor
-        The input array with sample spacing dx to be filtered.
+        The real-valued input array with sample spacing dx to be filtered.
 
         Leading dimension is the input dimension, matching the filter bank.
         i_input_array.shape[0] == i

--- a/waveorder/filter.py
+++ b/waveorder/filter.py
@@ -97,6 +97,7 @@ def apply_filter_bank(
     padded_output_spectrum = torch.zeros(
         (num_output_channels,) + spatial_dims,
         dtype=padded_input_spectrum.dtype,
+        device=padded_input_spectrum.device,
     )
     for input_channel_idx in range(num_input_channels):
         for output_channel_idx in range(num_output_channels):

--- a/waveorder/filter.py
+++ b/waveorder/filter.py
@@ -47,7 +47,11 @@ def apply_transfer_function_filter(
 
     input_spectrum = torch.fft.fftn(input_array)
     output_spectrum = stretched_multiply(transfer_function, input_spectrum)
-    return torch.fft.ifftn(output_spectrum).type(input_array.dtype)
+
+    # Casts to input_array dtype, which typically ignores imaginary part
+    result = torch.fft.ifftn(output_spectrum).type(input_array.dtype)
+
+    return result
 
 def stretched_multiply(
     small_array: torch.Tensor, large_array: torch.Tensor

--- a/waveorder/filter.py
+++ b/waveorder/filter.py
@@ -1,0 +1,103 @@
+import numpy as np
+import torch
+
+
+def stretched_multiply(
+    small_array: torch.Tensor, large_array: torch.Tensor
+) -> torch.Tensor:
+    """
+    Effectively "stretches" small_array onto large_array before multiplying.
+
+    Instead of upsampling small_array, this function uses a "block element-wise"
+    multiplication by breaking the large_array into blocks before
+    element-wise multiplication with the small_array.
+
+    For example, a `stretched_multiply` of a 3x3 array by a 100x100 array will
+    break the 100x100 array into 3x3 blocks, with sizes
+    [[34x34, 33x34, 33x33],
+     [34x33, 33x33, 33x33],
+     [34x33, 33x33, 33x33]]
+    and multiply each block by the corresponding element in the 3x3 array.
+
+    Returns an array with the same shape as large_array.
+
+    Works for arbitrary dimensions.
+
+    Parameters
+    ----------
+    small_array : torch.Tensor
+        A smaller array whose elements will be "stretched" onto blocks in the large array.
+    large_array : torch.Tensor
+        A larger array that will be divided into blocks and multiplied by the small array.
+
+    Returns
+    -------
+    torch.Tensor
+        Resulting tensor with shape matching large_array.
+
+    Example
+    -------
+    small_array = torch.tensor([[1, 2],
+                                [3, 4]])
+
+    large_array = torch.tensor([[1,   2,  3,  4],
+                                [5,   6,  7,  8],
+                                [9,  10, 11, 12],
+                                [13, 14, 15, 16]])
+
+    stretched_multiply(small_array, large_array) returns
+
+    [[  1,  2,  6,  8],
+     [  5,  6, 14, 16],
+     [ 27, 30, 44, 48],
+     [ 39, 42, 60, 64]]
+    """
+    # Ensure all dimensions of small_array are smaller than large_array
+    if any(s > l for s, l in zip(small_array.shape, large_array.shape)):
+        raise ValueError(
+            "All dimensions of small_array must be <=  large_array"
+        )
+
+    # Ensure the number of dimensions match
+    if small_array.ndim != large_array.ndim:
+        raise ValueError(
+            "small_array and large_array must have the same number of dimensions"
+        )
+
+    # Get shapes
+    s_shape = small_array.shape
+    l_shape = large_array.shape
+
+    # Compute base block sizes using integer division
+    # This gives the approximate size of each block before handling remainders
+    base_block_size = tuple(l // s for l, s in zip(l_shape, s_shape))
+
+    # Compute remainder (extra elements that don't fit evenly)
+    remainder = tuple(l % s for l, s in zip(l_shape, s_shape))
+
+    # Compute block boundaries by spreading remainder elements evenly
+    indices = []
+    for b, s, r in zip(base_block_size, s_shape, remainder):
+        # Create an array where the first 'r' blocks get an extra +1
+        # Example: if b=9, s=11, r=1 -> first remainder block gets size 10 instead of 9
+        block_sizes = [(b + 1) if i < r else b for i in range(s)]
+
+        # Compute cumulative sum to determine start and end indices
+        # Example: [0, 10, 19, 28, ..., 100] gives the split points
+        indices.append(np.cumsum([0] + block_sizes))
+
+    # Create output array initialized as a copy of the large array
+    result = large_array.clone()
+
+    # Iterate over small_array indices using ndindex
+    for idx in np.ndindex(s_shape):
+        # Extract multi-dimensional indices
+        slices = tuple(
+            slice(indices[dim][idx[dim]], indices[dim][idx[dim] + 1])
+            for dim in range(small_array.ndim)
+        )
+
+        # Multiply the corresponding block in the large array by the value from the small array
+        result[slices] *= small_array[idx]
+
+    return result

--- a/waveorder/filter.py
+++ b/waveorder/filter.py
@@ -94,6 +94,9 @@ def apply_filter_bank(
     # If this is a bottleneck, consider extending `stretched_multiply` to
     # a `stretched_matrix_multiply` that uses an call like
     # torch.einsum('io..., i... -> o...', io_filter_bank, padded_input_spectrum)
+    #
+    # Further optimization is likely with a combination of
+    # torch.baddbmm, torch.pixel_shuffle, torch.pixel_unshuffle.
     padded_output_spectrum = torch.zeros(
         (num_output_channels,) + spatial_dims,
         dtype=padded_input_spectrum.dtype,

--- a/waveorder/models/isotropic_fluorescent_thick_3d.py
+++ b/waveorder/models/isotropic_fluorescent_thick_3d.py
@@ -6,7 +6,7 @@ from torch import Tensor
 
 from waveorder import optics, sampling, util
 from waveorder.visuals.napari_visuals import add_transfer_function_to_viewer
-from waveorder.filter import apply_transfer_function_filter
+from waveorder.filter import apply_filter_bank
 from waveorder.reconstruct import tikhonov_regularized_inverse_filter
 
 
@@ -217,7 +217,7 @@ def apply_inverse_transfer_function(
         inverse_filter = tikhonov_regularized_inverse_filter(
             optical_transfer_function, regularization_strength
         )
-        f_real = apply_transfer_function_filter(inverse_filter, zyx_padded)
+        f_real = apply_filter_bank(inverse_filter, zyx_padded)
     elif reconstruction_algorithm == "TV":
         raise NotImplementedError
         f_real = util.single_variable_admm_tv_deconvolution_3D(

--- a/waveorder/models/isotropic_fluorescent_thick_3d.py
+++ b/waveorder/models/isotropic_fluorescent_thick_3d.py
@@ -217,7 +217,10 @@ def apply_inverse_transfer_function(
         inverse_filter = tikhonov_regularized_inverse_filter(
             optical_transfer_function, regularization_strength
         )
-        f_real = apply_filter_bank(inverse_filter, zyx_padded)
+        
+        # [None]s and [0] are for applying a 1x1 "bank" of filters.
+        # For further uniformity, consider returning (1, Z, Y, X)
+        f_real = apply_filter_bank(inverse_filter[None, None], zyx_padded[None])[0]
     elif reconstruction_algorithm == "TV":
         raise NotImplementedError
         f_real = util.single_variable_admm_tv_deconvolution_3D(

--- a/waveorder/models/isotropic_thin_3d.py
+++ b/waveorder/models/isotropic_thin_3d.py
@@ -288,6 +288,7 @@ def apply_inverse_transfer_function(
     zyx_data_hat = torch.fft.fft2(zyx_data_normalized, dim=(1, 2))
 
     # TODO AHA and b_vec calculations should be moved into tikhonov/tv calculations
+    # TODO Reformulate to use filter.apply_filter_bank
     AHA = [
         torch.sum(torch.abs(absorption_2d_to_3d_transfer_function) ** 2, dim=0)
         + regularization_strength,

--- a/waveorder/models/phase_thick_3d.py
+++ b/waveorder/models/phase_thick_3d.py
@@ -257,7 +257,10 @@ def apply_inverse_transfer_function(
         inverse_filter = tikhonov_regularized_inverse_filter(
             effective_transfer_function, regularization_strength
         )
-        f_real = apply_filter_bank(inverse_filter, zyx)
+
+        # [None]s and [0] are for applying a 1x1 "bank" of filters.
+        # For further uniformity, consider returning (1, Z, Y, X)
+        f_real = apply_filter_bank(inverse_filter[None, None], zyx[None])[0]
 
     elif reconstruction_algorithm == "TV":
         raise NotImplementedError

--- a/waveorder/models/phase_thick_3d.py
+++ b/waveorder/models/phase_thick_3d.py
@@ -8,6 +8,7 @@ from waveorder import optics, sampling, util
 from waveorder.models import isotropic_fluorescent_thick_3d
 from waveorder.visuals.napari_visuals import add_transfer_function_to_viewer
 from waveorder.filter import apply_transfer_function_filter
+from waveorder.reconstruct import tikhonov_regularized_inverse_filter
 
 
 def generate_test_phantom(
@@ -253,11 +254,8 @@ def apply_inverse_transfer_function(
 
     # Reconstruct
     if reconstruction_algorithm == "Tikhonov":
-        H_eff = effective_transfer_function
-        H_eff_conj = torch.conj(H_eff)
-        inverse_tf = H_eff_conj / ((H_eff_conj * H_eff) + regularization_strength)
-        
-        f_real = apply_transfer_function_filter(inverse_tf, zyx)
+        inverse_filter = tikhonov_regularized_inverse_filter(effective_transfer_function, regularization_strength)        
+        f_real = apply_transfer_function_filter(inverse_filter, zyx)
 
     elif reconstruction_algorithm == "TV":
         raise NotImplementedError

--- a/waveorder/models/phase_thick_3d.py
+++ b/waveorder/models/phase_thick_3d.py
@@ -7,7 +7,7 @@ from torch import Tensor
 from waveorder import optics, sampling, util
 from waveorder.models import isotropic_fluorescent_thick_3d
 from waveorder.visuals.napari_visuals import add_transfer_function_to_viewer
-from waveorder.filter import apply_transfer_function_filter
+from waveorder.filter import apply_filter_bank
 from waveorder.reconstruct import tikhonov_regularized_inverse_filter
 
 
@@ -254,8 +254,10 @@ def apply_inverse_transfer_function(
 
     # Reconstruct
     if reconstruction_algorithm == "Tikhonov":
-        inverse_filter = tikhonov_regularized_inverse_filter(effective_transfer_function, regularization_strength)        
-        f_real = apply_transfer_function_filter(inverse_filter, zyx)
+        inverse_filter = tikhonov_regularized_inverse_filter(
+            effective_transfer_function, regularization_strength
+        )
+        f_real = apply_filter_bank(inverse_filter, zyx)
 
     elif reconstruction_algorithm == "TV":
         raise NotImplementedError

--- a/waveorder/reconstruct.py
+++ b/waveorder/reconstruct.py
@@ -1,0 +1,28 @@
+import torch
+
+
+def tikhonov_regularized_inverse_filter(
+    forward_filter: torch.Tensor, regularization_strength: float
+):
+    """Compute the Tikhonov regularized inverse filter from a forward filter.
+
+    Parameters
+    ----------
+    forward_filter : torch.Tensor
+        The forward filter tensor.
+    regularization_strength : float
+        The strength of the regularization term.
+    Returns
+    -------
+    torch.Tensor
+        The Tikhonov regularized inverse filter.
+    """
+
+    if forward_filter.ndim == 3:
+        forward_filter_conj = torch.conj(forward_filter)
+        return forward_filter_conj / (
+            (forward_filter_conj * forward_filter) + regularization_strength
+        )
+    else:
+        # TC TODO INTEGRATE THE 5D FILTER BANK CASE
+        raise NotImplementedError("Only 3D tensors are supported.")


### PR DESCRIPTION
This PR allows transfer functions to be calculated on smaller grids then applied to larger grids.  

This PR uses a `stretched_multiply` strategy for efficient application of a small OTF to a large dataset. This approach approximates the OTF as a piece-wise constant function, and applies this smaller array to datasets without upsampling. This approach allows us to reduce OTF memory requirements by as much as needed, trading OTF computational expense and OTF memory for accuracy.

To uniformly apply this strategy, I have implemented a new function `filter.apply_filter_bank`, which handles these the prepadding, stretched multiplications, matrix-vector bank multiplications, and unpadding. 

These three reconstructions now use a precomputed inverse filter bank and use the new shared `filter.apply_filter_bank`. 
- [x] isotropic_thick_3d
- [x] isotropic_fluorescent_thick_3d
- [x] inplane_oriented_thick_pol3d_vector 