### PR TITLE
bug in monitor

### DIFF
--- a/waveorder/cli/monitor.py
+++ b/waveorder/cli/monitor.py
@@ -117,7 +117,7 @@ def monitor_jobs(
 
     # print all jobs once if terminal is too small
     if shutil.get_terminal_size().lines - NON_JOB_LINES < len(jobs):
-        _print_status(jobs, position_dirpaths, elapsed_list, do_print)
+        _print_status(jobs, position_dirpaths, elapsed_list, do_print=do_print)
 
     # main monitor loop
     try:


### PR DESCRIPTION
bug in monitor, where do_print is passed as a positional rather than a keyword arg, was causing print_indices to contain the wrong variable