### PR TITLE
demos for AQLM 2025

### DIFF
--- a/docs/examples/demos/QLIPP/QLIPP_simulation.ipynb
+++ b/docs/examples/demos/QLIPP/QLIPP_simulation.ipynb
@@ -1,0 +1,425 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "1b6996b0",
+   "metadata": {
+    "cell_marker": "\"\"\""
+   },
+   "source": [
+    "# 2D QLIPP Simulation and Reconstruction Demo\n",
+    "\n",
+    "This notebook demonstrates forward simulation and reconstruction for Quantitative Label-free Imaging with Phase and Polarization (QLIPP).\n",
+    "The simulation and reconstruction are based on the QLIPP paper ([here](https://elifesciences.org/articles/55502)):\n",
+    "\n",
+    "S.-M. Guo, L.-H. Yeh, J. Folkesson, I. E. Ivanov, A. P. Krishnan, M. G. Keefe, E. Hashemi,\n",
+    "D. Shin, B. B. Chhun, N. H. Cho, M. D. Leonetti, M. H. Han, T. J. Nowakowski, S. B. Mehta,\n",
+    "\"Revealing architectural order with quantitative label-free imaging and deep learning,\"\n",
+    "eLife 9:e55502 (2020)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f0aba1ee",
+   "metadata": {
+    "cell_marker": "\"\"\""
+   },
+   "source": [
+    "## Setup and Imports\n",
+    "First, let's install the latest version of waveorder from the main branch"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6218d6b2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "import subprocess\n",
+    "\n",
+    "# Install latest waveorder from main branch\n",
+    "subprocess.check_call(\n",
+    "    [\n",
+    "        sys.executable,\n",
+    "        \"-m\",\n",
+    "        \"pip\",\n",
+    "        \"install\",\n",
+    "        \"git+https://github.com/mehta-lab/waveorder.git@main\",\n",
+    "    ]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f5f5e091",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "from numpy.fft import fftshift\n",
+    "from platformdirs import user_data_dir\n",
+    "\n",
+    "from waveorder import optics, util, waveorder_simulator\n",
+    "from waveorder.visuals import jupyter_visuals"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "32850c70",
+   "metadata": {
+    "cell_marker": "\"\"\""
+   },
+   "source": [
+    "## Forward Simulation\n",
+    "Here we simulate QLIPP measurements of a Siemens star pattern with uniform phase, uniform retardance, and radial orientation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a63e5541",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Key parameters\n",
+    "N = 256  # number of pixel in y dimension\n",
+    "M = 256  # number of pixel in x dimension\n",
+    "mag = 40  # magnification\n",
+    "ps = 6.5 / mag  # effective pixel size\n",
+    "lambda_illu = 0.532  # wavelength\n",
+    "n_media = 1  # refractive index in the media\n",
+    "NA_obj = 0.55  # objective NA\n",
+    "NA_illu = 0.4  # illumination NA (condenser)\n",
+    "NA_illu_in = 0.4  # illumination NA (phase contrast inner ring)\n",
+    "z_defocus = (np.r_[:5] - 2) * 1.757  # a set of defocus plane\n",
+    "chi = 0.03 * 2 * np.pi  # swing of Polscope analyzer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "875bd8a7",
+   "metadata": {
+    "cell_marker": "\"\"\""
+   },
+   "source": [
+    "### Generate Sample: Siemens Star Pattern"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8c00af74",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Sample : star with uniform phase, uniform retardance, and radial orientation\n",
+    "star, theta, _ = util.generate_star_target((N, M))\n",
+    "star = star.numpy()\n",
+    "theta = theta.numpy()\n",
+    "jupyter_visuals.plot_multicolumn(np.array([star, theta]), num_col=2, size=5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b027a316",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Assign uniform phase, uniform retardance, and radial slow axes to the star pattern\n",
+    "phase_value = 1  # average phase in radians (optical path length)\n",
+    "phi_s = star * (phase_value + 0.15)  # slower OPL across target\n",
+    "phi_f = star * (phase_value - 0.15)  # faster OPL across target\n",
+    "mu_s = np.zeros((N, M))  # absorption\n",
+    "mu_f = mu_s.copy()\n",
+    "t_eigen = np.zeros((2, N, M), complex)  # complex specimen transmission\n",
+    "t_eigen[0] = np.exp(-mu_s + 1j * phi_s)\n",
+    "t_eigen[1] = np.exp(-mu_f + 1j * phi_f)\n",
+    "sa = theta % np.pi  # slow axes.\n",
+    "\n",
+    "jupyter_visuals.plot_multicolumn(\n",
+    "    np.array([phi_s, phi_f, mu_s, sa]),\n",
+    "    num_col=2,\n",
+    "    size=5,\n",
+    "    set_title=True,\n",
+    "    titles=[\"Phase (slow)\", \"Phase (fast)\", \"absorption\", \"slow axis\"],\n",
+    "    origin=\"lower\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b872e446",
+   "metadata": {
+    "cell_marker": "\"\"\""
+   },
+   "source": [
+    "### Forward Model Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dcd634a8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Source pupil\n",
+    "# Subsample source pattern for speed\n",
+    "xx, yy, fxx, fyy = util.gen_coordinate((N, M), ps)\n",
+    "radial_frequencies = np.sqrt(fxx**2 + fyy**2)\n",
+    "Source_cont = optics.generate_pupil(\n",
+    "    radial_frequencies, NA_illu, lambda_illu\n",
+    ").numpy()\n",
+    "Source_discrete = optics.Source_subsample(\n",
+    "    Source_cont, lambda_illu * fxx, lambda_illu * fyy, subsampled_NA=0.1\n",
+    ")\n",
+    "plt.figure(figsize=(10, 10))\n",
+    "plt.imshow(fftshift(Source_discrete), cmap=\"gray\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4d7e68da",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Initialize microscope simulator\n",
+    "simulator = waveorder_simulator.waveorder_microscopy_simulator(\n",
+    "    (N, M),\n",
+    "    lambda_illu,\n",
+    "    ps,\n",
+    "    NA_obj,\n",
+    "    NA_illu,\n",
+    "    z_defocus,\n",
+    "    chi,\n",
+    "    n_media=n_media,\n",
+    "    illu_mode=\"Arbitrary\",\n",
+    "    Source=Source_discrete,\n",
+    ")\n",
+    "\n",
+    "# Compute image volumes and Stokes volumes\n",
+    "I_meas, Stokes_out = simulator.simulate_waveorder_measurements(\n",
+    "    t_eigen, sa, multiprocess=False\n",
+    ")\n",
+    "\n",
+    "# Add noise to the measurement\n",
+    "photon_count = 14000\n",
+    "ext_ratio = 10000\n",
+    "const_bg = photon_count / (0.5 * (1 - np.cos(chi))) / ext_ratio\n",
+    "I_meas_noise = (\n",
+    "    np.random.poisson(I_meas / np.max(I_meas) * photon_count + const_bg)\n",
+    ").astype(\"float64\")\n",
+    "\n",
+    "# Save simulation\n",
+    "temp_dirpath = Path(user_data_dir(\"QLIPP_simulation\"))\n",
+    "temp_dirpath.mkdir(parents=True, exist_ok=True)\n",
+    "output_file = temp_dirpath / \"2D_QLIPP_simulation.npz\"\n",
+    "np.savez(\n",
+    "    output_file,\n",
+    "    I_meas=I_meas_noise,\n",
+    "    Stokes_out=Stokes_out,\n",
+    "    lambda_illu=lambda_illu,\n",
+    "    n_media=n_media,\n",
+    "    NA_obj=NA_obj,\n",
+    "    NA_illu=NA_illu,\n",
+    "    ps=ps,\n",
+    "    Source_cont=Source_cont,\n",
+    "    z_defocus=z_defocus,\n",
+    "    chi=chi,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e11f2336",
+   "metadata": {
+    "cell_marker": "\"\"\""
+   },
+   "source": [
+    "## Reconstruction\n",
+    "Now we'll reconstruct the simulated data to recover the sample properties."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ac9963b7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from waveorder import waveorder_reconstructor\n",
+    "\n",
+    "# Load simulated data\n",
+    "array_loaded = np.load(output_file)\n",
+    "list_of_array_names = sorted(array_loaded)\n",
+    "\n",
+    "for array_name in list_of_array_names:\n",
+    "    globals()[array_name] = array_loaded[array_name]\n",
+    "\n",
+    "print(\"Loaded arrays:\", list_of_array_names)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2f26d28e",
+   "metadata": {
+    "cell_marker": "\"\"\""
+   },
+   "source": [
+    "### Initial Reconstruction of Stokes Parameters and Anisotropy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4700565f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_, N, M, L = I_meas.shape\n",
+    "cali = False\n",
+    "bg_option = \"global\"\n",
+    "\n",
+    "setup = waveorder_reconstructor.waveorder_microscopy(\n",
+    "    (N, M),\n",
+    "    lambda_illu,\n",
+    "    ps,\n",
+    "    NA_obj,\n",
+    "    NA_illu,\n",
+    "    z_defocus,\n",
+    "    chi,\n",
+    "    n_media=n_media,\n",
+    "    phase_deconv=\"2D\",\n",
+    "    bire_in_plane_deconv=\"2D\",\n",
+    "    illu_mode=\"BF\",\n",
+    ")\n",
+    "\n",
+    "S_image_recon = setup.Stokes_recon(I_meas)\n",
+    "S_image_tm = setup.Stokes_transform(S_image_recon)\n",
+    "Recon_para = setup.Polarization_recon(\n",
+    "    S_image_tm\n",
+    ")  # Without accounting for diffraction\n",
+    "\n",
+    "jupyter_visuals.plot_multicolumn(\n",
+    "    np.array(\n",
+    "        [\n",
+    "            Recon_para[0, :, :, L // 2],\n",
+    "            Recon_para[1, :, :, L // 2],\n",
+    "            Recon_para[2, :, :, L // 2],\n",
+    "            Recon_para[3, :, :, L // 2],\n",
+    "        ]\n",
+    "    ),\n",
+    "    num_col=2,\n",
+    "    size=5,\n",
+    "    set_title=True,\n",
+    "    titles=[\"Retardance\", \"2D orientation\", \"Brightfield\", \"Depolarization\"],\n",
+    "    origin=\"lower\",\n",
+    ")\n",
+    "\n",
+    "jupyter_visuals.plot_hsv(\n",
+    "    [Recon_para[1, :, :, L // 2], Recon_para[0, :, :, L // 2]],\n",
+    "    max_val=1,\n",
+    "    origin=\"lower\",\n",
+    "    size=10,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4039e76a",
+   "metadata": {
+    "cell_marker": "\"\"\""
+   },
+   "source": [
+    "### 2D Retardance and Orientation Reconstruction with S₁ and S₂"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1cc78a50",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Diffraction aware reconstruction assuming slowly varying transmission\n",
+    "S1_stack = S_image_recon[1].copy() / S_image_recon[0].mean()\n",
+    "S2_stack = S_image_recon[2].copy() / S_image_recon[0].mean()\n",
+    "\n",
+    "# Tikhonov regularization\n",
+    "retardance, azimuth = setup.Birefringence_recon_2D(\n",
+    "    S1_stack, S2_stack, method=\"Tikhonov\", reg_br=1e-2\n",
+    ")\n",
+    "\n",
+    "jupyter_visuals.plot_multicolumn(\n",
+    "    np.array([retardance, azimuth]),\n",
+    "    num_col=2,\n",
+    "    size=10,\n",
+    "    set_title=True,\n",
+    "    titles=[\"Reconstructed retardance\", \"Reconstructed orientation\"],\n",
+    "    origin=\"lower\",\n",
+    ")\n",
+    "jupyter_visuals.plot_hsv([azimuth, retardance], size=10, origin=\"lower\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7ca537ca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TV-regularized birefringence deconvolution\n",
+    "retardance_TV, azimuth_TV = setup.Birefringence_recon_2D(\n",
+    "    S1_stack,\n",
+    "    S2_stack,\n",
+    "    method=\"TV\",\n",
+    "    reg_br=1e-1,\n",
+    "    rho=1e-5,\n",
+    "    lambda_br=1e-3,\n",
+    "    itr=20,\n",
+    "    verbose=True,\n",
+    ")\n",
+    "\n",
+    "jupyter_visuals.plot_multicolumn(\n",
+    "    np.array([retardance_TV, azimuth_TV]),\n",
+    "    num_col=2,\n",
+    "    size=10,\n",
+    "    set_title=True,\n",
+    "    titles=[\"Reconstructed retardance (TV)\", \"Reconstructed orientation (TV)\"],\n",
+    "    origin=\"lower\",\n",
+    ")\n",
+    "jupyter_visuals.plot_hsv([azimuth_TV, retardance_TV], size=10, origin=\"lower\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5d942ade",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "encoding": "# -*- coding: utf-8 -*-",
+   "formats": "py:percent,ipynb"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/examples/demos/QLIPP/QLIPP_simulation.py
+++ b/docs/examples/demos/QLIPP/QLIPP_simulation.py
@@ -1,0 +1,300 @@
+# -*- coding: utf-8 -*-
+# ---
+# jupyter:
+#   jupytext:
+#     formats: py:percent,ipynb
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.15.2
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown]
+"""
+# 2D QLIPP Simulation and Reconstruction Demo
+
+This notebook demonstrates forward simulation and reconstruction for Quantitative Label-free Imaging with Phase and Polarization (QLIPP).
+The simulation and reconstruction are based on the QLIPP paper ([here](https://elifesciences.org/articles/55502)):
+
+S.-M. Guo, L.-H. Yeh, J. Folkesson, I. E. Ivanov, A. P. Krishnan, M. G. Keefe, E. Hashemi,
+D. Shin, B. B. Chhun, N. H. Cho, M. D. Leonetti, M. H. Han, T. J. Nowakowski, S. B. Mehta,
+"Revealing architectural order with quantitative label-free imaging and deep learning,"
+eLife 9:e55502 (2020).
+"""
+
+# %% [markdown]
+"""
+## Setup and Imports
+First, let's install the latest version of waveorder from the main branch
+"""
+
+# %%
+import sys
+import subprocess
+
+# Install latest waveorder from main branch
+subprocess.check_call(
+    [
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "git+https://github.com/mehta-lab/waveorder.git@main",
+    ]
+)
+
+# %%
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+from numpy.fft import fftshift
+from platformdirs import user_data_dir
+
+from waveorder import optics, util, waveorder_simulator
+from waveorder.visuals import jupyter_visuals
+
+# %% [markdown]
+"""
+## Forward Simulation
+Here we simulate QLIPP measurements of a Siemens star pattern with uniform phase, uniform retardance, and radial orientation.
+"""
+
+# %%
+# Key parameters
+N = 256  # number of pixel in y dimension
+M = 256  # number of pixel in x dimension
+mag = 40  # magnification
+ps = 6.5 / mag  # effective pixel size
+lambda_illu = 0.532  # wavelength
+n_media = 1  # refractive index in the media
+NA_obj = 0.55  # objective NA
+NA_illu = 0.4  # illumination NA (condenser)
+NA_illu_in = 0.4  # illumination NA (phase contrast inner ring)
+z_defocus = (np.r_[:5] - 2) * 1.757  # a set of defocus plane
+chi = 0.03 * 2 * np.pi  # swing of Polscope analyzer
+
+# %% [markdown]
+"""
+### Generate Sample: Siemens Star Pattern
+"""
+
+# %%
+# Sample : star with uniform phase, uniform retardance, and radial orientation
+star, theta, _ = util.generate_star_target((N, M))
+star = star.numpy()
+theta = theta.numpy()
+jupyter_visuals.plot_multicolumn(np.array([star, theta]), num_col=2, size=5)
+
+# %%
+# Assign uniform phase, uniform retardance, and radial slow axes to the star pattern
+phase_value = 1  # average phase in radians (optical path length)
+phi_s = star * (phase_value + 0.15)  # slower OPL across target
+phi_f = star * (phase_value - 0.15)  # faster OPL across target
+mu_s = np.zeros((N, M))  # absorption
+mu_f = mu_s.copy()
+t_eigen = np.zeros((2, N, M), complex)  # complex specimen transmission
+t_eigen[0] = np.exp(-mu_s + 1j * phi_s)
+t_eigen[1] = np.exp(-mu_f + 1j * phi_f)
+sa = theta % np.pi  # slow axes.
+
+jupyter_visuals.plot_multicolumn(
+    np.array([phi_s, phi_f, mu_s, sa]),
+    num_col=2,
+    size=5,
+    set_title=True,
+    titles=["Phase (slow)", "Phase (fast)", "absorption", "slow axis"],
+    origin="lower",
+)
+
+# %% [markdown]
+"""
+### Forward Model Setup
+"""
+
+# %%
+# Source pupil
+# Subsample source pattern for speed
+xx, yy, fxx, fyy = util.gen_coordinate((N, M), ps)
+radial_frequencies = np.sqrt(fxx**2 + fyy**2)
+Source_cont = optics.generate_pupil(
+    radial_frequencies, NA_illu, lambda_illu
+).numpy()
+Source_discrete = optics.Source_subsample(
+    Source_cont, lambda_illu * fxx, lambda_illu * fyy, subsampled_NA=0.1
+)
+plt.figure(figsize=(10, 10))
+plt.imshow(fftshift(Source_discrete), cmap="gray")
+plt.show()
+
+# %%
+# Initialize microscope simulator
+simulator = waveorder_simulator.waveorder_microscopy_simulator(
+    (N, M),
+    lambda_illu,
+    ps,
+    NA_obj,
+    NA_illu,
+    z_defocus,
+    chi,
+    n_media=n_media,
+    illu_mode="Arbitrary",
+    Source=Source_discrete,
+)
+
+# Compute image volumes and Stokes volumes
+I_meas, Stokes_out = simulator.simulate_waveorder_measurements(
+    t_eigen, sa, multiprocess=False
+)
+
+# Add noise to the measurement
+photon_count = 14000
+ext_ratio = 10000
+const_bg = photon_count / (0.5 * (1 - np.cos(chi))) / ext_ratio
+I_meas_noise = (
+    np.random.poisson(I_meas / np.max(I_meas) * photon_count + const_bg)
+).astype("float64")
+
+# Save simulation
+temp_dirpath = Path(user_data_dir("QLIPP_simulation"))
+temp_dirpath.mkdir(parents=True, exist_ok=True)
+output_file = temp_dirpath / "2D_QLIPP_simulation.npz"
+np.savez(
+    output_file,
+    I_meas=I_meas_noise,
+    Stokes_out=Stokes_out,
+    lambda_illu=lambda_illu,
+    n_media=n_media,
+    NA_obj=NA_obj,
+    NA_illu=NA_illu,
+    ps=ps,
+    Source_cont=Source_cont,
+    z_defocus=z_defocus,
+    chi=chi,
+)
+
+# %% [markdown]
+"""
+## Reconstruction
+Now we'll reconstruct the simulated data to recover the sample properties.
+"""
+
+# %%
+from waveorder import waveorder_reconstructor
+
+# Load simulated data
+array_loaded = np.load(output_file)
+list_of_array_names = sorted(array_loaded)
+
+for array_name in list_of_array_names:
+    globals()[array_name] = array_loaded[array_name]
+
+print("Loaded arrays:", list_of_array_names)
+
+# %% [markdown]
+"""
+### Initial Reconstruction of Stokes Parameters and Anisotropy
+"""
+
+# %%
+_, N, M, L = I_meas.shape
+cali = False
+bg_option = "global"
+
+setup = waveorder_reconstructor.waveorder_microscopy(
+    (N, M),
+    lambda_illu,
+    ps,
+    NA_obj,
+    NA_illu,
+    z_defocus,
+    chi,
+    n_media=n_media,
+    phase_deconv="2D",
+    bire_in_plane_deconv="2D",
+    illu_mode="BF",
+)
+
+S_image_recon = setup.Stokes_recon(I_meas)
+S_image_tm = setup.Stokes_transform(S_image_recon)
+Recon_para = setup.Polarization_recon(
+    S_image_tm
+)  # Without accounting for diffraction
+
+jupyter_visuals.plot_multicolumn(
+    np.array(
+        [
+            Recon_para[0, :, :, L // 2],
+            Recon_para[1, :, :, L // 2],
+            Recon_para[2, :, :, L // 2],
+            Recon_para[3, :, :, L // 2],
+        ]
+    ),
+    num_col=2,
+    size=5,
+    set_title=True,
+    titles=["Retardance", "2D orientation", "Brightfield", "Depolarization"],
+    origin="lower",
+)
+
+jupyter_visuals.plot_hsv(
+    [Recon_para[1, :, :, L // 2], Recon_para[0, :, :, L // 2]],
+    max_val=1,
+    origin="lower",
+    size=10,
+)
+
+# %% [markdown]
+"""
+### 2D Retardance and Orientation Reconstruction with S₁ and S₂
+"""
+
+# %%
+# Diffraction aware reconstruction assuming slowly varying transmission
+S1_stack = S_image_recon[1].copy() / S_image_recon[0].mean()
+S2_stack = S_image_recon[2].copy() / S_image_recon[0].mean()
+
+# Tikhonov regularization
+retardance, azimuth = setup.Birefringence_recon_2D(
+    S1_stack, S2_stack, method="Tikhonov", reg_br=1e-2
+)
+
+jupyter_visuals.plot_multicolumn(
+    np.array([retardance, azimuth]),
+    num_col=2,
+    size=10,
+    set_title=True,
+    titles=["Reconstructed retardance", "Reconstructed orientation"],
+    origin="lower",
+)
+jupyter_visuals.plot_hsv([azimuth, retardance], size=10, origin="lower")
+
+# %%
+# TV-regularized birefringence deconvolution
+retardance_TV, azimuth_TV = setup.Birefringence_recon_2D(
+    S1_stack,
+    S2_stack,
+    method="TV",
+    reg_br=1e-1,
+    rho=1e-5,
+    lambda_br=1e-3,
+    itr=20,
+    verbose=True,
+)
+
+jupyter_visuals.plot_multicolumn(
+    np.array([retardance_TV, azimuth_TV]),
+    num_col=2,
+    size=10,
+    set_title=True,
+    titles=["Reconstructed retardance (TV)", "Reconstructed orientation (TV)"],
+    origin="lower",
+)
+jupyter_visuals.plot_hsv([azimuth_TV, retardance_TV], size=10, origin="lower")
+
+# %%

--- a/docs/examples/demos/QPI_defocus/QPI_defocus_experiment.ipynb
+++ b/docs/examples/demos/QPI_defocus/QPI_defocus_experiment.ipynb
@@ -1,0 +1,195 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "562c4414",
+   "metadata": {
+    "cell_marker": "\"\"\""
+   },
+   "source": [
+    "# Quantitative Phase Imaging from Defocus Demo\n",
+    "\n",
+    "This notebook demonstrates reconstruction for Quantitative Phase Imaging (QPI) from defocus.\n",
+    "The reconstruction is based on partially coherent optical diffraction tomography (ODT):\n",
+    "\n",
+    "J. M. Soto, J. A. Rodrigo, and T. Alieva, \"Label-free quantitative 3D tomographic imaging\n",
+    "for partially coherent light microscopy,\" Opt. Express 25, 15699-15712 (2017)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f85dc1ab",
+   "metadata": {
+    "cell_marker": "\"\"\""
+   },
+   "source": [
+    "## Setup and Imports\n",
+    "First, let's install the latest version of waveorder from the main branch"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cc35c1f1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "import subprocess\n",
+    "\n",
+    "# Install latest waveorder from main branch\n",
+    "subprocess.check_call(\n",
+    "    [\n",
+    "        sys.executable,\n",
+    "        \"-m\",\n",
+    "        \"pip\",\n",
+    "        \"install\",\n",
+    "        \"git+https://github.com/mehta-lab/waveorder.git@main\",\n",
+    "    ]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6cb2897f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import torch\n",
+    "\n",
+    "from waveorder.models import phase_thick_3d\n",
+    "import requests\n",
+    "import zipfile\n",
+    "import io\n",
+    "from iohub import open_ome_zarr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7d715954",
+   "metadata": {
+    "title": "Load the data"
+   },
+   "outputs": [],
+   "source": [
+    "# Download the file from Zenodo\n",
+    "url = \"https://zenodo.org/record/8386856/files/recOrder_session.zip\"\n",
+    "response = requests.get(url)\n",
+    "response.raise_for_status()\n",
+    "\n",
+    "# Unzip the downloaded file\n",
+    "with zipfile.ZipFile(io.BytesIO(response.content)) as z:\n",
+    "    z.extractall(\"./recOrder_session\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6b261eb2",
+   "metadata": {
+    "title": "Load data into an array"
+   },
+   "outputs": [],
+   "source": [
+    "zarr_path = \"./recOrder_session/recOrder_session/phase_snap_0/raw_data.zarr\"\n",
+    "with open_ome_zarr(zarr_path) as input_plate:\n",
+    "    zyx_data = input_plate[\"0/0/0/0\"][0, 0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4fb99579",
+   "metadata": {
+    "lines_to_next_cell": 0,
+    "title": "specify reconstruction parameters (all lengths in micrometers)"
+   },
+   "outputs": [],
+   "source": [
+    "transfer_function_arguments = {\n",
+    "    \"yx_pixel_size\": 6.5 / 20,  # Lateral pixel size\n",
+    "    \"z_pixel_size\": 2.0,  # Axial pixel size\n",
+    "    \"index_of_refraction_media\": 1.0,  # Refractive index of medium\n",
+    "    \"z_padding\": 0,  # Padding in z direction\n",
+    "    \"wavelength_illumination\": 0.532,  # Wavelength in microns\n",
+    "    \"numerical_aperture_illumination\": 0.4,  # Illumination NA\n",
+    "    \"numerical_aperture_detection\": 0.55,  # Detection NA\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7b07436a",
+   "metadata": {
+    "title": "Calculate the transfer function"
+   },
+   "outputs": [],
+   "source": [
+    "(\n",
+    "    real_potential_transfer_function,\n",
+    "    imag_potential_transfer_function,\n",
+    ") = phase_thick_3d.calculate_transfer_function(\n",
+    "    zyx_shape=zyx_data.shape, **transfer_function_arguments\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ca70ff92",
+   "metadata": {
+    "lines_to_next_cell": 0,
+    "title": "Reconstruct"
+   },
+   "outputs": [],
+   "source": [
+    "zyx_recon = phase_thick_3d.apply_inverse_transfer_function(\n",
+    "    torch.Tensor(zyx_data),\n",
+    "    real_potential_transfer_function,\n",
+    "    imag_potential_transfer_function,\n",
+    "    transfer_function_arguments[\"z_padding\"],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6d2dcd15",
+   "metadata": {
+    "title": "Compared data and reconstruction"
+   },
+   "outputs": [],
+   "source": [
+    "z_slices = [1, 3, 5, 7, 9]\n",
+    "\n",
+    "fig, axes = plt.subplots(2, 5, figsize=(15, 6))\n",
+    "for i, z in enumerate(z_slices):\n",
+    "    axes[0, i].imshow(zyx_data[z], cmap=\"gray\", origin=\"lower\")\n",
+    "    axes[0, i].set_title(f\"Ground Truth, z = {z}\")\n",
+    "    axes[0, i].axis(\"off\")\n",
+    "    axes[1, i].imshow(zyx_recon[z], cmap=\"gray\", origin=\"lower\")\n",
+    "    axes[1, i].set_title(f\"Reconstruction, z = {z}\")\n",
+    "    axes[1, i].axis(\"off\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "encoding": "# -*- coding: utf-8 -*-",
+   "formats": "py:percent,ipynb"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/examples/demos/QPI_defocus/QPI_defocus_experiment.ipynb
+++ b/docs/examples/demos/QPI_defocus/QPI_defocus_experiment.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "de89a5e5",
+   "id": "0c49272c",
    "metadata": {
     "cell_marker": "\"\"\""
    },
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fb9b7241",
+   "id": "195e91da",
    "metadata": {
     "cell_marker": "\"\"\""
    },
@@ -30,7 +30,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b2838740",
+   "id": "8597d52a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -53,7 +53,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b51868e6",
+   "id": "c6cd89b4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -70,7 +70,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0cd590f3",
+   "id": "729ba340",
    "metadata": {
     "title": "Load the data"
    },
@@ -89,7 +89,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bcbbc7b8",
+   "id": "02ac6ada",
    "metadata": {
     "title": "Load data into an array"
    },
@@ -103,7 +103,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4146ce11",
+   "id": "64908074",
    "metadata": {
     "lines_to_next_cell": 0,
     "title": "specify reconstruction parameters (all lengths in micrometers)"
@@ -124,7 +124,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4e73c0f2",
+   "id": "3d196bf9",
    "metadata": {
     "title": "Calculate the transfer function"
    },
@@ -141,7 +141,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31d9c445",
+   "id": "0258c0ae",
    "metadata": {
     "lines_to_next_cell": 0,
     "title": "Reconstruct"
@@ -153,13 +153,14 @@
     "    real_potential_transfer_function,\n",
     "    imag_potential_transfer_function,\n",
     "    transfer_function_arguments[\"z_padding\"],\n",
+    "    regularization_parameter=0.01,\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e9c2872f",
+   "id": "9f548841",
    "metadata": {
     "title": "Compared data and reconstruction"
    },
@@ -170,10 +171,10 @@
     "fig, axes = plt.subplots(2, 5, figsize=(15, 6))\n",
     "for i, z in enumerate(z_slices):\n",
     "    axes[0, i].imshow(zyx_data[z], cmap=\"gray\", origin=\"lower\")\n",
-    "    axes[0, i].set_title(f\"Ground Truth, z = {z}\")\n",
+    "    axes[0, i].set_title(f\"Brightfield Data, z = {z}\")\n",
     "    axes[0, i].axis(\"off\")\n",
     "    axes[1, i].imshow(zyx_recon[z], cmap=\"gray\", origin=\"lower\")\n",
-    "    axes[1, i].set_title(f\"Reconstruction, z = {z}\")\n",
+    "    axes[1, i].set_title(f\"Phase Reconstruction, z = {z}\")\n",
     "    axes[1, i].axis(\"off\")\n",
     "plt.tight_layout()\n",
     "plt.show()"

--- a/docs/examples/demos/QPI_defocus/QPI_defocus_experiment.ipynb
+++ b/docs/examples/demos/QPI_defocus/QPI_defocus_experiment.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "562c4414",
+   "id": "de89a5e5",
    "metadata": {
     "cell_marker": "\"\"\""
    },
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f85dc1ab",
+   "id": "fb9b7241",
    "metadata": {
     "cell_marker": "\"\"\""
    },
@@ -30,7 +30,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cc35c1f1",
+   "id": "b2838740",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -46,13 +46,14 @@
     "        \"install\",\n",
     "        \"git+https://github.com/mehta-lab/waveorder.git@main\",\n",
     "    ]\n",
-    ")"
+    ")\n",
+    "!pip install iohub==0.2.0"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6cb2897f",
+   "id": "b51868e6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -69,7 +70,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7d715954",
+   "id": "0cd590f3",
    "metadata": {
     "title": "Load the data"
    },
@@ -88,7 +89,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6b261eb2",
+   "id": "bcbbc7b8",
    "metadata": {
     "title": "Load data into an array"
    },
@@ -102,7 +103,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4fb99579",
+   "id": "4146ce11",
    "metadata": {
     "lines_to_next_cell": 0,
     "title": "specify reconstruction parameters (all lengths in micrometers)"
@@ -123,7 +124,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7b07436a",
+   "id": "4e73c0f2",
    "metadata": {
     "title": "Calculate the transfer function"
    },
@@ -140,7 +141,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ca70ff92",
+   "id": "31d9c445",
    "metadata": {
     "lines_to_next_cell": 0,
     "title": "Reconstruct"
@@ -158,7 +159,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6d2dcd15",
+   "id": "e9c2872f",
    "metadata": {
     "title": "Compared data and reconstruction"
    },

--- a/docs/examples/demos/QPI_defocus/QPI_defocus_experiment.py
+++ b/docs/examples/demos/QPI_defocus/QPI_defocus_experiment.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+# ---
+# jupyter:
+#   jupytext:
+#     formats: py:percent,ipynb
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.15.2
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown]
+"""
+# Quantitative Phase Imaging from Defocus Demo
+
+This notebook demonstrates reconstruction for Quantitative Phase Imaging (QPI) from defocus.
+The reconstruction is based on partially coherent optical diffraction tomography (ODT):
+
+J. M. Soto, J. A. Rodrigo, and T. Alieva, "Label-free quantitative 3D tomographic imaging
+for partially coherent light microscopy," Opt. Express 25, 15699-15712 (2017)
+"""
+
+# %% [markdown]
+"""
+## Setup and Imports
+First, let's install the latest version of waveorder from the main branch
+"""
+
+# %%
+import sys
+import subprocess
+
+# Install latest waveorder from main branch
+subprocess.check_call(
+    [
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "git+https://github.com/mehta-lab/waveorder.git@main",
+    ]
+)
+
+# %%
+import matplotlib.pyplot as plt
+import torch
+
+from waveorder.models import phase_thick_3d
+import requests
+import zipfile
+import io
+from iohub import open_ome_zarr
+
+# %% Load the data
+# Download the file from Zenodo
+url = "https://zenodo.org/record/8386856/files/recOrder_session.zip"
+response = requests.get(url)
+response.raise_for_status()
+
+# Unzip the downloaded file
+with zipfile.ZipFile(io.BytesIO(response.content)) as z:
+    z.extractall("./recOrder_session")
+
+# %% Load data into an array
+zarr_path = "./recOrder_session/recOrder_session/phase_snap_0/raw_data.zarr"
+with open_ome_zarr(zarr_path) as input_plate:
+    zyx_data = input_plate["0/0/0/0"][0, 0]
+
+# %% specify reconstruction parameters (all lengths in micrometers)
+transfer_function_arguments = {
+    "yx_pixel_size": 6.5 / 20,  # Lateral pixel size
+    "z_pixel_size": 2.0,  # Axial pixel size
+    "index_of_refraction_media": 1.0,  # Refractive index of medium
+    "z_padding": 0,  # Padding in z direction
+    "wavelength_illumination": 0.532,  # Wavelength in microns
+    "numerical_aperture_illumination": 0.4,  # Illumination NA
+    "numerical_aperture_detection": 0.55,  # Detection NA
+}
+# %% Calculate the transfer function
+(
+    real_potential_transfer_function,
+    imag_potential_transfer_function,
+) = phase_thick_3d.calculate_transfer_function(
+    zyx_shape=zyx_data.shape, **transfer_function_arguments
+)
+
+# %% Reconstruct
+zyx_recon = phase_thick_3d.apply_inverse_transfer_function(
+    torch.Tensor(zyx_data),
+    real_potential_transfer_function,
+    imag_potential_transfer_function,
+    transfer_function_arguments["z_padding"],
+)
+# %% Compared data and reconstruction
+z_slices = [1, 3, 5, 7, 9]
+
+fig, axes = plt.subplots(2, 5, figsize=(15, 6))
+for i, z in enumerate(z_slices):
+    axes[0, i].imshow(zyx_data[z], cmap="gray", origin="lower")
+    axes[0, i].set_title(f"Ground Truth, z = {z}")
+    axes[0, i].axis("off")
+    axes[1, i].imshow(zyx_recon[z], cmap="gray", origin="lower")
+    axes[1, i].set_title(f"Reconstruction, z = {z}")
+    axes[1, i].axis("off")
+plt.tight_layout()
+plt.show()

--- a/docs/examples/demos/QPI_defocus/QPI_defocus_experiment.py
+++ b/docs/examples/demos/QPI_defocus/QPI_defocus_experiment.py
@@ -96,6 +96,7 @@ zyx_recon = phase_thick_3d.apply_inverse_transfer_function(
     real_potential_transfer_function,
     imag_potential_transfer_function,
     transfer_function_arguments["z_padding"],
+    regularization_parameter=0.01,
 )
 # %% Compared data and reconstruction
 z_slices = [1, 3, 5, 7, 9]
@@ -103,10 +104,10 @@ z_slices = [1, 3, 5, 7, 9]
 fig, axes = plt.subplots(2, 5, figsize=(15, 6))
 for i, z in enumerate(z_slices):
     axes[0, i].imshow(zyx_data[z], cmap="gray", origin="lower")
-    axes[0, i].set_title(f"Ground Truth, z = {z}")
+    axes[0, i].set_title(f"Brightfield Data, z = {z}")
     axes[0, i].axis("off")
     axes[1, i].imshow(zyx_recon[z], cmap="gray", origin="lower")
-    axes[1, i].set_title(f"Reconstruction, z = {z}")
+    axes[1, i].set_title(f"Phase Reconstruction, z = {z}")
     axes[1, i].axis("off")
 plt.tight_layout()
 plt.show()

--- a/docs/examples/demos/QPI_defocus/QPI_defocus_experiment.py
+++ b/docs/examples/demos/QPI_defocus/QPI_defocus_experiment.py
@@ -45,6 +45,7 @@ subprocess.check_call(
         "git+https://github.com/mehta-lab/waveorder.git@main",
     ]
 )
+!pip install iohub==0.2.0
 
 # %%
 import matplotlib.pyplot as plt

--- a/docs/examples/demos/QPI_defocus/QPI_defocus_simulation.ipynb
+++ b/docs/examples/demos/QPI_defocus/QPI_defocus_simulation.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "8c1de60b",
+   "id": "7bf01653",
    "metadata": {
     "cell_marker": "\"\"\""
    },
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a8dde653",
+   "id": "46dd50ba",
    "metadata": {
     "cell_marker": "\"\"\""
    },
@@ -30,7 +30,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5e914f59",
+   "id": "80761384",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -52,7 +52,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "203ce689",
+   "id": "66256a1a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -69,7 +69,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "111c40e3",
+   "id": "8c233e46",
    "metadata": {
     "cell_marker": "\"\"\""
    },
@@ -80,7 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64c8c3f2",
+   "id": "add7b620",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -107,7 +107,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "88918394",
+   "id": "f7e7a7ad",
    "metadata": {
     "cell_marker": "\"\"\""
    },
@@ -118,7 +118,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "02bfef17",
+   "id": "c14d5942",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -161,7 +161,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7d2fd655",
+   "id": "4d2fe109",
    "metadata": {
     "cell_marker": "\"\"\""
    },
@@ -172,7 +172,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16a3a161",
+   "id": "08db7d6c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -211,7 +211,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b491d2ff",
+   "id": "651fe7b0",
    "metadata": {
     "cell_marker": "\"\"\""
    },
@@ -222,7 +222,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9d112e4d",
+   "id": "62ada3b4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -233,11 +233,13 @@
     "    transfer_function_arguments[\"z_padding\"],\n",
     "    brightness=1e3,\n",
     ")\n",
-    "\n",
+    "zyx_data_norm = (zyx_data - zyx_data.min()) / (zyx_data.max() - zyx_data.min())\n",
     "# Visualize simulated data\n",
     "fig, axes = plt.subplots(1, 5, figsize=(15, 3))\n",
     "for i, z in enumerate(z_slices):\n",
-    "    axes[i].imshow(zyx_data[z], cmap=\"gray\", origin=\"lower\")\n",
+    "    axes[i].imshow(\n",
+    "        zyx_data_norm[z], cmap=\"gray\", origin=\"lower\", vmin=0, vmax=1\n",
+    "    )\n",
     "    axes[i].set_title(f\"Data, z = {z - z_center}\")\n",
     "    axes[i].axis(\"off\")\n",
     "plt.tight_layout()\n",
@@ -246,7 +248,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e124be4f",
+   "id": "9b71cbe0",
    "metadata": {
     "cell_marker": "\"\"\""
    },
@@ -257,7 +259,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58e1434e",
+   "id": "cd07f7cc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -301,7 +303,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2dfb3a3b",
+   "id": "3f8b73c4",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/docs/examples/demos/QPI_defocus/QPI_defocus_simulation.ipynb
+++ b/docs/examples/demos/QPI_defocus/QPI_defocus_simulation.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "be76c50e",
+   "id": "8c1de60b",
    "metadata": {
     "cell_marker": "\"\"\""
    },
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1c499a11",
+   "id": "a8dde653",
    "metadata": {
     "cell_marker": "\"\"\""
    },
@@ -30,7 +30,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dd068541",
+   "id": "5e914f59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -52,7 +52,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c5dc9918",
+   "id": "203ce689",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -69,7 +69,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fc4ce347",
+   "id": "111c40e3",
    "metadata": {
     "cell_marker": "\"\"\""
    },
@@ -80,7 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ad6f7b13",
+   "id": "64c8c3f2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -107,7 +107,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1259c40f",
+   "id": "88918394",
    "metadata": {
     "cell_marker": "\"\"\""
    },
@@ -118,7 +118,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6c60214c",
+   "id": "02bfef17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -129,7 +129,8 @@
     "    yx_shape=simulation_arguments[\"zyx_shape\"][1:3]\n",
     ")\n",
     "yx_phase = star * (\n",
-    "    phantom_arguments[\"index_of_refraction_sample\"] - simulation_arguments[\"index_of_refraction_media\"]\n",
+    "    phantom_arguments[\"index_of_refraction_sample\"]\n",
+    "    - simulation_arguments[\"index_of_refraction_media\"]\n",
     ")  # phase in radians\n",
     "# Initialize zyx_phase with zeros\n",
     "zyx_phase = torch.zeros(simulation_arguments[\"zyx_shape\"])\n",
@@ -152,7 +153,7 @@
     "fig, axes = plt.subplots(1, 5, figsize=(15, 3))\n",
     "for i, z in enumerate(z_slices):\n",
     "    axes[i].imshow(zyx_phase[z], cmap=\"gray\", origin=\"lower\")\n",
-    "    axes[i].set_title(f\"z = {z}\")\n",
+    "    axes[i].set_title(f\"z = {z - z_center}\")\n",
     "    axes[i].axis(\"off\")\n",
     "plt.tight_layout()\n",
     "plt.show()"
@@ -160,7 +161,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0794004e",
+   "id": "7d2fd655",
    "metadata": {
     "cell_marker": "\"\"\""
    },
@@ -171,41 +172,38 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dca667fc",
+   "id": "16a3a161",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Calculate real and imaginary parts of the transfer function\n",
     "(\n",
-    "    real_potential_transfer_function,\n",
-    "    imag_potential_transfer_function,\n",
+    "    real_component_transfer_function,\n",
+    "    imaginary_component_transfer_function,\n",
     ") = phase_thick_3d.calculate_transfer_function(\n",
     "    **simulation_arguments, **transfer_function_arguments\n",
     ")\n",
-    "# Convert complex valued transfer functions to real valued\n",
-    "real_potential_transfer_function_shifted = np.fft.ifftshift(\n",
-    "    real_potential_transfer_function.real\n",
-    ")\n",
-    "imag_potential_transfer_function_shifted = np.fft.ifftshift(\n",
-    "    imag_potential_transfer_function.real\n",
-    ")\n",
+    "\n",
+    "# Magnitude and phase of the real component of the transfer function\n",
+    "tf_real_magnitude = np.fft.ifftshift(real_component_transfer_function.abs())\n",
+    "tf_real_phase = np.fft.ifftshift(real_component_transfer_function.angle())\n",
     "\n",
     "# Visualize transfer functions\n",
     "fig, axes = plt.subplots(2, 5, figsize=(15, 6))\n",
     "for i, z in enumerate(z_slices):\n",
     "    axes[0, i].imshow(\n",
-    "        real_potential_transfer_function_shifted[z],\n",
+    "        tf_real_magnitude[z],\n",
     "        cmap=\"gray\",\n",
     "        origin=\"lower\",\n",
     "    )\n",
-    "    axes[0, i].set_title(f\"Real TF, z = {z}\")\n",
+    "    axes[0, i].set_title(f\"Magnitude of TF, z = {z - z_center}\")\n",
     "    axes[0, i].axis(\"off\")\n",
     "    axes[1, i].imshow(\n",
-    "        imag_potential_transfer_function_shifted[z],\n",
+    "        tf_real_phase[z],\n",
     "        cmap=\"gray\",\n",
     "        origin=\"lower\",\n",
     "    )\n",
-    "    axes[1, i].set_title(f\"Imag TF, z = {z}\")\n",
+    "    axes[1, i].set_title(f\"Phase of TF, z = {z - z_center}\")\n",
     "    axes[1, i].axis(\"off\")\n",
     "plt.tight_layout()\n",
     "plt.show()"
@@ -213,7 +211,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4f1f271e",
+   "id": "b491d2ff",
    "metadata": {
     "cell_marker": "\"\"\""
    },
@@ -224,14 +222,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cb16fc0c",
+   "id": "9d112e4d",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Simulate defocus data\n",
     "zyx_data = phase_thick_3d.apply_transfer_function(\n",
     "    zyx_phase,\n",
-    "    real_potential_transfer_function,\n",
+    "    real_component_transfer_function,\n",
     "    transfer_function_arguments[\"z_padding\"],\n",
     "    brightness=1e3,\n",
     ")\n",
@@ -240,7 +238,7 @@
     "fig, axes = plt.subplots(1, 5, figsize=(15, 3))\n",
     "for i, z in enumerate(z_slices):\n",
     "    axes[i].imshow(zyx_data[z], cmap=\"gray\", origin=\"lower\")\n",
-    "    axes[i].set_title(f\"Data, z = {z}\")\n",
+    "    axes[i].set_title(f\"Data, z = {z - z_center}\")\n",
     "    axes[i].axis(\"off\")\n",
     "plt.tight_layout()\n",
     "plt.show()"
@@ -248,7 +246,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5a75411c",
+   "id": "e124be4f",
    "metadata": {
     "cell_marker": "\"\"\""
    },
@@ -259,27 +257,43 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57b85c74",
+   "id": "58e1434e",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Reconstruct phase\n",
     "zyx_recon = phase_thick_3d.apply_inverse_transfer_function(\n",
     "    zyx_data,\n",
-    "    real_potential_transfer_function,\n",
-    "    imag_potential_transfer_function,\n",
+    "    real_component_transfer_function,\n",
+    "    imaginary_component_transfer_function,\n",
     "    transfer_function_arguments[\"z_padding\"],\n",
+    "    reconstruction_algorithm=\"Tikhonov\",\n",
+    "    regularization_strength=1e-5,\n",
     ")\n",
     "\n",
     "# Visualize reconstruction compared to ground truth\n",
-    "fig, axes = plt.subplots(2, 5, figsize=(15, 6))\n",
+    "fig, axes = plt.subplots(3, 5, figsize=(15, 9))\n",
+    "\n",
+    "# Normalize data and reconstruction between 0 and 1\n",
+    "zyx_data_norm = (zyx_data - zyx_data.min()) / (zyx_data.max() - zyx_data.min())\n",
+    "zyx_recon_norm = (zyx_recon - zyx_recon.min()) / (\n",
+    "    zyx_recon.max() - zyx_recon.min()\n",
+    ")\n",
+    "\n",
     "for i, z in enumerate(z_slices):\n",
     "    axes[0, i].imshow(zyx_phase[z], cmap=\"gray\", origin=\"lower\")\n",
-    "    axes[0, i].set_title(f\"Ground Truth, z = {z}\")\n",
+    "    axes[0, i].set_title(f\"Ground Truth, z = {z - z_center}\")\n",
     "    axes[0, i].axis(\"off\")\n",
-    "    axes[1, i].imshow(zyx_recon[z], cmap=\"gray\", origin=\"lower\")\n",
-    "    axes[1, i].set_title(f\"Reconstruction, z = {z}\")\n",
+    "    axes[1, i].imshow(\n",
+    "        zyx_data_norm[z], cmap=\"gray\", origin=\"lower\", vmin=0, vmax=1\n",
+    "    )\n",
+    "    axes[1, i].set_title(f\"Data, z = {z - z_center}\")\n",
     "    axes[1, i].axis(\"off\")\n",
+    "    axes[2, i].imshow(\n",
+    "        zyx_recon_norm[z], cmap=\"gray\", origin=\"lower\", vmin=0, vmax=1\n",
+    "    )\n",
+    "    axes[2, i].set_title(f\"Reconstruction, z = {z - z_center}\")\n",
+    "    axes[2, i].axis(\"off\")\n",
     "plt.tight_layout()\n",
     "plt.show()"
    ]
@@ -287,7 +301,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9cc5853d",
+   "id": "2dfb3a3b",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -299,13 +313,9 @@
    "formats": "py:percent,ipynb"
   },
   "kernelspec": {
-   "display_name": "wo-dev3",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "name": "python",
-   "version": "3.11.11"
   }
  },
  "nbformat": 4,

--- a/docs/examples/demos/QPI_defocus/QPI_defocus_simulation.ipynb
+++ b/docs/examples/demos/QPI_defocus/QPI_defocus_simulation.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "5e4e90c6",
+   "id": "be76c50e",
    "metadata": {
     "cell_marker": "\"\"\""
    },
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f0ce6c0d",
+   "id": "1c499a11",
    "metadata": {
     "cell_marker": "\"\"\""
    },
@@ -30,7 +30,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "68bff0a9",
+   "id": "dd068541",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -52,7 +52,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "216ce117",
+   "id": "c5dc9918",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -60,14 +60,16 @@
     "from pathlib import Path\n",
     "from platformdirs import user_data_dir\n",
     "import matplotlib.pyplot as plt\n",
+    "import torch\n",
     "\n",
+    "from waveorder import util\n",
     "from waveorder.models import phase_thick_3d\n",
     "from waveorder.visuals import jupyter_visuals"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "aebdbd6e",
+   "id": "fc4ce347",
    "metadata": {
     "cell_marker": "\"\"\""
    },
@@ -78,7 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ebb327b4",
+   "id": "ad6f7b13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -105,7 +107,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e80f50a2",
+   "id": "1259c40f",
    "metadata": {
     "cell_marker": "\"\"\""
    },
@@ -116,17 +118,37 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31ce02f3",
+   "id": "6c60214c",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Create a phantom\n",
-    "zyx_phase = phase_thick_3d.generate_test_phantom(\n",
-    "    **simulation_arguments, **phantom_arguments\n",
-    ")\n",
     "\n",
-    "# Show 5 z-slices of the phantom\n",
-    "z_slices = np.linspace(0, zyx_phase.shape[0] - 1, 5).astype(int)\n",
+    "# Star target\n",
+    "star, _, _ = util.generate_star_target(\n",
+    "    yx_shape=simulation_arguments[\"zyx_shape\"][1:3]\n",
+    ")\n",
+    "yx_phase = star * (\n",
+    "    phantom_arguments[\"index_of_refraction_sample\"] - simulation_arguments[\"index_of_refraction_media\"]\n",
+    ")  # phase in radians\n",
+    "# Initialize zyx_phase with zeros\n",
+    "zyx_phase = torch.zeros(simulation_arguments[\"zyx_shape\"])\n",
+    "\n",
+    "# Copy yx_phase into the central 10 z slices\n",
+    "z_center = simulation_arguments[\"zyx_shape\"][0] // 2\n",
+    "z_start = z_center - 5\n",
+    "z_end = z_center + 6\n",
+    "zyx_phase[z_start:z_end] = yx_phase\n",
+    "\n",
+    "# Bead target\n",
+    "# zyx_phase = phase_thick_3d.generate_test_phantom(\n",
+    "#     **simulation_arguments, **phantom_arguments\n",
+    "# )\n",
+    "\n",
+    "\n",
+    "# Show 5 z-slices, five apart, centered on the central z slice\n",
+    "z_slices = np.arange(z_center - 10, z_center + 11, 5)\n",
+    "\n",
     "fig, axes = plt.subplots(1, 5, figsize=(15, 3))\n",
     "for i, z in enumerate(z_slices):\n",
     "    axes[i].imshow(zyx_phase[z], cmap=\"gray\", origin=\"lower\")\n",
@@ -138,7 +160,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "40b8c5a7",
+   "id": "0794004e",
    "metadata": {
     "cell_marker": "\"\"\""
    },
@@ -149,7 +171,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39c3b649",
+   "id": "dca667fc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -161,10 +183,10 @@
     "    **simulation_arguments, **transfer_function_arguments\n",
     ")\n",
     "# Convert complex valued transfer functions to real valued\n",
-    "real_potential_transfer_function = np.fft.ifftshift(\n",
+    "real_potential_transfer_function_shifted = np.fft.ifftshift(\n",
     "    real_potential_transfer_function.real\n",
     ")\n",
-    "imag_potential_transfer_function = np.fft.ifftshift(\n",
+    "imag_potential_transfer_function_shifted = np.fft.ifftshift(\n",
     "    imag_potential_transfer_function.real\n",
     ")\n",
     "\n",
@@ -172,12 +194,16 @@
     "fig, axes = plt.subplots(2, 5, figsize=(15, 6))\n",
     "for i, z in enumerate(z_slices):\n",
     "    axes[0, i].imshow(\n",
-    "        real_potential_transfer_function[z], cmap=\"gray\", origin=\"lower\"\n",
+    "        real_potential_transfer_function_shifted[z],\n",
+    "        cmap=\"gray\",\n",
+    "        origin=\"lower\",\n",
     "    )\n",
     "    axes[0, i].set_title(f\"Real TF, z = {z}\")\n",
     "    axes[0, i].axis(\"off\")\n",
     "    axes[1, i].imshow(\n",
-    "        imag_potential_transfer_function[z], cmap=\"gray\", origin=\"lower\"\n",
+    "        imag_potential_transfer_function_shifted[z],\n",
+    "        cmap=\"gray\",\n",
+    "        origin=\"lower\",\n",
     "    )\n",
     "    axes[1, i].set_title(f\"Imag TF, z = {z}\")\n",
     "    axes[1, i].axis(\"off\")\n",
@@ -187,7 +213,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d1b5d13b",
+   "id": "4f1f271e",
    "metadata": {
     "cell_marker": "\"\"\""
    },
@@ -198,7 +224,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ec16b55f",
+   "id": "cb16fc0c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -222,7 +248,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "756895f3",
+   "id": "5a75411c",
    "metadata": {
     "cell_marker": "\"\"\""
    },
@@ -233,7 +259,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ac7e77c2",
+   "id": "57b85c74",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -257,6 +283,14 @@
     "plt.tight_layout()\n",
     "plt.show()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9cc5853d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -265,9 +299,13 @@
    "formats": "py:percent,ipynb"
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "wo-dev3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,

--- a/docs/examples/demos/QPI_defocus/QPI_defocus_simulation.ipynb
+++ b/docs/examples/demos/QPI_defocus/QPI_defocus_simulation.ipynb
@@ -1,0 +1,275 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "5e4e90c6",
+   "metadata": {
+    "cell_marker": "\"\"\""
+   },
+   "source": [
+    "# Quantitative Phase Imaging from Defocus Demo\n",
+    "\n",
+    "This notebook demonstrates forward simulation and reconstruction for Quantitative Phase Imaging (QPI) from defocus.\n",
+    "The simulation and reconstruction are based on partially coherent optical diffraction tomography (ODT):\n",
+    "\n",
+    "J. M. Soto, J. A. Rodrigo, and T. Alieva, \"Label-free quantitative 3D tomographic imaging\n",
+    "for partially coherent light microscopy,\" Opt. Express 25, 15699-15712 (2017)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f0ce6c0d",
+   "metadata": {
+    "cell_marker": "\"\"\""
+   },
+   "source": [
+    "## Setup and Imports\n",
+    "First, let's install the latest version of waveorder from the main branch"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "68bff0a9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "import subprocess\n",
+    "\n",
+    "# Install latest waveorder from main branch\n",
+    "subprocess.check_call(\n",
+    "    [\n",
+    "        sys.executable,\n",
+    "        \"-m\",\n",
+    "        \"pip\",\n",
+    "        \"install\",\n",
+    "        \"git+https://github.com/mehta-lab/waveorder.git@main\",\n",
+    "    ]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "216ce117",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from pathlib import Path\n",
+    "from platformdirs import user_data_dir\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from waveorder.models import phase_thick_3d\n",
+    "from waveorder.visuals import jupyter_visuals"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aebdbd6e",
+   "metadata": {
+    "cell_marker": "\"\"\""
+   },
+   "source": [
+    "## Forward Simulation Parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ebb327b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Parameters (all lengths in micrometers)\n",
+    "simulation_arguments = {\n",
+    "    \"zyx_shape\": (100, 256, 256),  # 3D shape of the volume\n",
+    "    \"yx_pixel_size\": 6.5 / 63,  # Lateral pixel size\n",
+    "    \"z_pixel_size\": 0.25,  # Axial pixel size\n",
+    "    \"index_of_refraction_media\": 1.3,  # Refractive index of medium\n",
+    "}\n",
+    "\n",
+    "phantom_arguments = {\n",
+    "    \"index_of_refraction_sample\": 1.50,  # Refractive index of sample\n",
+    "    \"sphere_radius\": 5,  # Radius of test sphere in microns\n",
+    "}\n",
+    "\n",
+    "transfer_function_arguments = {\n",
+    "    \"z_padding\": 0,  # Padding in z direction\n",
+    "    \"wavelength_illumination\": 0.532,  # Wavelength in microns\n",
+    "    \"numerical_aperture_illumination\": 0.9,  # Illumination NA\n",
+    "    \"numerical_aperture_detection\": 1.2,  # Detection NA\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e80f50a2",
+   "metadata": {
+    "cell_marker": "\"\"\""
+   },
+   "source": [
+    "## Generate Test Phantom"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "31ce02f3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a phantom\n",
+    "zyx_phase = phase_thick_3d.generate_test_phantom(\n",
+    "    **simulation_arguments, **phantom_arguments\n",
+    ")\n",
+    "\n",
+    "# Show 5 z-slices of the phantom\n",
+    "z_slices = np.linspace(0, zyx_phase.shape[0] - 1, 5).astype(int)\n",
+    "fig, axes = plt.subplots(1, 5, figsize=(15, 3))\n",
+    "for i, z in enumerate(z_slices):\n",
+    "    axes[i].imshow(zyx_phase[z], cmap=\"gray\", origin=\"lower\")\n",
+    "    axes[i].set_title(f\"z = {z}\")\n",
+    "    axes[i].axis(\"off\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "40b8c5a7",
+   "metadata": {
+    "cell_marker": "\"\"\""
+   },
+   "source": [
+    "## Calculate Transfer Functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "39c3b649",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Calculate real and imaginary parts of the transfer function\n",
+    "(\n",
+    "    real_potential_transfer_function,\n",
+    "    imag_potential_transfer_function,\n",
+    ") = phase_thick_3d.calculate_transfer_function(\n",
+    "    **simulation_arguments, **transfer_function_arguments\n",
+    ")\n",
+    "# Convert complex valued transfer functions to real valued\n",
+    "real_potential_transfer_function = np.fft.ifftshift(\n",
+    "    real_potential_transfer_function.real\n",
+    ")\n",
+    "imag_potential_transfer_function = np.fft.ifftshift(\n",
+    "    imag_potential_transfer_function.real\n",
+    ")\n",
+    "\n",
+    "# Visualize transfer functions\n",
+    "fig, axes = plt.subplots(2, 5, figsize=(15, 6))\n",
+    "for i, z in enumerate(z_slices):\n",
+    "    axes[0, i].imshow(\n",
+    "        real_potential_transfer_function[z], cmap=\"gray\", origin=\"lower\"\n",
+    "    )\n",
+    "    axes[0, i].set_title(f\"Real TF, z = {z}\")\n",
+    "    axes[0, i].axis(\"off\")\n",
+    "    axes[1, i].imshow(\n",
+    "        imag_potential_transfer_function[z], cmap=\"gray\", origin=\"lower\"\n",
+    "    )\n",
+    "    axes[1, i].set_title(f\"Imag TF, z = {z}\")\n",
+    "    axes[1, i].axis(\"off\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d1b5d13b",
+   "metadata": {
+    "cell_marker": "\"\"\""
+   },
+   "source": [
+    "## Forward Simulation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ec16b55f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Simulate defocus data\n",
+    "zyx_data = phase_thick_3d.apply_transfer_function(\n",
+    "    zyx_phase,\n",
+    "    real_potential_transfer_function,\n",
+    "    transfer_function_arguments[\"z_padding\"],\n",
+    "    brightness=1e3,\n",
+    ")\n",
+    "\n",
+    "# Visualize simulated data\n",
+    "fig, axes = plt.subplots(1, 5, figsize=(15, 3))\n",
+    "for i, z in enumerate(z_slices):\n",
+    "    axes[i].imshow(zyx_data[z], cmap=\"gray\", origin=\"lower\")\n",
+    "    axes[i].set_title(f\"Data, z = {z}\")\n",
+    "    axes[i].axis(\"off\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "756895f3",
+   "metadata": {
+    "cell_marker": "\"\"\""
+   },
+   "source": [
+    "## Phase Reconstruction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ac7e77c2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Reconstruct phase\n",
+    "zyx_recon = phase_thick_3d.apply_inverse_transfer_function(\n",
+    "    zyx_data,\n",
+    "    real_potential_transfer_function,\n",
+    "    imag_potential_transfer_function,\n",
+    "    transfer_function_arguments[\"z_padding\"],\n",
+    ")\n",
+    "\n",
+    "# Visualize reconstruction compared to ground truth\n",
+    "fig, axes = plt.subplots(2, 5, figsize=(15, 6))\n",
+    "for i, z in enumerate(z_slices):\n",
+    "    axes[0, i].imshow(zyx_phase[z], cmap=\"gray\", origin=\"lower\")\n",
+    "    axes[0, i].set_title(f\"Ground Truth, z = {z}\")\n",
+    "    axes[0, i].axis(\"off\")\n",
+    "    axes[1, i].imshow(zyx_recon[z], cmap=\"gray\", origin=\"lower\")\n",
+    "    axes[1, i].set_title(f\"Reconstruction, z = {z}\")\n",
+    "    axes[1, i].axis(\"off\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "encoding": "# -*- coding: utf-8 -*-",
+   "formats": "py:percent,ipynb"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/examples/demos/QPI_defocus/QPI_defocus_simulation.ipynb
+++ b/docs/examples/demos/QPI_defocus/QPI_defocus_simulation.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "7bf01653",
+   "id": "2318a692",
    "metadata": {
     "cell_marker": "\"\"\""
    },
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "46dd50ba",
+   "id": "ffbc4a7d",
    "metadata": {
     "cell_marker": "\"\"\""
    },
@@ -30,7 +30,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "80761384",
+   "id": "a6652364",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -52,7 +52,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "66256a1a",
+   "id": "c0b2d37a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -69,7 +69,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8c233e46",
+   "id": "dd94a687",
    "metadata": {
     "cell_marker": "\"\"\""
    },
@@ -80,7 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "add7b620",
+   "id": "678efb51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -107,7 +107,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f7e7a7ad",
+   "id": "3653ede7",
    "metadata": {
     "cell_marker": "\"\"\""
    },
@@ -118,13 +118,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c14d5942",
+   "id": "f77c22cd",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Create a phantom\n",
     "\n",
-    "# Star target\n",
+    "# 3D Star target\n",
     "star, _, _ = util.generate_star_target(\n",
     "    yx_shape=simulation_arguments[\"zyx_shape\"][1:3]\n",
     ")\n",
@@ -161,7 +161,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4d2fe109",
+   "id": "685b2b8d",
    "metadata": {
     "cell_marker": "\"\"\""
    },
@@ -172,7 +172,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "08db7d6c",
+   "id": "02f03b11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -211,7 +211,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "651fe7b0",
+   "id": "113155ee",
    "metadata": {
     "cell_marker": "\"\"\""
    },
@@ -222,7 +222,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62ada3b4",
+   "id": "2bb41cb2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -248,7 +248,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9b71cbe0",
+   "id": "b96f7a70",
    "metadata": {
     "cell_marker": "\"\"\""
    },
@@ -259,7 +259,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cd07f7cc",
+   "id": "5b6391ea",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -303,7 +303,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3f8b73c4",
+   "id": "d4268c90",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/docs/examples/demos/QPI_defocus/QPI_defocus_simulation.py
+++ b/docs/examples/demos/QPI_defocus/QPI_defocus_simulation.py
@@ -91,7 +91,7 @@ transfer_function_arguments = {
 # %%
 # Create a phantom
 
-# Star target
+# 3D Star target
 star, _, _ = util.generate_star_target(
     yx_shape=simulation_arguments["zyx_shape"][1:3]
 )

--- a/docs/examples/demos/QPI_defocus/QPI_defocus_simulation.py
+++ b/docs/examples/demos/QPI_defocus/QPI_defocus_simulation.py
@@ -116,10 +116,10 @@ plt.show()
     **simulation_arguments, **transfer_function_arguments
 )
 # Convert complex valued transfer functions to real valued
-real_potential_transfer_function = np.fft.ifftshift(
+real_potential_transfer_function_shifted = np.fft.ifftshift(
     real_potential_transfer_function.real
 )
-imag_potential_transfer_function = np.fft.ifftshift(
+imag_potential_transfer_function_shifted = np.fft.ifftshift(
     imag_potential_transfer_function.real
 )
 
@@ -127,12 +127,12 @@ imag_potential_transfer_function = np.fft.ifftshift(
 fig, axes = plt.subplots(2, 5, figsize=(15, 6))
 for i, z in enumerate(z_slices):
     axes[0, i].imshow(
-        real_potential_transfer_function[z], cmap="gray", origin="lower"
+        real_potential_transfer_function_shifted[z], cmap="gray", origin="lower"
     )
     axes[0, i].set_title(f"Real TF, z = {z}")
     axes[0, i].axis("off")
     axes[1, i].imshow(
-        imag_potential_transfer_function[z], cmap="gray", origin="lower"
+        imag_potential_transfer_function_shifted[z], cmap="gray", origin="lower"
     )
     axes[1, i].set_title(f"Imag TF, z = {z}")
     axes[1, i].axis("off")
@@ -187,3 +187,5 @@ for i, z in enumerate(z_slices):
     axes[1, i].axis("off")
 plt.tight_layout()
 plt.show()
+
+# %%

--- a/docs/examples/demos/QPI_defocus/QPI_defocus_simulation.py
+++ b/docs/examples/demos/QPI_defocus/QPI_defocus_simulation.py
@@ -176,11 +176,13 @@ zyx_data = phase_thick_3d.apply_transfer_function(
     transfer_function_arguments["z_padding"],
     brightness=1e3,
 )
-
+zyx_data_norm = (zyx_data - zyx_data.min()) / (zyx_data.max() - zyx_data.min())
 # Visualize simulated data
 fig, axes = plt.subplots(1, 5, figsize=(15, 3))
 for i, z in enumerate(z_slices):
-    axes[i].imshow(zyx_data[z], cmap="gray", origin="lower")
+    axes[i].imshow(
+        zyx_data_norm[z], cmap="gray", origin="lower", vmin=0, vmax=1
+    )
     axes[i].set_title(f"Data, z = {z - z_center}")
     axes[i].axis("off")
 plt.tight_layout()

--- a/docs/examples/demos/QPI_defocus/QPI_defocus_simulation.py
+++ b/docs/examples/demos/QPI_defocus/QPI_defocus_simulation.py
@@ -1,0 +1,189 @@
+# -*- coding: utf-8 -*-
+# ---
+# jupyter:
+#   jupytext:
+#     formats: py:percent,ipynb
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.15.2
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown]
+"""
+# Quantitative Phase Imaging from Defocus Demo
+
+This notebook demonstrates forward simulation and reconstruction for Quantitative Phase Imaging (QPI) from defocus.
+The simulation and reconstruction are based on partially coherent optical diffraction tomography (ODT):
+
+J. M. Soto, J. A. Rodrigo, and T. Alieva, "Label-free quantitative 3D tomographic imaging
+for partially coherent light microscopy," Opt. Express 25, 15699-15712 (2017)
+"""
+
+# %% [markdown]
+"""
+## Setup and Imports
+First, let's install the latest version of waveorder from the main branch
+"""
+
+# %%
+import sys
+import subprocess
+
+# Install latest waveorder from main branch
+subprocess.check_call(
+    [
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "git+https://github.com/mehta-lab/waveorder.git@main",
+    ]
+)
+
+# %%
+import numpy as np
+from pathlib import Path
+from platformdirs import user_data_dir
+import matplotlib.pyplot as plt
+
+from waveorder.models import phase_thick_3d
+from waveorder.visuals import jupyter_visuals
+
+# %% [markdown]
+"""
+## Forward Simulation Parameters
+"""
+
+# %%
+# Parameters (all lengths in micrometers)
+simulation_arguments = {
+    "zyx_shape": (100, 256, 256),  # 3D shape of the volume
+    "yx_pixel_size": 6.5 / 63,  # Lateral pixel size
+    "z_pixel_size": 0.25,  # Axial pixel size
+    "index_of_refraction_media": 1.3,  # Refractive index of medium
+}
+
+phantom_arguments = {
+    "index_of_refraction_sample": 1.50,  # Refractive index of sample
+    "sphere_radius": 5,  # Radius of test sphere in microns
+}
+
+transfer_function_arguments = {
+    "z_padding": 0,  # Padding in z direction
+    "wavelength_illumination": 0.532,  # Wavelength in microns
+    "numerical_aperture_illumination": 0.9,  # Illumination NA
+    "numerical_aperture_detection": 1.2,  # Detection NA
+}
+
+# %% [markdown]
+"""
+## Generate Test Phantom
+"""
+
+# %%
+# Create a phantom
+zyx_phase = phase_thick_3d.generate_test_phantom(
+    **simulation_arguments, **phantom_arguments
+)
+
+# Show 5 z-slices of the phantom
+z_slices = np.linspace(0, zyx_phase.shape[0] - 1, 5).astype(int)
+fig, axes = plt.subplots(1, 5, figsize=(15, 3))
+for i, z in enumerate(z_slices):
+    axes[i].imshow(zyx_phase[z], cmap="gray", origin="lower")
+    axes[i].set_title(f"z = {z}")
+    axes[i].axis("off")
+plt.tight_layout()
+plt.show()
+
+# %% [markdown]
+"""
+## Calculate Transfer Functions
+"""
+
+# %%
+# Calculate real and imaginary parts of the transfer function
+(
+    real_potential_transfer_function,
+    imag_potential_transfer_function,
+) = phase_thick_3d.calculate_transfer_function(
+    **simulation_arguments, **transfer_function_arguments
+)
+# Convert complex valued transfer functions to real valued
+real_potential_transfer_function = np.fft.ifftshift(
+    real_potential_transfer_function.real
+)
+imag_potential_transfer_function = np.fft.ifftshift(
+    imag_potential_transfer_function.real
+)
+
+# Visualize transfer functions
+fig, axes = plt.subplots(2, 5, figsize=(15, 6))
+for i, z in enumerate(z_slices):
+    axes[0, i].imshow(
+        real_potential_transfer_function[z], cmap="gray", origin="lower"
+    )
+    axes[0, i].set_title(f"Real TF, z = {z}")
+    axes[0, i].axis("off")
+    axes[1, i].imshow(
+        imag_potential_transfer_function[z], cmap="gray", origin="lower"
+    )
+    axes[1, i].set_title(f"Imag TF, z = {z}")
+    axes[1, i].axis("off")
+plt.tight_layout()
+plt.show()
+
+# %% [markdown]
+"""
+## Forward Simulation
+"""
+
+# %%
+# Simulate defocus data
+zyx_data = phase_thick_3d.apply_transfer_function(
+    zyx_phase,
+    real_potential_transfer_function,
+    transfer_function_arguments["z_padding"],
+    brightness=1e3,
+)
+
+# Visualize simulated data
+fig, axes = plt.subplots(1, 5, figsize=(15, 3))
+for i, z in enumerate(z_slices):
+    axes[i].imshow(zyx_data[z], cmap="gray", origin="lower")
+    axes[i].set_title(f"Data, z = {z}")
+    axes[i].axis("off")
+plt.tight_layout()
+plt.show()
+
+# %% [markdown]
+"""
+## Phase Reconstruction
+"""
+
+# %%
+# Reconstruct phase
+zyx_recon = phase_thick_3d.apply_inverse_transfer_function(
+    zyx_data,
+    real_potential_transfer_function,
+    imag_potential_transfer_function,
+    transfer_function_arguments["z_padding"],
+)
+
+# Visualize reconstruction compared to ground truth
+fig, axes = plt.subplots(2, 5, figsize=(15, 6))
+for i, z in enumerate(z_slices):
+    axes[0, i].imshow(zyx_phase[z], cmap="gray", origin="lower")
+    axes[0, i].set_title(f"Ground Truth, z = {z}")
+    axes[0, i].axis("off")
+    axes[1, i].imshow(zyx_recon[z], cmap="gray", origin="lower")
+    axes[1, i].set_title(f"Reconstruction, z = {z}")
+    axes[1, i].axis("off")
+plt.tight_layout()
+plt.show()

--- a/docs/examples/demos/README.md
+++ b/docs/examples/demos/README.md
@@ -1,0 +1,22 @@
+# WaveOrder Demos
+
+The demos in this folder illustrate image formation models and reconstruction algorithms using simulated data. Each demo illustrates image formation and reconstruction for a specific computational imaging method.
+
+The demos are provided in two formats:
+
+1. Python scripts with cell delimiters that can be run interactively using a local Python installation and an IDE such as vscode.
+2. Jupyter Notebooks that can be run using Google Colab using the URL of following format.
+`https://colab.research.google.com/github/mehta-lab/waveorder/blob/<branch>/<path to notebook>`
+
+
+## QPI (Quantitative Phase Imaging) from defocus
+- [Python script](./QPI_defocus/QPI_defocus_simulation.py)
+- [Jupyter Notebook on Google Colab](https://colab.research.google.com/github/mehta-lab/waveorder/blob/demos-aqlm/docs/examples/demos/QPI_defocus/QPI_defocus_simulation.ipynb)
+
+## QLIPP (Quantitative label-free imaging with phase and polarization)
+- [Python script](./QLIPP/QLIPP_simulation.py)
+- [Jupyter Notebook on Google Colab](https://colab.research.google.com/github/mehta-lab/waveorder/blob/demos-aqlm/docs/examples/demos/QLIPP/QLIPP_simulation.ipynb)
+
+
+## Developer notes:
+- The notebooks are generated from the Python scripts using jupytext.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,8 +68,10 @@ all = [
   "napari[pyqt6]",
   "napari-ome-zarr>=0.3.2", # drag and drop convenience
   "pycromanager==0.27.2",
-  "jupyter"
-]
+  "jupyter",
+  "jupytext"
+  ]
+  
 dev = [
   "black==25.1.0",
   "hypothesis",
@@ -78,6 +80,8 @@ dev = [
   "pytest-qt",
   "pytest>=5.0.0",
   "tox",
+  "jupyter",
+  "jupytext"
 ]
 
 [project.urls]


### PR DESCRIPTION
I am adding two demos in the `examples/demos/` folder. These are based on simulations on `examples/maintanence` folder. During AQLM, we will finetune these demos. It would make sense to turn the `examples/maintenance` into non-interactive tests after we merge this PR. 

- [x] Make jupytext dependency of dev installation.
- [x] QLIPP forward simulation and reconstruction
- [x] test QLIPP forward simulation and reconstruction using Google Colab: https://colab.research.google.com/github/mehta-lab/waveorder/blob/demos-aqlm/docs/examples/demos/QLIPP/QLIPP_simulation.ipynb 
- [x] QPI from defocus simulation and reconstruction
- [x] test QPI from defocus simulation and reconstruction using Google Colab: 
https://colab.research.google.com/github/mehta-lab/waveorder/blob/demos-aqlm/docs/examples/demos/QPI_defocus/QPI_defocus_simulation.ipynb
- [x] QPI from defocus reconstruction with experimental data 
- [x] test QPI from defocus reconstruction with experimental data https://colab.research.google.com/github/mehta-lab/waveorder/blob/demos-aqlm/docs/examples/demos/QPI_defocus/QPI_defocus_experiment.ipynb