### PR TITLE
Instructions to install from pip and github

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,17 +201,17 @@ conda create -y -n waveorder python=3.12
 conda activate waveorder
 ```
 
-Install `waveorder` from PyPI:
+(Option 1) Install a stable version of `waveorder` from PyPI:
 
 ```sh
 pip install waveorder
 ```
 
-(Optional) Install all visualization dependencies (napari, jupyter), clone the repository, and run an example script:
+(Option 2) Install the latest version of `waveorder` from GitHub with all visualization dependencies (napari, jupyter), clone the repository, and run an example script:
 ```sh
-pip install "waveorder[all]"
+pip install "git+https://github.com/mehta-lab/waveorder.git@main#egg=waveorder[all]"
 git clone https://github.com/mehta-lab/waveorder.git
-python waveorder/examples/models/phase_thick_3d.py
+python waveorder/docs/examples/models/phase_thick_3d.py
 ```
 
 (M1 users) `pytorch` has [incomplete GPU support](https://github.com/pytorch/pytorch/issues/77764),


### PR DESCRIPTION
`pip install waveorder` installs the latest stable release from PyPI, which is often incompatible with the latest changes in the GitHub README. 

This change clarifies two major ways to install: (1) from PyPI, and (2) from Github for running examples. 