### PR TITLE
Settings-ratio checks should give warnings, not errors

### DIFF
--- a/tests/cli_tests/test_settings.py
+++ b/tests/cli_tests/test_settings.py
@@ -69,7 +69,7 @@ def test_phase_tf_settings():
         )
 
     # Inconsistent units
-    with pytest.raises(Warning):
+    with pytest.warns(UserWarning):
         settings.PhaseTransferFunctionSettings(
             yx_pixel_size=650, z_pixel_size=0.3
         )
@@ -84,7 +84,7 @@ def test_fluor_tf_settings():
         wavelength_emission=0.500, yx_pixel_size=0.2
     )
 
-    with pytest.raises(Warning):
+    with pytest.warns(UserWarning):
         settings.FluorescenceTransferFunctionSettings(
             wavelength_emission=0.500, yx_pixel_size=2000
         )

--- a/waveorder/cli/settings.py
+++ b/waveorder/cli/settings.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 from pathlib import Path
 from typing import List, Literal, Optional, Union
 
@@ -79,8 +80,9 @@ class FourierTransferFunctionSettings(MyBaseModel):
         yx_pixel_size = values["yx_pixel_size"]
         ratio = yx_pixel_size / v
         if ratio < 1.0 / 20 or ratio > 20:
-            raise Warning(
-                f"yx_pixel_size ({yx_pixel_size}) / z_pixel_size ({v}) = {ratio}. Did you use consistent units?"
+            warnings.warn(
+                f"yx_pixel_size ({yx_pixel_size}) / z_pixel_size ({v}) = {ratio}. Did you use consistent units?",
+                UserWarning,
             )
         return v
 
@@ -117,8 +119,9 @@ class FluorescenceTransferFunctionSettings(FourierTransferFunctionSettings):
         yx_pixel_size = values.get("yx_pixel_size")
         ratio = yx_pixel_size / v
         if ratio < 1.0 / 20 or ratio > 20:
-            raise Warning(
-                f"yx_pixel_size ({yx_pixel_size}) / wavelength_illumination ({v}) = {ratio}. Did you use consistent units?"
+            warnings.warn(
+                f"yx_pixel_size ({yx_pixel_size}) / wavelength_illumination ({v}) = {ratio}. Did you use consistent units?",
+                UserWarning,
             )
         return v
 


### PR DESCRIPTION
`waveorder` checks that the ratios of several input parameters are not too different to guard against incorrect units. This PR changes these checks to raise warnings, not errors, because `waveorder` sometimes needs to reconstruct data collected with far-less-than-Nyquist sampling. 