### PR TITLE
Exclude `docs/examples/deprecated` from wheel

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+prune docs/examples/deprecated


### PR DESCRIPTION
Fixes #456. 

Excluding `docs/examples/deprecated` reduces the wheel size from ~65MB to ~7MB. 

The next largest contributors are documentation images. 