### PR TITLE
Handle single position .zarr stores as CLI input

### DIFF
--- a/tests/util_tests/test_create_empty.py
+++ b/tests/util_tests/test_create_empty.py
@@ -3,7 +3,11 @@ from pathlib import Path
 import numpy as np
 from iohub.ngff import Position, open_ome_zarr
 
-from waveorder.cli.utils import create_empty_hcs_zarr
+from waveorder.cli.utils import (
+    create_empty_hcs_zarr,
+    generate_valid_position_key,
+    is_single_position_store,
+)
 
 
 def test_create_empty_hcs_zarr(tmp_path):
@@ -58,3 +62,50 @@ def test_create_empty_hcs_zarr(tmp_path):
             position_path /= element
         with open_ome_zarr(position_path, mode="r") as position:
             assert position.channel_names == channel_names
+
+
+def test_generate_valid_position_key():
+    """Test that position key generation produces valid alphanumeric keys."""
+    # Test first few positions
+    assert generate_valid_position_key(0) == ("A", "1", "0")
+    assert generate_valid_position_key(1) == ("A", "2", "0")
+    assert generate_valid_position_key(9) == ("A", "10", "0")
+    assert generate_valid_position_key(10) == ("B", "1", "0")
+
+    # Test all keys are alphanumeric
+    for i in range(20):
+        key = generate_valid_position_key(i)
+        for part in key:
+            assert part.isalnum(), f"Part '{part}' is not alphanumeric"
+
+
+def test_single_position_detection(tmp_path):
+    """Test single position store detection."""
+    # Create an HCS plate structure first
+    hcs_plate = tmp_path / "plate.zarr"
+    with open_ome_zarr(
+        str(hcs_plate), layout="hcs", mode="a", channel_names=["test"]
+    ) as plate:
+        position = plate.create_position("A", "1", "0")
+        position.create_zeros(
+            name="0",
+            shape=(1, 1, 10, 512, 512),
+            chunks=(1, 1, 1, 256, 256),
+            dtype=np.uint16,
+        )
+
+    hcs_position = hcs_plate / "A" / "1" / "0"
+    assert not is_single_position_store(
+        hcs_position
+    ), "Should detect as HCS plate position"
+
+    # Create a simple single-position zarr store path (simulate what happens in real usage)
+    # In real usage, the path would be something like /path/to/single-pos.zarr/0/
+    # and when we try to open 3 levels up, it would fail
+    fake_single_pos = tmp_path / "does-not-exist" / "single.zarr" / "0"
+    fake_single_pos.mkdir(parents=True)
+
+    # This should detect as single position because 3 levels up doesn't exist as plate
+    assert is_single_position_store(
+        fake_single_pos
+    ), "Should detect as single position"

--- a/waveorder/cli/utils.py
+++ b/waveorder/cli/utils.py
@@ -9,6 +9,38 @@ from iohub.ngff.models import TransformationMeta
 from numpy.typing import DTypeLike
 
 
+def generate_valid_position_key(index: int) -> tuple[str, str, str]:
+    """Generate a valid HCS position key for single-position stores.
+
+    Args:
+        index: Position index (0-based)
+
+    Returns:
+        Tuple of (row, column, field) with alphanumeric characters only
+    """
+    row = chr(65 + (index // 10))  # A, B, C, etc.
+    column = str((index % 10) + 1)  # 1, 2, 3, etc.
+    field = "0"  # Always 0 for single positions
+    return (row, column, field)
+
+
+def is_single_position_store(position_path: Path) -> bool:
+    """Check if a position path is from a single-position store (not HCS plate).
+
+    Args:
+        position_path: Path to the position directory
+
+    Returns:
+        True if it's a single-position store, False if it's part of an HCS plate
+    """
+    try:
+        # Try to open as HCS plate 3 levels up
+        open_ome_zarr(position_path.parent.parent.parent, mode="r")
+        return False  # Successfully opened as plate
+    except RuntimeError:
+        return True  # Not a plate structure
+
+
 def create_empty_hcs_zarr(
     store_path: Path,
     position_keys: list[Tuple[str]],


### PR DESCRIPTION
Fixes #484. 

Takes single-position zarr stores as input, and always outputs an HCS zarr store. By default names the single position `A/1/0`. 