### PR TITLE
Faster tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 
 on:
   push:
-    # branches: [main]  # uncomment if branch-PRs are causing dual triggers
+    branches: [main]
   pull_request:
 
 jobs:

--- a/docs/examples/maintenance/PTI_simulation/PTI_Simulation_Forward_2D3D.py
+++ b/docs/examples/maintenance/PTI_simulation/PTI_Simulation_Forward_2D3D.py
@@ -1,8 +1,9 @@
-""" 
+"""
 Forward simulation of uniaxial permittivity tensor imaging
 ===========================================================
 Forward simulation of uniaxial permittivity tensor imaging
 """
+
 ####################################################################
 # Forward simulation of uniaxial permittivity tensor imaging (uPTI)#
 # This simulation is based on the uPTI paper                       #
@@ -51,8 +52,8 @@ from waveorder.visuals import jupyter_visuals
 ### Parameters of sample
 
 sample_type = "2D"  # 2D or 3D
-N = 50  # number of pixel in y dimension
-M = 50  # number of pixel in x dimension
+N = 30  # number of pixel in y dimension
+M = 30  # number of pixel in x dimension
 L = 26  # number of layers in z dimension
 z_layer = L // 2  # default z-slice to display in XY views.
 y_layer = M // 2  # default y-slice to display in XZ views.

--- a/tests/models/test_phase_thick_3d.py
+++ b/tests/models/test_phase_thick_3d.py
@@ -28,8 +28,8 @@ def simulate_phase_recon(
     z_pixel_size_um=0.1,
     yx_pixel_size_um=6.5 / 63,
 ):
-    z_fov_um = 50
-    yx_fov_um = 50
+    z_fov_um = 25
+    yx_fov_um = 20
 
     n_z = np.int32(z_fov_um / z_pixel_size_um)
     n_yx = np.int32(yx_fov_um / yx_pixel_size_um)
@@ -89,13 +89,17 @@ def simulate_phase_recon(
     return recon_center
 
 
-def test_phase_invariance():
-    recon = simulate_phase_recon()
-
-    # test z pixel size invariance
-    recon1 = simulate_phase_recon(z_pixel_size_um=0.3)
-    assert np.abs((recon1 - recon) / recon) < 0.02
-
-    # test yx pixel size invariance
-    recon2 = simulate_phase_recon(yx_pixel_size_um=0.7 * 6.5 / 63)
-    assert np.abs((recon2 - recon) / recon) < 0.02
+@pytest.mark.parametrize(
+    "z_pixel_size_um, yx_pixel_size_um, tolerance",
+    [
+        (0.1, 6.5 / 63, 0.02),  # baseline
+        (0.15, 6.5 / 63, 0.02),  # test z pixel size invariance
+        (0.1, 0.8 * 6.5 / 63, 0.02),  # test yx pixel size invariance
+    ],
+)
+def test_phase_invariance(z_pixel_size_um, yx_pixel_size_um, tolerance):
+    baseline = simulate_phase_recon()
+    recon = simulate_phase_recon(
+        z_pixel_size_um=z_pixel_size_um, yx_pixel_size_um=yx_pixel_size_um
+    )
+    assert np.abs((recon - baseline) / baseline) < tolerance


### PR DESCRIPTION
This PR makes two tests smaller (phase invariance test and legacy PTI simulation) and fixes a test double trigger. These shorten the test suite from ~25 minutes (bottlenecked on macOS tests) to ~8 minutes (~bottlenecked on Windows pip installation).