### PR TITLE
Package layout fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,8 +118,5 @@ line_length = 79
 [tool.setuptools_scm]
 write_to = "waveorder/_version.py"
 
-[tool.setuptools.packages.find]
-where = ["waveorder"]
-
 [tool.setuptools.package-data]
 "*" = ["*.yaml"]


### PR DESCRIPTION
Fixes a installation problem introduced by #480.

Specifying `[tool.setuptools.packages.find]; where = ["waveorder"]` looks for a package named `waveorder` inside `waveorder` which was one too deep...leading to import issues. 