### PR TITLE
Confocal fluorescence reconstructions

### DIFF
--- a/docs/examples/configs/fluorescence.yml
+++ b/docs/examples/configs/fluorescence.yml
@@ -11,6 +11,7 @@ fluorescence:
     index_of_refraction_media: 1.3
     numerical_aperture_detection: 1.2
     wavelength_emission: 0.507
+    confocal_pinhole_diameter: null
   apply_inverse:
     reconstruction_algorithm: Tikhonov
     regularization_strength: 0.001

--- a/docs/examples/models/isotropic_fluorescent_thick_3d.py
+++ b/docs/examples/models/isotropic_fluorescent_thick_3d.py
@@ -4,6 +4,7 @@ Isotropic fluorescent thick 3d
 
 Isotropic fluorescent thick 3d summary
 """
+
 import napari
 import numpy as np
 
@@ -22,6 +23,7 @@ transfer_function_arguments = {
     "z_padding": 0,
     "index_of_refraction_media": 1.3,
     "numerical_aperture_detection": 1.2,
+    "confocal_pinhole_diameter": None,  # Set to a value (e.g., 1.0) for confocal
 }
 
 # Create a phantom

--- a/tests/cli_tests/test_reconstruct.py
+++ b/tests/cli_tests/test_reconstruct.py
@@ -98,7 +98,7 @@ def test_reconstruct(tmp_input_path_zarr):
 
 def test_append_channel_reconstruction(tmp_input_path_zarr):
     input_path, tmp_config_yml = tmp_input_path_zarr
-    output_path = input_path.with_name(f"output.zarr")
+    output_path = input_path.with_name("output.zarr")
 
     # Generate input "dataset"
     channel_names = [f"State{x}" for x in range(4)] + ["GFP"]
@@ -133,8 +133,8 @@ def test_append_channel_reconstruction(tmp_input_path_zarr):
         phase=None,
         fluorescence=settings.FluorescenceSettings(),
     )
-    biref_config_path = tmp_config_yml.with_name(f"biref.yml")
-    fluor_config_path = tmp_config_yml.with_name(f"fluor.yml")
+    biref_config_path = tmp_config_yml.with_name("biref.yml")
+    fluor_config_path = tmp_config_yml.with_name("fluor.yml")
 
     utils.model_to_yaml(biref_settings, biref_config_path)
     utils.model_to_yaml(fluor_settings, fluor_config_path)
@@ -190,7 +190,7 @@ def test_append_channel_reconstruction(tmp_input_path_zarr):
 def test_fluorescence_2d_reconstruction(tmp_input_path_zarr):
     """Test 2D fluorescence reconstruction through CLI"""
     input_path, tmp_config_yml = tmp_input_path_zarr
-    output_path = input_path.with_name(f"fluor_2d_output.zarr")
+    output_path = input_path.with_name("fluor_2d_output.zarr")
 
     # Generate input "dataset" with fluorescence channel
     channel_names = [f"State{x}" for x in range(4)] + ["GFP"]
@@ -217,7 +217,7 @@ def test_fluorescence_2d_reconstruction(tmp_input_path_zarr):
         phase=None,
         fluorescence=settings.FluorescenceSettings(),
     )
-    fluor_2d_config_path = tmp_config_yml.with_name(f"fluor_2d.yml")
+    fluor_2d_config_path = tmp_config_yml.with_name("fluor_2d.yml")
     utils.model_to_yaml(fluor_2d_settings, fluor_2d_config_path)
 
     # Run 2D fluorescence reconstruction

--- a/tests/models/test_isotropic_fluorescent_thick_3d.py
+++ b/tests/models/test_isotropic_fluorescent_thick_3d.py
@@ -1,6 +1,33 @@
 import torch
 
+from waveorder import util
 from waveorder.models import isotropic_fluorescent_thick_3d
+
+
+def test_pinhole_aperture_otf_small_diameter():
+    """Test that pinhole OTF is broader for smaller diameter."""
+    yx_shape = (128, 128)
+    yx_pixel_size = 0.1
+    radial_frequencies = util.generate_radial_frequencies(
+        yx_shape, yx_pixel_size
+    )
+
+    # Small pinhole should give broad OTF (higher mean value)
+    small_pinhole_otf = (
+        isotropic_fluorescent_thick_3d._calculate_pinhole_aperture_otf(
+            radial_frequencies, pinhole_diameter=0.1
+        )
+    )
+
+    # Large pinhole should give narrow OTF (lower mean, more concentrated)
+    large_pinhole_otf = (
+        isotropic_fluorescent_thick_3d._calculate_pinhole_aperture_otf(
+            radial_frequencies, pinhole_diameter=5.0
+        )
+    )
+
+    # Small pinhole OTF should have higher mean (broader)
+    assert small_pinhole_otf.mean() > large_pinhole_otf.mean()
 
 
 def test_calculate_transfer_function():
@@ -18,6 +45,37 @@ def test_calculate_transfer_function():
     )
 
     assert transfer_function.shape == (20 + 2 * z_padding, 100, 101)
+
+
+def test_confocal_otf_extended_support():
+    """Test that confocal OTF has extended support compared to widefield."""
+    z_padding = 0
+    zyx_shape = (20, 64, 64)
+    params = {
+        "zyx_shape": zyx_shape,
+        "yx_pixel_size": 0.2,
+        "z_pixel_size": 0.5,
+        "wavelength_emission": 0.5,
+        "z_padding": z_padding,
+        "index_of_refraction_media": 1.0,
+        "numerical_aperture_detection": 0.55,
+    }
+
+    # Widefield OTF
+    otf_widefield = isotropic_fluorescent_thick_3d.calculate_transfer_function(
+        **params, confocal_pinhole_diameter=None
+    )
+
+    # Confocal OTF with small pinhole
+    otf_confocal = isotropic_fluorescent_thick_3d.calculate_transfer_function(
+        **params, confocal_pinhole_diameter=0.5
+    )
+
+    # Confocal OTF should have more high-frequency content (extended support)
+    threshold = 0.01
+    widefield_support = (torch.abs(otf_widefield) > threshold).sum()
+    confocal_support = (torch.abs(otf_confocal) > threshold).sum()
+    assert confocal_support > widefield_support
 
 
 def test_apply_inverse_transfer_function():

--- a/waveorder/cli/settings.py
+++ b/waveorder/cli/settings.py
@@ -113,6 +113,7 @@ class PhaseTransferFunctionSettings(
 
 class FluorescenceTransferFunctionSettings(FourierTransferFunctionSettings):
     wavelength_emission: PositiveFloat = 0.507
+    confocal_pinhole_diameter: Optional[PositiveFloat] = None
 
     @validator("wavelength_emission")
     def warn_unit_consistency(cls, v, values):

--- a/waveorder/models/isotropic_fluorescent_thick_3d.py
+++ b/waveorder/models/isotropic_fluorescent_thick_3d.py
@@ -33,6 +33,38 @@ def calculate_transfer_function(
     numerical_aperture_detection: float,
     confocal_pinhole_diameter: float | None = None,
 ) -> Tensor:
+    """Calculate the optical transfer function for fluorescence imaging.
+
+    Supports both widefield and confocal microscopy modes. When
+    confocal_pinhole_diameter is None, computes widefield OTF. When specified,
+    computes confocal OTF by multiplying excitation and detection PSFs, where
+    the detection PSF is downweighted by the pinhole aperture function.
+
+    Parameters
+    ----------
+    zyx_shape : tuple[int, int, int]
+        Shape of the 3D volume
+    yx_pixel_size : float
+        Pixel size in YX plane
+    z_pixel_size : float
+        Pixel size in Z dimension
+    wavelength_emission : float
+        Emission wavelength
+    z_padding : int
+        Padding for axial dimension
+    index_of_refraction_media : float
+        Refractive index of imaging medium
+    numerical_aperture_detection : float
+        Numerical aperture of detection objective
+    confocal_pinhole_diameter : float | None, optional
+        Diameter of confocal pinhole in image space (demagnified). If None,
+        computes widefield OTF. If specified, computes confocal OTF.
+
+    Returns
+    -------
+    Tensor
+        3D optical transfer function
+    """
     transverse_nyquist = sampling.transverse_nyquist(
         wavelength_emission,
         numerical_aperture_detection,  # ill = det for fluorescence

--- a/waveorder/models/isotropic_fluorescent_thin_3d.py
+++ b/waveorder/models/isotropic_fluorescent_thin_3d.py
@@ -52,6 +52,7 @@ def calculate_transfer_function(
     wavelength_emission: float,
     index_of_refraction_media: float,
     numerical_aperture_detection: float,
+    confocal_pinhole_diameter: float | None = None,
 ) -> Tensor:
     """Calculate transfer function for fluorescent thin object imaging.
 
@@ -69,12 +70,24 @@ def calculate_transfer_function(
         Refractive index of imaging medium
     numerical_aperture_detection : float
         Numerical aperture of detection objective
+    confocal_pinhole_diameter : float | None, optional
+        Diameter of confocal pinhole. Not implemented for 2D fluorescence.
 
     Returns
     -------
     Tensor
         Fluorescent 2D-to-3D transfer function
+
+    Raises
+    ------
+    NotImplementedError
+        If confocal_pinhole_diameter is not None
     """
+    if confocal_pinhole_diameter is not None:
+        raise NotImplementedError(
+            "Confocal reconstruction is not implemented for 2D fluorescence"
+        )
+
     transverse_nyquist = sampling.transverse_nyquist(
         wavelength_emission,
         numerical_aperture_detection,  # ill = det for fluorescence


### PR DESCRIPTION
This branch adds confocal fluorescence reconstructions to `waveorder` using a new parameter, `confocal_pinhole_diameter`. If this parameter is absent or `None`, `waveorder` uses a widefield fluorescence model. If this parameter is present, the PSF gets smaller (and the OTF gets broader) as the pinhole diameter gets smaller. See below for (top) a summary of PSFs and (bottom) the OTF outer boundary:  

<img width="1378" height="785" alt="g14" src="https://github.com/user-attachments/assets/301a9d9a-ae3d-48a6-b0de-f842cc741973" />
