### PR TITLE
Oblique illumination reconstructions

### DIFF
--- a/docs/examples/configs/birefringence-and-phase.yml
+++ b/docs/examples/configs/birefringence-and-phase.yml
@@ -25,6 +25,7 @@ phase:
     numerical_aperture_detection: 1.2
     numerical_aperture_illumination: 0.5
     invert_phase_contrast: false
+    illumination_sector_angles: null
   apply_inverse:
     reconstruction_algorithm: Tikhonov
     regularization_strength: 0.001

--- a/docs/examples/configs/phase.yml
+++ b/docs/examples/configs/phase.yml
@@ -13,6 +13,7 @@ phase:
     numerical_aperture_detection: 1.2
     numerical_aperture_illumination: 0.5
     invert_phase_contrast: false
+    illumination_sector_angles: null
   apply_inverse:
     reconstruction_algorithm: Tikhonov
     regularization_strength: 0.001

--- a/docs/examples/models/phase_thick_3d.py
+++ b/docs/examples/models/phase_thick_3d.py
@@ -34,7 +34,7 @@ zyx_phase = phase_thick_3d.generate_test_phantom(
     **simulation_arguments, **phantom_arguments
 )
 
-# Calculate transfer function
+# Calculate transfer function (returns shape (C, Z, Y, X))
 (
     real_potential_transfer_function,
     imag_potential_transfer_function,
@@ -42,7 +42,7 @@ zyx_phase = phase_thick_3d.generate_test_phantom(
     **simulation_arguments, **transfer_function_arguments
 )
 
-# Display transfer function
+# Display transfer function (extract single channel for visualization)
 viewer = napari.Viewer()
 zyx_scale = np.array(
     [
@@ -53,25 +53,25 @@ zyx_scale = np.array(
 )
 phase_thick_3d.visualize_transfer_function(
     viewer,
-    real_potential_transfer_function,
-    imag_potential_transfer_function,
+    real_potential_transfer_function[0],
+    imag_potential_transfer_function[0],
     zyx_scale,
 )
 input("Showing OTFs. Press <enter> to continue...")
 viewer.layers.select_all()
 viewer.layers.remove_selected()
 
-# Simulate
+# Simulate (extract single channel for forward model)
 zyx_data = phase_thick_3d.apply_transfer_function(
     zyx_phase,
-    real_potential_transfer_function,
+    real_potential_transfer_function[0],
     transfer_function_arguments["z_padding"],
     brightness=1e3,
 )
 
-# Reconstruct
+# Reconstruct (wrap data in channel dimension for inverse)
 zyx_recon = phase_thick_3d.apply_inverse_transfer_function(
-    zyx_data,
+    zyx_data[None],  # Add channel dimension: (Z, Y, X) -> (1, Z, Y, X)
     real_potential_transfer_function,
     imag_potential_transfer_function,
     transfer_function_arguments["z_padding"],

--- a/docs/examples/models/phase_thick_3d_sector_illumination.py
+++ b/docs/examples/models/phase_thick_3d_sector_illumination.py
@@ -32,11 +32,16 @@ transfer_function_arguments = {
 # Define 9 sector illumination angles
 # 8 sectors at 45-degree intervals + 1 full aperture
 sector_angle = 45
+sector_angle_offset = -22.5
 illumination_sector_angles = [
-    (i * sector_angle, (i + 1) * sector_angle) for i in range(8)
+    (
+        (i * sector_angle + sector_angle_offset) % 360,
+        ((i + 1) * sector_angle + sector_angle_offset) % 360,
+    )
+    for i in range(8)
 ] + [(0, 360)]
 
-print(f"Using {len(illumination_sector_angles)} illumination sectors")
+print(f"Using {illumination_sector_angles} illumination sectors")
 
 # Create a phantom
 zyx_phase = phase_thick_3d.generate_test_phantom(

--- a/docs/examples/models/phase_thick_3d_sector_illumination.py
+++ b/docs/examples/models/phase_thick_3d_sector_illumination.py
@@ -1,0 +1,177 @@
+"""
+phase thick 3d with sector illumination
+========================================
+
+# 3D phase reconstruction with oblique sector illumination
+# This example demonstrates multi-channel phase reconstruction where each channel
+# corresponds to a different illumination sector angle.
+"""
+
+import napari
+import numpy as np
+import torch
+
+from waveorder.models import phase_thick_3d
+
+# Parameters
+# all lengths must use consistent units e.g. um
+simulation_arguments = {
+    "zyx_shape": (100, 256, 256),
+    "yx_pixel_size": 6.5 / 63,
+    "z_pixel_size": 0.25,
+    "index_of_refraction_media": 1.3,
+}
+phantom_arguments = {"index_of_refraction_sample": 1.50, "sphere_radius": 5}
+transfer_function_arguments = {
+    "z_padding": 0,
+    "wavelength_illumination": 0.532,
+    "numerical_aperture_illumination": 0.9,
+    "numerical_aperture_detection": 1.2,
+}
+
+# Define 9 sector illumination angles
+# 8 sectors at 45-degree intervals + 1 full aperture
+sector_angle = 45
+illumination_sector_angles = [
+    (i * sector_angle, (i + 1) * sector_angle) for i in range(8)
+] + [(0, 360)]
+
+print(f"Using {len(illumination_sector_angles)} illumination sectors")
+
+# Create a phantom
+zyx_phase = phase_thick_3d.generate_test_phantom(
+    **simulation_arguments, **phantom_arguments
+)
+
+# Calculate multi-channel transfer function (one for each sector)
+(
+    real_potential_transfer_function,
+    imag_potential_transfer_function,
+) = phase_thick_3d.calculate_transfer_function(
+    **simulation_arguments,
+    **transfer_function_arguments,
+    illumination_sector_angles=illumination_sector_angles,
+)
+
+print(
+    f"Transfer function shape: {real_potential_transfer_function.shape}"
+)  # Should be (C, Z, Y, X)
+
+# Display complete multi-channel transfer function
+viewer = napari.Viewer()
+zyx_scale = np.array(
+    [
+        simulation_arguments["z_pixel_size"],
+        simulation_arguments["yx_pixel_size"],
+        simulation_arguments["yx_pixel_size"],
+    ]
+)
+
+# Add full CZYX transfer function (imaginary part) as single 4D layer
+# Match the visualization style from add_transfer_function_to_viewer
+czyx_shape = imag_potential_transfer_function.shape
+voxel_scale = np.array(
+    [
+        czyx_shape[1] * zyx_scale[0],  # Z extent
+        czyx_shape[2] * zyx_scale[1],  # Y extent
+        czyx_shape[3] * zyx_scale[2],  # X extent
+    ]
+)
+lim = 0.5 * torch.max(torch.abs(imag_potential_transfer_function)).item()
+
+viewer.add_image(
+    torch.fft.ifftshift(
+        torch.imag(imag_potential_transfer_function), dim=(-3, -2, -1)
+    )
+    .cpu()
+    .numpy(),
+    name="Imag pot. TF (CZYX)",
+    colormap="bwr",
+    contrast_limits=(-lim, lim),
+    scale=(1,) + tuple(1 / voxel_scale),  # No scaling on C dimension
+)
+
+# Set up XZ view with C and Y as sliders
+viewer.dims.order = [0, 2, 1, 3]  # (C, Y, Z, X) for XZ display
+viewer.dims.current_step = (
+    0,
+    czyx_shape[1] // 2,
+    czyx_shape[2] // 2,
+    czyx_shape[3] // 2,
+)
+
+input(
+    "Showing CZYX OTF in XZ view (use C and Y sliders). Press <enter> to continue..."
+)
+viewer.layers.select_all()
+viewer.layers.remove_selected()
+
+# Simulate multi-channel data (one channel per sector)
+# In practice, these would come from your microscope as separate acquisitions
+zyx_data_multi_channel = []
+for c in range(len(illumination_sector_angles)):
+    zyx_data_channel = phase_thick_3d.apply_transfer_function(
+        zyx_phase,
+        real_potential_transfer_function[c],
+        transfer_function_arguments["z_padding"],
+        brightness=1e3,
+    )
+    zyx_data_multi_channel.append(zyx_data_channel)
+
+# Stack into (C, Z, Y, X) tensor
+zyx_data_multi_channel = torch.stack(zyx_data_multi_channel, dim=0)
+print(f"Multi-channel data shape: {zyx_data_multi_channel.shape}")
+
+# Reconstruct phase from all channels combined
+zyx_recon = phase_thick_3d.apply_inverse_transfer_function(
+    zyx_data_multi_channel,
+    real_potential_transfer_function,
+    imag_potential_transfer_function,
+    transfer_function_arguments["z_padding"],
+)
+
+# Display
+viewer.add_image(zyx_phase.numpy(), name="Phantom", scale=zyx_scale)
+viewer.add_image(
+    zyx_data_multi_channel.numpy(),
+    name="Data (CZYX)",
+    scale=zyx_scale,
+)
+viewer.add_image(zyx_recon.numpy(), name="Reconstruction", scale=zyx_scale)
+
+# Show comparison with single channel (full aperture) for reference
+print("\nComparing with single-channel (full aperture) reconstruction...")
+(
+    real_tf_single,
+    imag_tf_single,
+) = phase_thick_3d.calculate_transfer_function(
+    **simulation_arguments,
+    **transfer_function_arguments,
+    illumination_sector_angles=None,  # Full aperture
+)
+zyx_data_single = phase_thick_3d.apply_transfer_function(
+    zyx_phase,
+    real_tf_single[0],  # Single channel
+    transfer_function_arguments["z_padding"],
+    brightness=1e3,
+)
+zyx_recon_single = phase_thick_3d.apply_inverse_transfer_function(
+    zyx_data_single[None, ...],  # Add channel dimension
+    real_tf_single,
+    imag_tf_single,
+    transfer_function_arguments["z_padding"],
+)
+viewer.add_image(
+    zyx_recon_single.numpy(),
+    name="Reconstruction (single channel)",
+    scale=zyx_scale,
+)
+
+print(
+    f"\nReconstruction error (multi-channel): {torch.mean(torch.abs(zyx_recon - zyx_phase)).item():.6f}"
+)
+print(
+    f"Reconstruction error (single channel): {torch.mean(torch.abs(zyx_recon_single - zyx_phase)).item():.6f}"
+)
+
+input("\nShowing phantom, data, and reconstructions. Press <enter> to quit...")

--- a/tests/models/test_isotropic_thin_3d.py
+++ b/tests/models/test_isotropic_thin_3d.py
@@ -17,5 +17,6 @@ def test_calculate_transfer_function(invert_phase_contrast):
         invert_phase_contrast=invert_phase_contrast,
     )
 
-    assert Hu.shape == (3, 100, 101)
-    assert Hp.shape == (3, 100, 101)
+    # Transfer functions now have shape (C, Z, Y, X) where C is number of channels
+    assert Hu.shape == (1, 3, 100, 101)
+    assert Hp.shape == (1, 3, 100, 101)

--- a/waveorder/cli/apply_inverse_models.py
+++ b/waveorder/cli/apply_inverse_models.py
@@ -92,19 +92,19 @@ def phase(
 
     # [phase only, 3]
     elif recon_dim == 3:
-        # Load transfer functions
+        # Load transfer functions (keep channel dimension)
         real_potential_transfer_function = torch.tensor(
-            transfer_function_dataset["real_potential_transfer_function"][0, 0]
+            transfer_function_dataset["real_potential_transfer_function"][0]
         )
         imaginary_potential_transfer_function = torch.tensor(
             transfer_function_dataset["imaginary_potential_transfer_function"][
-                0, 0
+                0
             ]
         )
 
-        # Apply
+        # Apply (pass full CZYX data)
         output = phase_thick_3d.apply_inverse_transfer_function(
-            czyx_data[0],
+            czyx_data,
             real_potential_transfer_function,
             imaginary_potential_transfer_function,
             z_padding=settings_phase.transfer_function.z_padding,

--- a/waveorder/cli/compute_transfer_function.py
+++ b/waveorder/cli/compute_transfer_function.py
@@ -211,14 +211,12 @@ def generate_and_save_phase_transfer_function(
         # Save
         dataset.create_image(
             "real_potential_transfer_function",
-            real_potential_transfer_function.cpu().numpy()[None, None, ...],
+            real_potential_transfer_function.cpu().numpy()[None, ...],
             chunks=(1, 1, 1, zyx_shape[1], zyx_shape[2]),
         )
         dataset.create_image(
             "imaginary_potential_transfer_function",
-            imaginary_potential_transfer_function.cpu().numpy()[
-                None, None, ...
-            ],
+            imaginary_potential_transfer_function.cpu().numpy()[None, ...],
             chunks=(1, 1, 1, zyx_shape[1], zyx_shape[2]),
         )
 
@@ -367,14 +365,15 @@ def compute_transfer_function_cli(
         print("Found z_focus_offset:", z_focus_offset)
 
     # Prepare output dataset
-    num_channels = (
+    num_input_channel = len(settings.input_channel_names)
+    num_output_channels = (
         2 if settings.reconstruction_dimension == 2 else 1
     )  # space for SVD
     output_dataset = open_ome_zarr(
         output_dirpath,
         layout="fov",
         mode="w",
-        channel_names=num_channels * ["None"],
+        channel_names=num_input_channel * num_output_channels * ["None"],
     )
 
     # Pass settings to appropriate calculate_transfer_function and save

--- a/waveorder/cli/compute_transfer_function.py
+++ b/waveorder/cli/compute_transfer_function.py
@@ -69,7 +69,9 @@ def generate_and_save_vector_birefringence_transfer_function(
     )
     phase_settings_dict = settings.phase.transfer_function.model_dump()
     phase_settings_dict.pop("z_focus_offset")  # not used in 3D
-    phase_settings_dict.pop("illumination_sector_angles")  # not used in vector birefringence
+    phase_settings_dict.pop(
+        "illumination_sector_angles"
+    )  # not used in vector birefringence
 
     sfZYX_transfer_function, _, singular_system = (
         inplane_oriented_thick_pol3d_vector.calculate_transfer_function(

--- a/waveorder/cli/compute_transfer_function.py
+++ b/waveorder/cli/compute_transfer_function.py
@@ -69,6 +69,7 @@ def generate_and_save_vector_birefringence_transfer_function(
     )
     phase_settings_dict = settings.phase.transfer_function.model_dump()
     phase_settings_dict.pop("z_focus_offset")  # not used in 3D
+    phase_settings_dict.pop("illumination_sector_angles")  # not used in vector birefringence
 
     sfZYX_transfer_function, _, singular_system = (
         inplane_oriented_thick_pol3d_vector.calculate_transfer_function(

--- a/waveorder/cli/settings.py
+++ b/waveorder/cli/settings.py
@@ -126,8 +126,9 @@ class PhaseTransferFunctionSettings(
                     f"Sector start angle {start} must be less than end angle {end}"
                 )
             # Normalize angles to [0, 360) using modulo 360
+            # Special case: preserve 360 for full aperture (don't reduce to 0)
             normalized_start = start % 360
-            normalized_end = end % 360
+            normalized_end = end % 360 if end % 360 != 0 else 360
             normalized.append((normalized_start, normalized_end))
         return normalized
 

--- a/waveorder/cli/settings.py
+++ b/waveorder/cli/settings.py
@@ -119,20 +119,17 @@ class PhaseTransferFunctionSettings(
             raise ValueError(
                 "illumination_sector_angles must contain at least one sector"
             )
+        normalized = []
         for start, end in v:
-            if start < 0 or start >= 360:
-                raise ValueError(
-                    f"Sector start angle {start} must be in range [0, 360)"
-                )
-            if end <= 0 or end > 360:
-                raise ValueError(
-                    f"Sector end angle {end} must be in range (0, 360]"
-                )
-            if start >= end and not (start > 0 and end == 360):
+            if start >= end:
                 raise ValueError(
                     f"Sector start angle {start} must be less than end angle {end}"
                 )
-        return v
+            # Normalize angles to [0, 360) using modulo 360
+            normalized_start = start % 360
+            normalized_end = end % 360
+            normalized.append((normalized_start, normalized_end))
+        return normalized
 
 
 class FluorescenceTransferFunctionSettings(FourierTransferFunctionSettings):

--- a/waveorder/cli/settings.py
+++ b/waveorder/cli/settings.py
@@ -212,10 +212,7 @@ class ReconstructionSettings(MyBaseModel):
                     )
             else:
                 # Single channel phase reconstruction without sector illumination
-                if (
-                    self.birefringence is None
-                    and num_channel_names != 1
-                ):
+                if self.birefringence is None and num_channel_names != 1:
                     raise ValueError(
                         f"{num_channel_names} channels names provided. Please provide a single channel for phase reconstructions without sector illumination."
                     )

--- a/waveorder/cli/settings.py
+++ b/waveorder/cli/settings.py
@@ -115,7 +115,8 @@ class PhaseTransferFunctionSettings(
             )
         return self
 
-    @validator("illumination_sector_angles")
+    @field_validator("illumination_sector_angles")
+    @classmethod
     def validate_sector_angles(cls, v):
         if v is None:
             return v
@@ -195,10 +196,10 @@ class ReconstructionSettings(MyBaseModel):
             raise ValueError(
                 '"fluorescence" cannot be present alongside "birefringence" or "phase". Please use one configuration file for a "fluorescence" reconstruction and another configuration file for a "birefringence" and/or "phase" reconstructions.'
             )
-        num_channel_names = len(values.get("input_channel_names"))
+        num_channel_names = len(self.input_channel_names)
 
         # Check for sector illumination in phase reconstruction
-        phase_settings = values.get("phase")
+        phase_settings = self.phase
         if phase_settings is not None:
             sector_angles = (
                 phase_settings.transfer_function.illumination_sector_angles
@@ -212,15 +213,15 @@ class ReconstructionSettings(MyBaseModel):
             else:
                 # Single channel phase reconstruction without sector illumination
                 if (
-                    values.get("birefringence") is None
+                    self.birefringence is None
                     and num_channel_names != 1
                 ):
                     raise ValueError(
                         f"{num_channel_names} channels names provided. Please provide a single channel for phase reconstructions without sector illumination."
                     )
         else:
-            if values.get("birefringence") is None:
-                if values.get("fluorescence") is None:
+            if self.birefringence is None:
+                if self.fluorescence is None:
                     raise ValueError(
                         "Provide settings for either birefringence, phase, birefringence + phase, or fluorescence."
                     )

--- a/waveorder/models/phase_thick_3d.py
+++ b/waveorder/models/phase_thick_3d.py
@@ -67,7 +67,10 @@ def calculate_transfer_function(
     real_tfs = []
     imag_tfs = []
 
-    for start_angle, end_angle in illumination_sector_angles:
+    for i, (start_angle, end_angle) in enumerate(illumination_sector_angles):
+        print(
+            f"Calculating transfer function {i+1}/{len(illumination_sector_angles)} for sector [{start_angle:.1f}, {end_angle:.1f}] degrees"
+        )
         (
             real_potential_transfer_function,
             imag_potential_transfer_function,
@@ -282,6 +285,7 @@ def apply_inverse_transfer_function(
     reconstructions = []
 
     for c in range(num_channels):
+        print(f"Reconstructing channel {c+1}/{num_channels}")
         # Handle padding
         zyx_padded = util.pad_zyx_along_z(zyx_data[c], z_padding)
 


### PR DESCRIPTION
This PR adds multi-aperture oblique illumination reconstructions to `waveorder`. 

A single new parameter `illumination_sector_angles` enables these reconstructions, best described by example: 

1. `illumination_sector_angles = None` uses the old behavior---a single circular illumination aperture
2. `illumination_sector_angles = [(0, 45), (45, 90)]` reconstructs from two sector-illumination channels, the first sector from 0-45 degrees and the second from 45-90 degrees. 
3. `illumination_sector_angles = [(i * sector_angle, (i + 1) * sector_angle) for i in range(8)] + [(0, 360)]` reconstructs from 8 sector-illumination channels and a final full-aperture channel. 

Below is a simulation of a sphere (first column) and simulated data acquired under different illumination orientation (second column). As expected, the reconstruction with a single full aperture (third column) is not as sharp as the reconstruction with all 9 channels (last column).   

https://github.com/user-attachments/assets/fb395380-ea90-48c4-bd87-856f4c26d2d9