### PR TITLE
Constrain `PyQt6>=6.5,<6.8` for older linux systems

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ dynamic = ["version"]
 [project.optional-dependencies]
 visual = [
   "napari[pyqt6]",
+  "PyQt6>=6.5,<6.8",  # Constrain to versions with manylinux_2_28 support for older Linux systems
   "napari-ome-zarr>=0.3.2", # drag and drop convenience
   "pycromanager==0.27.2",
   "jupyter",
@@ -74,6 +75,7 @@ dev = [
   "click>=8.2.0",
   "hypothesis",
   "napari[pyqt6]",  # needed for napari plugin tests
+  "PyQt6>=6.5,<6.8",  # Constrain to versions with manylinux_2_28 support for older Linux systems
   "pre-commit",
   "pytest-cov",
   "pytest-qt",
@@ -94,7 +96,7 @@ docs = [
 ]
 all = [
   "waveorder[visual]",
-  "waveorder[dev]", 
+  "waveorder[dev]",
   "waveorder[docs]",
 ]
 


### PR DESCRIPTION
Biohub's HPC depends on Rocky Linux 8 -> glibc 2.28-2.33 -> manylinux_2_28 -> PyQt6 6.5-6.8. If we don't constrain `PyQt6>=6.5,<6.8`, PyQt6 wheels are unavailable and PyQt6 will try to use `qmake` to build PyQt6 which typically fails. 

Related: 
- https://github.com/mehta-lab/recOrder/pull/503
- https://github.com/mehta-lab/waveorder/issues/503
- https://github.com/napari/napari/issues/7976
