### PR TITLE
Support OME-Zarr v0.5 (Zarr v3) datasets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
   "click>=8.0.1",
   "colorspacious>=1.1.2",
   "importlib-metadata",
-  "iohub>=0.2,<0.4",
+  "iohub>=0.3.0a3,<0.4",
   "ipywidgets>=7.5.1",
   "matplotlib>=3.1.1",
   "natsort>=7.1.1",

--- a/tests/cli_tests/test_parsing.py
+++ b/tests/cli_tests/test_parsing.py
@@ -1,16 +1,16 @@
 """Tests for CLI path parsing with zarr v3 structures."""
 
-from pathlib import Path
-
+import numpy as np
 import pytest
 from iohub.ngff import open_ome_zarr
+from iohub.ngff.models import TransformationMeta
 
 from waveorder.cli.parsing import _validate_and_process_paths
 
 
 def test_validate_paths_filters_zarr_json_from_glob(tmp_path):
-    """Test that zarr.json files are filtered when using */*/*/* glob pattern."""
-    # Create a minimal zarr v3 plate structure
+    """Test that zarr.json files are filtered when using glob pattern."""
+    # Create a minimal zarr v3 plate structure with actual data
     plate_path = tmp_path / "plate.zarr"
     try:
         plate = open_ome_zarr(
@@ -20,24 +20,34 @@ def test_validate_paths_filters_zarr_json_from_glob(tmp_path):
             channel_names=["ch"],
             version="0.5",
         )
-        plate.create_position("A", "1", "0")
+        pos = plate.create_position("A", "1", "0")
+        # Create data so position has proper OME-NGFF metadata
+        pos.create_zeros(
+            "0",
+            (1, 1, 2, 3, 4),
+            dtype=np.uint16,
+            transform=[
+                TransformationMeta(type="scale", scale=[1, 1, 1, 1, 1])
+            ],
+        )
         plate.close()
     except Exception:
         # Skip if zarr v3 not supported
         pytest.skip("Zarr v3 not supported by installed iohub version")
 
-    # Glob pattern that would include both positions and zarr.json files
-    glob_pattern = str(plate_path / "*" / "*" / "*")
-    paths = [str(p) for p in Path(plate_path).glob("*/*/*")]
+    # Glob pattern A/1/* returns both position dir and zarr.json
+    glob_paths = list(plate_path.glob("A/1/*"))
+    zarr_jsons = [p for p in glob_paths if not p.is_dir()]
 
-    # Verify zarr.json files exist in glob results
-    json_files = [p for p in paths if "zarr.json" in p]
-    assert len(json_files) > 0, "Test setup should include zarr.json files"
+    # Verify zarr.json files are in glob results
+    assert len(zarr_jsons) > 0, "zarr.json files should be in glob results"
 
-    # Call the parsing function
-    result = _validate_and_process_paths(None, None, paths)
+    # Call the parsing function with glob results
+    result = _validate_and_process_paths(
+        None, None, [str(p) for p in glob_paths]
+    )
 
-    # All results should be directories only
-    assert all(p.is_dir() for p in result)
-    assert len(result) == 1  # Only the position directory
+    # Only the position directory should remain
+    assert len(result) == 1
     assert result[0].name == "0"
+    assert result[0].is_dir()

--- a/tests/cli_tests/test_parsing.py
+++ b/tests/cli_tests/test_parsing.py
@@ -1,0 +1,43 @@
+"""Tests for CLI path parsing with zarr v3 structures."""
+
+from pathlib import Path
+
+import pytest
+from iohub.ngff import open_ome_zarr
+
+from waveorder.cli.parsing import _validate_and_process_paths
+
+
+def test_validate_paths_filters_zarr_json_from_glob(tmp_path):
+    """Test that zarr.json files are filtered when using */*/*/* glob pattern."""
+    # Create a minimal zarr v3 plate structure
+    plate_path = tmp_path / "plate.zarr"
+    try:
+        plate = open_ome_zarr(
+            plate_path,
+            layout="hcs",
+            mode="w-",
+            channel_names=["ch"],
+            version="0.5",
+        )
+        plate.create_position("A", "1", "0")
+        plate.close()
+    except Exception:
+        # Skip if zarr v3 not supported
+        pytest.skip("Zarr v3 not supported by installed iohub version")
+
+    # Glob pattern that would include both positions and zarr.json files
+    glob_pattern = str(plate_path / "*" / "*" / "*")
+    paths = [str(p) for p in Path(plate_path).glob("*/*/*")]
+
+    # Verify zarr.json files exist in glob results
+    json_files = [p for p in paths if "zarr.json" in p]
+    assert len(json_files) > 0, "Test setup should include zarr.json files"
+
+    # Call the parsing function
+    result = _validate_and_process_paths(None, None, paths)
+
+    # All results should be directories only
+    assert all(p.is_dir() for p in result)
+    assert len(result) == 1  # Only the position directory
+    assert result[0].name == "0"

--- a/tests/cli_tests/test_zarr_v3_reconstruct.py
+++ b/tests/cli_tests/test_zarr_v3_reconstruct.py
@@ -1,0 +1,189 @@
+"""Tests for Zarr v3 (OME-NGFF v0.5) reconstruction support.
+
+Verifies that:
+- Plate metadata extraction works for both v0.4 and v0.5
+- Output zarr version matches input version
+- The full reconstruct CLI works for v0.5 input
+"""
+
+import shutil
+from pathlib import Path
+from tempfile import mkdtemp
+
+import numpy as np
+import pytest
+from click.testing import CliRunner
+from iohub.ngff import open_ome_zarr
+from iohub.ngff.models import TransformationMeta
+
+from waveorder.cli import settings
+from waveorder.cli.apply_inverse_transfer_function import (
+    get_reconstruction_output_metadata,
+)
+from waveorder.cli.main import cli
+from waveorder.cli.utils import create_empty_hcs_zarr
+from waveorder.io import utils
+
+INPUT_SCALE = [1, 1, 2.0, 6.5, 6.5]
+CHANNEL_NAMES = [f"State{x}" for x in range(4)]
+
+
+def _iohub_supports_v05():
+    """Check if the installed iohub actually creates v0.5 stores."""
+    tmp = Path(mkdtemp()) / "v05check.zarr"
+    try:
+        ds = open_ome_zarr(
+            tmp, layout="fov", mode="w-", channel_names=["ch"], version="0.5"
+        )
+        supported = ds.version == "0.5"
+        ds.close()
+        return supported
+    except Exception:
+        return False
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+_V05_SUPPORTED = _iohub_supports_v05()
+
+
+def _create_test_plate(path, version="0.4"):
+    """Create a minimal HCS plate for testing."""
+    plate = open_ome_zarr(
+        path,
+        layout="hcs",
+        mode="w-",
+        channel_names=CHANNEL_NAMES,
+        version=version,
+    )
+    pos = plate.create_position("0", "0", "0")
+    pos.create_zeros(
+        "0",
+        (2, 4, 4, 5, 6),
+        dtype=np.uint16,
+        transform=[TransformationMeta(type="scale", scale=INPUT_SCALE)],
+    )
+    plate.zattrs["Summary"] = {"custom_key": "custom_value"}
+    plate.close()
+
+
+def _get_store_version(path):
+    """Get the OME-NGFF version of a store using iohub's API."""
+    ds = open_ome_zarr(path, mode="r")
+    version = ds.version
+    ds.close()
+    return version
+
+
+def _versions():
+    versions = ["0.4"]
+    if _V05_SUPPORTED:
+        versions.append("0.5")
+    return versions
+
+
+@pytest.fixture(params=_versions())
+def input_plate_path(request, tmp_path):
+    """Create test input plates for supported versions."""
+    version = request.param
+    plate_path = tmp_path / f"input_{version}.zarr"
+    _create_test_plate(plate_path, version=version)
+    return plate_path, version
+
+
+class TestPlateMetadataExtraction:
+    """Test that get_reconstruction_output_metadata handles v0.4 and v0.5."""
+
+    def test_metadata_extraction(self, input_plate_path, tmp_path):
+        plate_path, version = input_plate_path
+        pos_path = plate_path / "0" / "0" / "0"
+
+        config = settings.ReconstructionSettings(
+            input_channel_names=CHANNEL_NAMES,
+            birefringence=settings.BirefringenceSettings(),
+        )
+        config_path = tmp_path / "config.yml"
+        utils.model_to_yaml(config, config_path)
+
+        metadata = get_reconstruction_output_metadata(pos_path, config_path)
+
+        # Custom metadata should be preserved
+        assert "Summary" in metadata["plate_metadata"]
+        # OME-specific keys should be stripped
+        assert "plate" not in metadata["plate_metadata"]
+        assert "ome" not in metadata["plate_metadata"]
+
+    def test_version_propagated(self, input_plate_path, tmp_path):
+        plate_path, version = input_plate_path
+        pos_path = plate_path / "0" / "0" / "0"
+
+        config = settings.ReconstructionSettings(
+            input_channel_names=CHANNEL_NAMES,
+            birefringence=settings.BirefringenceSettings(),
+        )
+        config_path = tmp_path / "config.yml"
+        utils.model_to_yaml(config, config_path)
+
+        metadata = get_reconstruction_output_metadata(pos_path, config_path)
+        assert metadata["version"] == version
+
+
+class TestOutputVersionPreservation:
+    """Test that output zarr format matches input version."""
+
+    def test_create_empty_hcs_zarr_version(self, tmp_path):
+        for version in _versions():
+            out_path = tmp_path / f"output_{version}.zarr"
+            create_empty_hcs_zarr(
+                store_path=out_path,
+                position_keys=[("A", "1", "0")],
+                shape=(1, 4, 4, 5, 6),
+                chunks=(1, 1, 1, 5, 6),
+                scale=INPUT_SCALE,
+                channel_names=["Retardance", "Orientation", "BF", "Pol"],
+                dtype=np.float32,
+                version=version,
+            )
+            assert _get_store_version(out_path) == version
+
+
+class TestReconstructCLI:
+    """Test the full reconstruct CLI with v0.4 and v0.5 inputs."""
+
+    def test_reconstruct_preserves_version(self, input_plate_path, tmp_path):
+        plate_path, version = input_plate_path
+        pos_path = plate_path / "0" / "0" / "0"
+        output_path = tmp_path / "output.zarr"
+
+        config = settings.ReconstructionSettings(
+            input_channel_names=CHANNEL_NAMES,
+            birefringence=settings.BirefringenceSettings(),
+            reconstruction_dimension=3,
+        )
+        config_path = tmp_path / "config.yml"
+        utils.model_to_yaml(config, config_path)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "reconstruct",
+                "-i",
+                str(pos_path),
+                "-c",
+                str(config_path),
+                "-o",
+                str(output_path),
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert output_path.exists()
+
+        # Verify output version matches input
+        assert _get_store_version(output_path) == version
+
+        # Verify output is readable
+        with open_ome_zarr(output_path) as dataset:
+            pos = dataset["0/0/0"]
+            assert pos["0"].shape[1] == 4  # Retardance, Orientation, BF, Pol

--- a/waveorder/cli/apply_inverse_transfer_function.py
+++ b/waveorder/cli/apply_inverse_transfer_function.py
@@ -41,12 +41,18 @@ def _check_background_consistency(
 def get_reconstruction_output_metadata(position_path: Path, config_path: Path):
     # Get non-OME-Zarr plate-level metadata if it's available
     plate_metadata = {}
+    input_version = "0.4"
     try:
         input_plate = open_ome_zarr(
             position_path.parent.parent.parent, mode="r"
         )
+        input_version = input_plate.version
         plate_metadata = dict(input_plate.zattrs)
-        plate_metadata.pop("plate")
+        # In v0.5 (zarr v3), OME metadata is nested inside an "ome" key
+        if "ome" in plate_metadata:
+            plate_metadata.pop("ome")
+        else:
+            plate_metadata.pop("plate")
     except (RuntimeError, FileNotFoundError):
         warnings.warn(
             "Position is not part of a plate...no plate metadata will be copied."
@@ -100,6 +106,7 @@ def get_reconstruction_output_metadata(position_path: Path, config_path: Path):
         "channel_names": channel_names,
         "dtype": np.float32,
         "plate_metadata": plate_metadata,
+        "version": input_version,
     }
 
 

--- a/waveorder/cli/compute_transfer_function.py
+++ b/waveorder/cli/compute_transfer_function.py
@@ -331,6 +331,7 @@ def compute_transfer_function_cli(
     input_dataset = open_ome_zarr(
         input_position_dirpath, layout="fov", mode="r"
     )
+    input_version = input_dataset.version
     zyx_shape = input_dataset.data.shape[
         2:
     ]  # only loads a single position "0"
@@ -377,6 +378,7 @@ def compute_transfer_function_cli(
         layout="fov",
         mode="w",
         channel_names=num_channels * ["None"],
+        version=input_version,
     )
 
     # Pass settings to appropriate calculate_transfer_function and save

--- a/waveorder/cli/parsing.py
+++ b/waveorder/cli/parsing.py
@@ -14,6 +14,8 @@ def _validate_and_process_paths(
 ) -> list[Path]:
     # Sort and validate the input paths, expanding plates into lists of positions
     input_paths = [Path(path) for path in natsorted(value)]
+    # Filter out non-directories (e.g., zarr.json files from glob expansion)
+    input_paths = [path for path in input_paths if path.is_dir()]
     for path in input_paths:
         with open_ome_zarr(path, mode="r") as dataset:
             if isinstance(dataset, Plate):

--- a/waveorder/cli/utils.py
+++ b/waveorder/cli/utils.py
@@ -50,6 +50,7 @@ def create_empty_hcs_zarr(
     channel_names: list[str],
     dtype: DTypeLike,
     plate_metadata: dict = {},
+    version: str = "0.4",
 ) -> None:
     """If the plate does not exist, create an empty zarr plate.
 
@@ -70,11 +71,17 @@ def create_empty_hcs_zarr(
         Channel names, will append if not present in metadata.
     dtype : DTypeLike
     plate_metadata : dict
+    version : str
+        OME-NGFF version ("0.4" or "0.5"), by default "0.4"
     """
 
     # Create plate
     output_plate = open_ome_zarr(
-        str(store_path), layout="hcs", mode="a", channel_names=channel_names
+        str(store_path),
+        layout="hcs",
+        mode="a",
+        channel_names=channel_names,
+        version=version,
     )
 
     # Pass metadata
@@ -140,7 +147,7 @@ def apply_inverse_to_zyx_and_save(
     with open_ome_zarr(output_path, mode="r+") as output_dataset:
         output_dataset[0].oindex[
             t_idx, output_channel_indices
-        ] = reconstruction_czyx
+        ] = reconstruction_czyx.cpu().numpy()
     click.echo(f"Finished Writing.. t={t_idx}")
 
 


### PR DESCRIPTION
Fixes three bugs that prevent reconstruction of v0.5 datasets. Closes #518.

- Fix `KeyError: 'plate'` when reading v0.5 plate metadata (nested inside `"ome"` key)
- Preserve zarr version from input to output (v2 in → v2 out, v3 in → v3 out)
- Convert torch tensors to numpy before writing to zarr (fixes `torch.dtype` incompatibility with zarr-python 3)
- Add parametrized tests covering v0.4 and v0.5 for metadata extraction, version propagation, and end-to-end reconstruct