### PR TITLE
Batched focused slice

### DIFF
--- a/tests/test_focus_estimator.py
+++ b/tests/test_focus_estimator.py
@@ -324,9 +324,7 @@ def test_compute_focus_slice_batch_3d():
     np.random.seed(42)
     data_3d = np.random.random((11, 64, 64)).astype(np.float32)
 
-    result = focus.compute_focus_slice_batch(
-        data_3d, NA_det, lambda_ill, ps
-    )
+    result = focus.compute_focus_slice_batch(data_3d, NA_det, lambda_ill, ps)
     assert isinstance(result, int)
     assert 0 <= result < data_3d.shape[0]
 
@@ -340,9 +338,7 @@ def test_compute_focus_slice_batch_4d():
     np.random.seed(42)
     data_4d = np.random.random((3, 11, 64, 64)).astype(np.float32)
 
-    result = focus.compute_focus_slice_batch(
-        data_4d, NA_det, lambda_ill, ps
-    )
+    result = focus.compute_focus_slice_batch(data_4d, NA_det, lambda_ill, ps)
     assert isinstance(result, np.ndarray)
     assert result.shape == (3,)
     assert all(0 <= idx < 11 for idx in result)
@@ -371,9 +367,7 @@ def test_compute_focus_slice_batch_matches_sequential():
         )
 
 
-@pytest.mark.skipif(
-    not torch.cuda.is_available(), reason="CUDA not available"
-)
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 def test_compute_focus_slice_batch_gpu():
     """Test batch focus on GPU produces same results as CPU."""
     ps = 6.5 / 100

--- a/tests/test_focus_estimator.py
+++ b/tests/test_focus_estimator.py
@@ -315,6 +315,101 @@ def test_subpixel_precision_with_plotting(tmp_path):
     assert plot_path.exists()
 
 
+def test_compute_focus_slice_batch_3d():
+    """Test batch focus on 3D input returns int in [0, Z)."""
+    ps = 6.5 / 100
+    lambda_ill = 0.532
+    NA_det = 1.4
+
+    np.random.seed(42)
+    data_3d = np.random.random((11, 64, 64)).astype(np.float32)
+
+    result = focus.compute_focus_slice_batch(
+        data_3d, NA_det, lambda_ill, ps
+    )
+    assert isinstance(result, int)
+    assert 0 <= result < data_3d.shape[0]
+
+
+def test_compute_focus_slice_batch_4d():
+    """Test batch focus on 4D input returns ndarray of shape (T,)."""
+    ps = 6.5 / 100
+    lambda_ill = 0.532
+    NA_det = 1.4
+
+    np.random.seed(42)
+    data_4d = np.random.random((3, 11, 64, 64)).astype(np.float32)
+
+    result = focus.compute_focus_slice_batch(
+        data_4d, NA_det, lambda_ill, ps
+    )
+    assert isinstance(result, np.ndarray)
+    assert result.shape == (3,)
+    assert all(0 <= idx < 11 for idx in result)
+
+
+def test_compute_focus_slice_batch_matches_sequential():
+    """Test that batch result matches sequential focus_from_transverse_band."""
+    ps = 6.5 / 100
+    lambda_ill = 0.532
+    NA_det = 1.4
+
+    np.random.seed(42)
+    data_4d = np.random.random((4, 7, 64, 64)).astype(np.float32)
+
+    batch_result = focus.compute_focus_slice_batch(
+        data_4d, NA_det, lambda_ill, ps
+    )
+
+    for t in range(data_4d.shape[0]):
+        sequential_result = focus.focus_from_transverse_band(
+            data_4d[t], NA_det, lambda_ill, ps
+        )
+        assert batch_result[t] == sequential_result, (
+            f"Mismatch at t={t}: batch={batch_result[t]}, "
+            f"sequential={sequential_result}"
+        )
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA not available"
+)
+def test_compute_focus_slice_batch_gpu():
+    """Test batch focus on GPU produces same results as CPU."""
+    ps = 6.5 / 100
+    lambda_ill = 0.532
+    NA_det = 1.4
+
+    np.random.seed(42)
+    data_4d = np.random.random((3, 7, 64, 64)).astype(np.float32)
+
+    cpu_result = focus.compute_focus_slice_batch(
+        data_4d, NA_det, lambda_ill, ps, device="cpu"
+    )
+    gpu_result = focus.compute_focus_slice_batch(
+        data_4d, NA_det, lambda_ill, ps, device="cuda"
+    )
+    np.testing.assert_array_equal(cpu_result, gpu_result)
+
+
+def test_compute_focus_slice_batch_chunked():
+    """Test that batch_size chunking produces same results as no chunking."""
+    ps = 6.5 / 100
+    lambda_ill = 0.532
+    NA_det = 1.4
+
+    np.random.seed(42)
+    data_4d = np.random.random((6, 7, 64, 64)).astype(np.float32)
+
+    full_result = focus.compute_focus_slice_batch(
+        data_4d, NA_det, lambda_ill, ps, batch_size=None
+    )
+    chunked_result = focus.compute_focus_slice_batch(
+        data_4d, NA_det, lambda_ill, ps, batch_size=2
+    )
+    np.testing.assert_array_equal(full_result, chunked_result)
+
+
 def test_z_focus_offset_float_type():
     """Test that z_focus_offset can accept float values in settings."""
     from waveorder.cli.settings import FourierTransferFunctionSettings

--- a/waveorder/focus.py
+++ b/waveorder/focus.py
@@ -9,6 +9,95 @@ from scipy.signal import peak_widths
 from waveorder import util
 
 
+def _compute_midband_power_batch(
+    array: np.ndarray | torch.Tensor,
+    NA_det: float,
+    lambda_ill: float,
+    pixel_size: float,
+    midband_fractions: tuple[float, float] = (0.125, 0.25),
+    device: torch.device | str = "cpu",
+    batch_size: int | None = None,
+) -> np.ndarray:
+    """Compute midband FFT power for all slices in a batched manner.
+
+    Precomputes the frequency mask once, then applies a batched 2D FFT
+    across all slices simultaneously.
+
+    Parameters
+    ----------
+    array : np.ndarray or torch.Tensor
+        2D (Y, X), 3D (Z, Y, X), or 4D (T, Z, Y, X) stack.
+    NA_det : float
+        Detection numerical aperture.
+    lambda_ill : float
+        Illumination wavelength (same units as pixel_size).
+    pixel_size : float
+        Object-space pixel size.
+    midband_fractions : tuple[float, float]
+        Inner and outer fractions of cutoff frequency.
+    device : torch.device or str
+        Torch device for computation.
+    batch_size : int or None
+        Max timepoints to process at once (controls GPU memory).
+        None = process all at once. Only applies to 4D input.
+
+    Returns
+    -------
+    np.ndarray
+        2D input: scalar array (shape ()).
+        3D input: array of shape (Z,) with per-slice midband power.
+        4D input: array of shape (T, Z) with per-timepoint, per-slice power.
+    """
+    if isinstance(array, np.ndarray):
+        tensor = torch.from_numpy(array).float()
+    else:
+        tensor = array.float()
+
+    orig_ndim = tensor.ndim
+    if orig_ndim == 2:
+        tensor = tensor.unsqueeze(0).unsqueeze(0)  # (1, 1, Y, X)
+    elif orig_ndim == 3:
+        tensor = tensor.unsqueeze(0)  # (1, Z, Y, X)
+    elif orig_ndim != 4:
+        raise ValueError(
+            f"{orig_ndim}D array supplied. "
+            "Only 2D, 3D, or 4D arrays are accepted."
+        )
+
+    T, Z, Y, X = tensor.shape
+
+    # Precompute frequency mask once for (Y, X) shape
+    _, _, fxx, fyy = util.gen_coordinate((Y, X), pixel_size)
+    frr = torch.tensor(np.sqrt(fxx**2 + fyy**2), device=device)
+    cutoff = 2 * NA_det / lambda_ill
+    mask = torch.logical_and(
+        frr > cutoff * midband_fractions[0],
+        frr < cutoff * midband_fractions[1],
+    )
+
+    if batch_size is None or batch_size >= T:
+        chunks = [tensor]
+    else:
+        chunks = list(tensor.split(batch_size, dim=0))
+
+    all_powers = []
+    for chunk in chunks:
+        chunk_t = chunk.shape[0]
+        flat = chunk.reshape(chunk_t * Z, Y, X).to(device)
+        abs_fft = torch.abs(torch.fft.fftn(flat, dim=(-2, -1)))
+        midband_power = abs_fft[:, mask].sum(dim=-1)
+        midband_power = midband_power.reshape(chunk_t, Z)
+        all_powers.append(midband_power.cpu())
+
+    result = torch.cat(all_powers).numpy()  # (T, Z)
+
+    if orig_ndim == 2:
+        return result[0, 0]
+    elif orig_ndim == 3:
+        return result[0]  # (Z,)
+    return result  # (T, Z)
+
+
 def compute_midband_power(
     yx_array: torch.Tensor,
     NA_det: float,
@@ -39,15 +128,10 @@ def compute_midband_power(
     torch.Tensor
         Sum of absolute FFT values in the midband region.
     """
-    _, _, fxx, fyy = util.gen_coordinate(yx_array.shape, pixel_size)
-    frr = torch.tensor(np.sqrt(fxx**2 + fyy**2))
-    xy_abs_fft = torch.abs(torch.fft.fftn(yx_array))
-    cutoff = 2 * NA_det / lambda_ill
-    mask = torch.logical_and(
-        frr > cutoff * midband_fractions[0],
-        frr < cutoff * midband_fractions[1],
+    result = _compute_midband_power_batch(
+        yx_array, NA_det, lambda_ill, pixel_size, midband_fractions
     )
-    return torch.sum(xy_abs_fft[mask])
+    return torch.tensor(result)
 
 
 def compute_focus_slice_batch(
@@ -88,55 +172,23 @@ def compute_focus_slice_batch(
         3D input: int (focus slice index).
         4D input: np.ndarray of shape (T,) with per-timepoint focus indices.
     """
-    if isinstance(array, np.ndarray):
-        tensor = torch.from_numpy(array).float()
-    else:
-        tensor = array.float()
-
-    ndim = tensor.ndim
-    if ndim == 3:
-        tensor = tensor.unsqueeze(0)  # (1, Z, Y, X)
-    elif ndim != 4:
+    ndim = array.ndim if isinstance(array, np.ndarray) else array.ndim
+    if ndim not in (3, 4):
         raise ValueError(
             f"{ndim}D array supplied. "
             "`compute_focus_slice_batch` only accepts 3D or 4D arrays."
         )
 
-    T, Z, Y, X = tensor.shape
-
-    # Precompute frequency mask once for (Y, X) shape
-    _, _, fxx, fyy = util.gen_coordinate((Y, X), pixel_size)
-    frr = torch.tensor(np.sqrt(fxx**2 + fyy**2), device=device)
-    cutoff = 2 * NA_det / lambda_ill
-    mask = torch.logical_and(
-        frr > cutoff * midband_fractions[0],
-        frr < cutoff * midband_fractions[1],
+    power = _compute_midband_power_batch(
+        array, NA_det, lambda_ill, pixel_size, midband_fractions,
+        device=device, batch_size=batch_size,
     )
-    num_masked = mask.sum().item()
-
-    if batch_size is None or batch_size >= T:
-        chunks = [tensor]
-    else:
-        chunks = list(tensor.split(batch_size, dim=0))
-
-    all_focus_indices = []
-    for chunk in chunks:
-        chunk_t = chunk.shape[0]
-        # Reshape to (chunk_t * Z, Y, X) for batched FFT
-        flat = chunk.reshape(chunk_t * Z, Y, X).to(device)
-        abs_fft = torch.abs(torch.fft.fftn(flat, dim=(-2, -1)))
-        # Apply mask: (chunk_t * Z, num_masked) -> sum -> (chunk_t * Z,)
-        midband_power = abs_fft[:, mask].sum(dim=-1)
-        # Reshape to (chunk_t, Z) and find argmax per timepoint
-        midband_power = midband_power.reshape(chunk_t, Z)
-        focus_indices = torch.argmax(midband_power, dim=-1)
-        all_focus_indices.append(focus_indices.cpu())
-
-    result = torch.cat(all_focus_indices).numpy()
 
     if ndim == 3:
-        return int(result[0])
-    return result
+        # power is (Z,), return int
+        return int(np.argmax(power))
+    # power is (T, Z), return (T,) array
+    return np.argmax(power, axis=-1)
 
 
 def focus_from_transverse_band(
@@ -223,19 +275,10 @@ def focus_from_transverse_band(
             return 0, peak_stats
         return 0
 
-    # Calculate midband power for each slice
-    midband_sum = np.array(
-        [
-            compute_midband_power(
-                torch.from_numpy(zyx_array[z]),
-                NA_det,
-                lambda_ill,
-                pixel_size,
-                midband_fractions,
-            ).numpy()
-            for z in range(zyx_array.shape[0])
-        ]
-    )
+    # Calculate midband power for each slice using batched engine
+    midband_sum = _compute_midband_power_batch(
+        zyx_array, NA_det, lambda_ill, pixel_size, midband_fractions
+    )  # (Z,)
 
     if polynomial_fit_order is None:
         peak_index = minmaxfunc(midband_sum)

--- a/waveorder/focus.py
+++ b/waveorder/focus.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Literal, Optional
+from typing import Callable, Literal, Optional, Union
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -75,18 +75,18 @@ def compute_midband_power(
 
 
 def focus_from_transverse_band(
-    zyx_array,
-    NA_det,
-    lambda_ill,
-    pixel_size,
-    midband_fractions=(0.125, 0.25),
+    zyx_array: Union[np.ndarray, torch.Tensor],
+    NA_det: float,
+    lambda_ill: float,
+    pixel_size: float,
+    midband_fractions: tuple[float, float] = (0.125, 0.25),
     mode: Literal["min", "max"] = "max",
     polynomial_fit_order: Optional[int] = None,
     plot_path: Optional[str] = None,
     threshold_FWHM: float = 0,
     return_statistics: bool = False,
     enable_subpixel_precision: bool = False,
-):
+) -> Union[int, float, None, tuple[Union[int, float, None], dict]]:
     """Estimates the in-focus slice from a 3D stack by optimizing a transverse spatial frequency band.
 
     Parameters
@@ -243,7 +243,7 @@ def focus_from_transverse_band(
     return in_focus_index
 
 
-def _mode_to_minmaxfunc(mode):
+def _mode_to_minmaxfunc(mode: Literal["min", "max"]) -> Callable:
     if mode == "min":
         minmaxfunc = np.argmin
     elif mode == "max":
@@ -254,8 +254,12 @@ def _mode_to_minmaxfunc(mode):
 
 
 def _check_focus_inputs(
-    zyx_array, NA_det, lambda_ill, pixel_size, midband_fractions
-):
+    zyx_array: Union[np.ndarray, torch.Tensor],
+    NA_det: float,
+    lambda_ill: float,
+    pixel_size: float,
+    midband_fractions: tuple[float, float],
+) -> None:
     N = len(zyx_array.shape)
     if N != 3:
         raise ValueError(
@@ -285,13 +289,13 @@ def _check_focus_inputs(
 
 
 def _plot_focus_metric(
-    plot_path,
-    midband_sum,
-    peak_index,
-    in_focus_index,
-    peak_results,
-    threshold_FWHM,
-):
+    plot_path: str,
+    midband_sum: np.ndarray,
+    peak_index: Union[int, float],
+    in_focus_index: Union[int, float, None],
+    peak_results: tuple,
+    threshold_FWHM: float,
+) -> None:
     _, ax = plt.subplots(1, 1, figsize=(4, 4))
     ax.plot(midband_sum, "-k")
 

--- a/waveorder/focus.py
+++ b/waveorder/focus.py
@@ -180,8 +180,13 @@ def compute_focus_slice_batch(
         )
 
     power = _compute_midband_power_batch(
-        array, NA_det, lambda_ill, pixel_size, midband_fractions,
-        device=device, batch_size=batch_size,
+        array,
+        NA_det,
+        lambda_ill,
+        pixel_size,
+        midband_fractions,
+        device=device,
+        batch_size=batch_size,
     )
 
     if ndim == 3:


### PR DESCRIPTION
Paired with https://github.com/mehta-lab/VisCy/pull/364

- allow for batched T*Z GPU compute
- From the little benchmarking on a small node using it at 60-75% VRAM capacity it sped up by 3x. This function itself doesn't automatically handle the batching but `viscy/preprocessing/focus.py` in viscy does. 