### PR TITLE
Reconstruction optimization and GPU support

### DIFF
--- a/docs/examples/demos/QLIPP/QLIPP_simulation.py
+++ b/docs/examples/demos/QLIPP/QLIPP_simulation.py
@@ -123,7 +123,9 @@ jupyter_visuals.plot_multicolumn(
 xx, yy, fxx, fyy = util.gen_coordinate((N, M), ps)
 radial_frequencies = torch.sqrt(fxx**2 + fyy**2)
 Source_cont = optics.generate_pupil(radial_frequencies, NA_illu, lambda_illu).numpy()
-Source_discrete = optics.Source_subsample(Source_cont, lambda_illu * fxx, lambda_illu * fyy, subsampled_NA=0.1)
+Source_discrete = optics.Source_subsample(
+    Source_cont, (lambda_illu * fxx).numpy(), (lambda_illu * fyy).numpy(), subsampled_NA=0.1
+)
 plt.figure(figsize=(10, 10))
 plt.imshow(fftshift(Source_discrete), cmap="gray")
 plt.show()

--- a/docs/examples/demos/QLIPP/QLIPP_simulation.py
+++ b/docs/examples/demos/QLIPP/QLIPP_simulation.py
@@ -121,7 +121,7 @@ jupyter_visuals.plot_multicolumn(
 # Source pupil
 # Subsample source pattern for speed
 xx, yy, fxx, fyy = util.gen_coordinate((N, M), ps)
-radial_frequencies = np.sqrt(fxx**2 + fyy**2)
+radial_frequencies = torch.sqrt(fxx**2 + fyy**2)
 Source_cont = optics.generate_pupil(radial_frequencies, NA_illu, lambda_illu).numpy()
 Source_discrete = optics.Source_subsample(Source_cont, lambda_illu * fxx, lambda_illu * fyy, subsampled_NA=0.1)
 plt.figure(figsize=(10, 10))

--- a/docs/examples/deprecated/PTI_experiment/PTI_Experiment_Recon3D_anisotropic_target_small.py
+++ b/docs/examples/deprecated/PTI_experiment/PTI_Experiment_Recon3D_anisotropic_target_small.py
@@ -69,7 +69,7 @@ I_cali_mean = np.array(PTI_file.I_cali_mean)
 _, _, Ns, Ms, _ = I_meas.shape
 
 xx, yy, fxx, fyy = util.gen_coordinate((Ns, Ms), ps)
-frr = np.sqrt(fxx**2 + fyy**2)
+frr = torch.sqrt(fxx**2 + fyy**2)
 
 rotation_angle = [
     180 - 22.5,

--- a/docs/examples/maintenance/PTI_simulation/PTI_Simulation_Forward_2D3D.py
+++ b/docs/examples/maintenance/PTI_simulation/PTI_Simulation_Forward_2D3D.py
@@ -343,8 +343,8 @@ radial_frequencies = torch.sqrt(torch.as_tensor(fxx**2 + fyy**2, dtype=torch.flo
 Pupil_obj = optics.generate_pupil(radial_frequencies, NA_obj / n_media, lambda_illu / n_media).numpy()
 Source_support = optics.generate_pupil(radial_frequencies, NA_illu / n_media, lambda_illu / n_media).numpy()
 
-NAx_coord = lambda_illu / n_media * fxx
-NAy_coord = lambda_illu / n_media * fyy
+NAx_coord = (lambda_illu / n_media * fxx).numpy()
+NAy_coord = (lambda_illu / n_media * fyy).numpy()
 
 rotation_angle = [0, 45, 90, 135, 180, 225, 270, 315]
 

--- a/docs/examples/maintenance/QLIPP_simulation/2D_QLIPP_forward.py
+++ b/docs/examples/maintenance/QLIPP_simulation/2D_QLIPP_forward.py
@@ -73,7 +73,9 @@ plt.show()
 xx, yy, fxx, fyy = util.gen_coordinate((N, M), ps)
 radial_frequencies = torch.sqrt(torch.as_tensor(fxx**2 + fyy**2, dtype=torch.float32))
 Source_cont = optics.generate_pupil(radial_frequencies, NA_illu, lambda_illu).numpy()
-Source_discrete = optics.Source_subsample(Source_cont, lambda_illu * fxx, lambda_illu * fyy, subsampled_NA=0.1)
+Source_discrete = optics.Source_subsample(
+    Source_cont, (lambda_illu * fxx).numpy(), (lambda_illu * fyy).numpy(), subsampled_NA=0.1
+)
 plt.figure(figsize=(10, 10))
 plt.imshow(fftshift(Source_discrete), cmap="gray")
 plt.show()

--- a/docs/examples/optimization/phase_2d_optimized.yml
+++ b/docs/examples/optimization/phase_2d_optimized.yml
@@ -1,6 +1,7 @@
 input_channel_names: [Brightfield]
 time_indices: all
 reconstruction_dimension: 2
+device: null                              # null=cpu, auto, cuda:0, cuda:1, mps
 phase:
   transfer_function:
     wavelength_illumination: 0.532        # illumination wavelength in micrometers

--- a/tests/cli_tests/test_reconstruct.py
+++ b/tests/cli_tests/test_reconstruct.py
@@ -258,7 +258,7 @@ def test_optimization_cli(tmp_path):
     channel_names = ["Brightfield"]
     dataset = open_ome_zarr(input_path, layout="hcs", mode="w", channel_names=channel_names)
     position = dataset.create_position("0", "0", "0")
-    data = np.random.rand(1, 1, 4, 5, 6).astype(np.float32) + 10.0
+    data = np.random.rand(1, 1, 4, 32, 32).astype(np.float32) + 10.0
     position.create_image("0", data, transform=[TransformationMeta(type="scale", scale=input_scale)])
     dataset.close()
 

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -33,6 +33,42 @@ def test_stretched_multiply():
     assert result.shape == (99, 99, 99)
 
 
+def test_stretched_matrix_multiply_matches_loop():
+    """Batched stretched_matrix_multiply must match the per-channel loop."""
+    torch.manual_seed(42)
+    for spatial_shape, filter_shape in [
+        ((16, 16), (4, 4)),
+        ((12, 18), (3, 3)),
+        ((8, 8, 8), (2, 2, 2)),
+    ]:
+        num_input, num_output = 3, 5
+        i_input = torch.rand((num_input,) + spatial_shape)
+        io_filter_bank = torch.rand((num_input, num_output) + filter_shape)
+
+        # Full pipeline (uses stretched_matrix_multiply internally)
+        result = filter.apply_filter_bank(io_filter_bank, i_input)
+
+        # Reference: original per-channel loop
+        import itertools
+
+        fft_dims = list(range(1, i_input.ndim))
+        pad_sizes = [(0, (t - (s % t)) % t) for t, s in zip(filter_shape[::-1], spatial_shape[::-1])]
+        padded = torch.nn.functional.pad(i_input, list(itertools.chain(*pad_sizes)))
+        spectrum = torch.fft.fftn(padded, dim=fft_dims)
+
+        ref = torch.zeros((num_output,) + spectrum.shape[1:], dtype=spectrum.dtype)
+        for i in range(num_input):
+            for o in range(num_output):
+                ref[o] += filter.stretched_multiply(io_filter_bank[i, o], spectrum[i])
+
+        ref_out = torch.real(torch.fft.ifftn(ref, dim=fft_dims))
+        slices = (slice(None),) + tuple(slice(0, n) for n in spatial_shape)
+        ref_out = ref_out[slices]
+
+        assert result.shape == ref_out.shape
+        assert torch.allclose(result, ref_out, atol=1e-5)
+
+
 def test_stretched_multiply_incompatible_dims():
     # small_array > large_array
     small_array = torch.tensor([[1, 2, 3], [4, 5, 6], [7, 8, 9]])

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -127,3 +127,38 @@ def test_WOTF_3D():
 
     assert H_re.shape == (11, 10, 10)
     assert H_im.shape == (11, 10, 10)
+
+
+def test_batched_wotf_matches_loop():
+    """Batched WOTF (Z,Y,X detection pupil) matches per-Z loop."""
+    wavelength = 0.5
+    yx_pixel_size = 0.25
+    z_pixel_size = 0.2
+    numerical_aperture = 0.5
+    z_position_list = torch.fft.fftfreq(7, 1 / z_pixel_size)
+
+    frr = util.generate_radial_frequencies((12, 12), yx_pixel_size)
+    illumination_pupil = optics.generate_pupil(frr, numerical_aperture, wavelength)
+    detection_pupil = optics.generate_pupil(frr, numerical_aperture, wavelength)
+    propagation_kernel = optics.generate_propagation_kernel(frr, detection_pupil, wavelength, z_position_list)
+
+    # Reference: loop over z-slices
+    abs_loop, phase_loop = [], []
+    for z in range(propagation_kernel.shape[0]):
+        a, p = optics.compute_weak_object_transfer_function_2d(
+            illumination_pupil, detection_pupil * propagation_kernel[z]
+        )
+        abs_loop.append(a)
+        phase_loop.append(p)
+    abs_loop = torch.stack(abs_loop, dim=0)
+    phase_loop = torch.stack(phase_loop, dim=0)
+
+    # Batched: pass (Z, Y, X) detection pupil
+    abs_batch, phase_batch = optics.compute_weak_object_transfer_function_2d(
+        illumination_pupil, detection_pupil.unsqueeze(0) * propagation_kernel
+    )
+
+    assert abs_batch.shape == (7, 12, 12)
+    assert phase_batch.shape == (7, 12, 12)
+    assert torch.allclose(abs_batch, abs_loop, atol=1e-6)
+    assert torch.allclose(phase_batch, phase_loop, atol=1e-6)

--- a/waveorder/api/fluorescence.py
+++ b/waveorder/api/fluorescence.py
@@ -29,7 +29,7 @@ from waveorder.models import (
     isotropic_fluorescent_thin_3d,
 )
 from waveorder.optim import (
-    PrintLogger,
+    NullLogger,
     TensorBoardLogger,
     extract_optimizable_params,
     optimize_reconstruction,
@@ -375,7 +375,7 @@ def optimize(
         print("No optimizable parameters found. Running standard reconstruction.")
         return settings, reconstruct(czyx_data, recon_dim=recon_dim, settings=settings)
 
-    logger = TensorBoardLogger(log_dir) if log_dir else PrintLogger()
+    logger = TensorBoardLogger(log_dir) if log_dir else NullLogger()
 
     s = settings.transfer_function.resolve_floats()
     zyx_data = torch.tensor(czyx_data.values[0], dtype=torch.float32)

--- a/waveorder/api/fluorescence.py
+++ b/waveorder/api/fluorescence.py
@@ -23,6 +23,7 @@ from waveorder.api._utils import (
     _to_singular_system,
     _to_tensor,
 )
+from waveorder.device import resolve_device
 from waveorder.focus import compute_midband_power
 from waveorder.models import (
     isotropic_fluorescent_thick_3d,
@@ -170,6 +171,7 @@ def compute_transfer_function(
     czyx_data: xr.DataArray,
     recon_dim: Literal[2, 3],
     settings: Settings = None,
+    device: str | torch.device | None = None,
 ) -> xr.Dataset:
     """Compute fluorescence transfer function.
 
@@ -191,15 +193,20 @@ def compute_transfer_function(
     """
     if settings is None:
         settings = Settings()
+    device = resolve_device(device)
 
     zyx_shape = czyx_data.shape[1:]  # CZYX -> ZYX
     s = settings.transfer_function.resolve_floats()
 
     if recon_dim == 2:
-        z_position_list = _position_list_from_shape_scale_offset(
-            shape=zyx_shape[0],
-            scale=s.z_pixel_size,
-            offset=s.z_focus_offset,
+        z_position_list = torch.tensor(
+            _position_list_from_shape_scale_offset(
+                shape=zyx_shape[0],
+                scale=s.z_pixel_size,
+                offset=s.z_focus_offset,
+            ),
+            dtype=torch.float32,
+            device=device,
         )
 
         fluorescent_tf = isotropic_fluorescent_thin_3d.calculate_transfer_function(
@@ -244,6 +251,7 @@ def apply_inverse_transfer_function(
     recon_dim: Literal[2, 3],
     settings: Settings = None,
     fluor_channel_name: str = "",
+    device: str | torch.device | None = None,
 ) -> xr.DataArray:
     """Reconstruct fluorescence density.
 
@@ -267,21 +275,23 @@ def apply_inverse_transfer_function(
     """
     if settings is None:
         settings = Settings()
+    device = resolve_device(device)
 
-    czyx_tensor = torch.tensor(czyx_data.values, dtype=torch.float32)
+    czyx_tensor = torch.tensor(czyx_data.values, dtype=torch.float32, device=device)
 
     # [fluo, 2]
     if recon_dim == 2:
+        U, S, Vh = _to_singular_system(transfer_function)
         output = isotropic_fluorescent_thin_3d.apply_inverse_transfer_function(
             czyx_tensor[0],
-            _to_singular_system(transfer_function),
+            (U.to(device), S.to(device), Vh.to(device)),
             **settings.apply_inverse.model_dump(),
         )
     # [fluo, 3]
     elif recon_dim == 3:
         output = isotropic_fluorescent_thick_3d.apply_inverse_transfer_function(
             czyx_tensor[0],
-            _to_tensor(transfer_function, "optical_transfer_function"),
+            _to_tensor(transfer_function, "optical_transfer_function").to(device),
             settings.transfer_function.z_padding,
             **settings.apply_inverse.model_dump(),
         )
@@ -290,7 +300,7 @@ def apply_inverse_transfer_function(
         output = torch.unsqueeze(output, 0)
 
     return _build_output_xarray(
-        output.numpy(),
+        output.cpu().numpy(),
         _output_channel_names(
             recon_fluo=True,
             recon_dim=recon_dim,
@@ -306,6 +316,7 @@ def reconstruct(
     recon_dim: Literal[2, 3],
     settings: Settings = None,
     fluor_channel_name: str = "",
+    device: str | torch.device | None = None,
 ) -> xr.DataArray:
     """Reconstruct fluorescence density.
 
@@ -331,8 +342,8 @@ def reconstruct(
     if settings is None:
         settings = Settings()
 
-    tf = compute_transfer_function(czyx_data, recon_dim, settings)
-    return apply_inverse_transfer_function(czyx_data, tf, recon_dim, settings, fluor_channel_name)
+    tf = compute_transfer_function(czyx_data, recon_dim, settings, device=device)
+    return apply_inverse_transfer_function(czyx_data, tf, recon_dim, settings, fluor_channel_name, device=device)
 
 
 def optimize(
@@ -343,6 +354,7 @@ def optimize(
     midband_fractions: tuple[float, float] = (0.125, 0.25),
     log_dir: str | None = None,
     log_images: bool = False,
+    device: str | torch.device | None = None,
 ) -> tuple[Settings, xr.DataArray]:
     """Optimize fluorescence reconstruction parameters.
 
@@ -378,7 +390,9 @@ def optimize(
     logger = TensorBoardLogger(log_dir) if log_dir else NullLogger()
 
     s = settings.transfer_function.resolve_floats()
-    zyx_data = torch.tensor(czyx_data.values[0], dtype=torch.float32)
+    device = resolve_device(device)
+
+    zyx_data = torch.tensor(czyx_data.values[0], dtype=torch.float32, device=device)
     Z = zyx_data.shape[0]
 
     def reconstruct_fn(data, **tensor_params):
@@ -440,6 +454,6 @@ def optimize(
         apply_inverse=settings.apply_inverse,
     )
 
-    final_recon = reconstruct(czyx_data, recon_dim=recon_dim, settings=new_settings)
+    final_recon = reconstruct(czyx_data, recon_dim=recon_dim, settings=new_settings, device=device)
 
     return new_settings, final_recon

--- a/waveorder/api/phase.py
+++ b/waveorder/api/phase.py
@@ -25,6 +25,7 @@ from waveorder.api._utils import (
     _to_singular_system,
     _to_tensor,
 )
+from waveorder.device import resolve_device
 from waveorder.focus import compute_midband_power
 from waveorder.models import isotropic_thin_3d, phase_thick_3d
 from waveorder.optim import (
@@ -189,6 +190,7 @@ def compute_transfer_function(
     czyx_data: xr.DataArray,
     recon_dim: Literal[2, 3],
     settings: Settings = None,
+    device: str | torch.device | None = None,
 ) -> xr.Dataset:
     """Compute phase transfer function.
 
@@ -200,6 +202,8 @@ def compute_transfer_function(
         Reconstruction dimensionality.
     settings : Settings, optional
         Phase reconstruction settings. Uses defaults if None.
+    device : str, torch.device, or None
+        Compute device. None = CPU, "auto" = best available.
 
     Returns
     -------
@@ -211,15 +215,20 @@ def compute_transfer_function(
     """
     if settings is None:
         settings = Settings()
+    device = resolve_device(device)
 
     zyx_shape = czyx_data.shape[1:]  # CZYX -> ZYX
     s = settings.transfer_function.resolve_floats()
 
     if recon_dim == 2:
-        z_position_list = _position_list_from_shape_scale_offset(
-            shape=zyx_shape[0],
-            scale=s.z_pixel_size,
-            offset=s.z_focus_offset,
+        z_position_list = torch.tensor(
+            _position_list_from_shape_scale_offset(
+                shape=zyx_shape[0],
+                scale=s.z_pixel_size,
+                offset=s.z_focus_offset,
+            ),
+            dtype=torch.float32,
+            device=device,
         )
 
         absorption_tf, phase_tf = isotropic_thin_3d.calculate_transfer_function(
@@ -278,6 +287,7 @@ def apply_inverse_transfer_function(
     transfer_function: xr.Dataset,
     recon_dim: Literal[2, 3],
     settings: Settings = None,
+    device: str | torch.device | None = None,
 ) -> xr.DataArray:
     """Reconstruct phase from brightfield data.
 
@@ -291,6 +301,8 @@ def apply_inverse_transfer_function(
         Reconstruction dimensionality.
     settings : Settings, optional
         Phase reconstruction settings. Uses defaults if None.
+    device : str, torch.device, or None
+        Compute device. None = CPU, "auto" = best available.
 
     Returns
     -------
@@ -299,17 +311,19 @@ def apply_inverse_transfer_function(
     """
     if settings is None:
         settings = Settings()
+    device = resolve_device(device)
 
-    czyx_tensor = torch.tensor(czyx_data.values, dtype=torch.float32)
+    czyx_tensor = torch.tensor(czyx_data.values, dtype=torch.float32, device=device)
 
     # [phase only, 2]
     if recon_dim == 2:
+        U, S, Vh = _to_singular_system(transfer_function)
         (
             absorption_yx,
             phase_yx,
         ) = isotropic_thin_3d.apply_inverse_transfer_function(
             czyx_tensor[0],
-            _to_singular_system(transfer_function),
+            (U.to(device), S.to(device), Vh.to(device)),
             **settings.apply_inverse.model_dump(),
         )
         output = phase_yx[None, None]
@@ -318,8 +332,8 @@ def apply_inverse_transfer_function(
     elif recon_dim == 3:
         output = phase_thick_3d.apply_inverse_transfer_function(
             czyx_tensor[0],
-            _to_tensor(transfer_function, "real_potential_transfer_function"),
-            _to_tensor(transfer_function, "imaginary_potential_transfer_function"),
+            _to_tensor(transfer_function, "real_potential_transfer_function").to(device),
+            _to_tensor(transfer_function, "imaginary_potential_transfer_function").to(device),
             z_padding=settings.transfer_function.z_padding,
             **settings.apply_inverse.model_dump(),
         )
@@ -329,7 +343,7 @@ def apply_inverse_transfer_function(
         output = torch.unsqueeze(output, 0)
 
     return _build_output_xarray(
-        output.numpy(),
+        output.cpu().numpy(),
         _output_channel_names(recon_phase=True, recon_dim=recon_dim),
         czyx_data,
         singleton_z=(recon_dim == 2),
@@ -340,6 +354,7 @@ def reconstruct(
     czyx_data: xr.DataArray,
     recon_dim: Literal[2, 3],
     settings: Settings = None,
+    device: str | torch.device | None = None,
 ) -> xr.DataArray:
     """Reconstruct phase from brightfield data.
 
@@ -354,6 +369,8 @@ def reconstruct(
         Reconstruction dimensionality.
     settings : Settings, optional
         Phase reconstruction settings. Uses defaults if None.
+    device : str, torch.device, or None
+        Compute device. None = CPU, "auto" = best available.
 
     Returns
     -------
@@ -363,8 +380,8 @@ def reconstruct(
     if settings is None:
         settings = Settings()
 
-    tf = compute_transfer_function(czyx_data, recon_dim, settings)
-    return apply_inverse_transfer_function(czyx_data, tf, recon_dim, settings)
+    tf = compute_transfer_function(czyx_data, recon_dim, settings, device=device)
+    return apply_inverse_transfer_function(czyx_data, tf, recon_dim, settings, device=device)
 
 
 def optimize(
@@ -375,6 +392,7 @@ def optimize(
     midband_fractions: tuple[float, float] = (0.125, 0.25),
     log_dir: str | None = None,
     log_images: bool = False,
+    device: str | torch.device | None = None,
 ) -> tuple[Settings, xr.DataArray]:
     """Optimize reconstruction parameters by maximizing midband spatial frequency power.
 
@@ -392,9 +410,11 @@ def optimize(
     midband_fractions : tuple[float, float]
         Inner and outer fractions of cutoff frequency for the loss annulus.
     log_dir : str, optional
-        TensorBoard log directory. None = print-only logging.
+        TensorBoard log directory. None = no logging.
     log_images : bool
         If True, log reconstruction images to TensorBoard each iteration.
+    device : str, torch.device, or None
+        Compute device. None = CPU, "auto" = best available.
 
     Returns
     -------
@@ -403,23 +423,27 @@ def optimize(
     """
     if settings is None:
         settings = Settings()
+    device = resolve_device(device)
 
     opt_params, _ = extract_optimizable_params(settings.transfer_function)
 
     if not opt_params:
         print("No optimizable parameters found. Running standard reconstruction.")
-        return settings, reconstruct(czyx_data, recon_dim=recon_dim, settings=settings)
+        return settings, reconstruct(czyx_data, recon_dim=recon_dim, settings=settings, device=device)
 
     logger = TensorBoardLogger(log_dir) if log_dir else NullLogger()
 
     s = settings.transfer_function.resolve_floats()
-    zyx_data = torch.tensor(czyx_data.values[0], dtype=torch.float32)
+    zyx_data = torch.tensor(czyx_data.values[0], dtype=torch.float32, device=device)
     Z = zyx_data.shape[0]
     yx_shape = (zyx_data.shape[1], zyx_data.shape[2])
 
     # Soft pupil cutoff for smooth gradients during optimization.
     # The final reconstruction (after optimize returns) uses the default 1e4.
     optim_steepness = 100.0
+
+    # Pre-allocate z index tensor on device (avoids GPU sync per iteration)
+    z_indices = -torch.arange(Z, device=device) + (Z // 2)
 
     def reconstruct_fn(data, **tensor_params):
         na_ill = tensor_params.get("numerical_aperture_illumination", s.numerical_aperture_illumination)
@@ -429,7 +453,7 @@ def optimize(
         tilt_azimuth = tensor_params.get("tilt_angle_azimuth", s.tilt_angle_azimuth)
 
         if recon_dim == 2:
-            z_positions = (-torch.arange(Z) + (Z // 2) + z_offset) * s.z_pixel_size
+            z_positions = (z_indices + z_offset) * s.z_pixel_size
             return isotropic_thin_3d.reconstruct(
                 data,
                 yx_pixel_size=s.yx_pixel_size,
@@ -513,5 +537,5 @@ def optimize(
         apply_inverse=settings.apply_inverse,
     )
 
-    final_recon = reconstruct(czyx_data, recon_dim=recon_dim, settings=new_settings)
+    final_recon = reconstruct(czyx_data, recon_dim=recon_dim, settings=new_settings, device=device)
     return new_settings, final_recon

--- a/waveorder/api/phase.py
+++ b/waveorder/api/phase.py
@@ -28,7 +28,7 @@ from waveorder.api._utils import (
 from waveorder.focus import compute_midband_power
 from waveorder.models import isotropic_thin_3d, phase_thick_3d
 from waveorder.optim import (
-    PrintLogger,
+    NullLogger,
     TensorBoardLogger,
     extract_optimizable_params,
     optimize_reconstruction,
@@ -410,7 +410,7 @@ def optimize(
         print("No optimizable parameters found. Running standard reconstruction.")
         return settings, reconstruct(czyx_data, recon_dim=recon_dim, settings=settings)
 
-    logger = TensorBoardLogger(log_dir) if log_dir else PrintLogger()
+    logger = TensorBoardLogger(log_dir) if log_dir else NullLogger()
 
     s = settings.transfer_function.resolve_floats()
     zyx_data = torch.tensor(czyx_data.values[0], dtype=torch.float32)

--- a/waveorder/cli/apply_inverse_transfer_function.py
+++ b/waveorder/cli/apply_inverse_transfer_function.py
@@ -141,9 +141,11 @@ def apply_inverse_transfer_function_single_position(
     output_position_dirpath: Path,
     num_processes,
     output_channel_names: list[str],
+    verbose: bool = True,
 ) -> None:
 
-    echo_headline("\nStarting reconstruction...")
+    if verbose:
+        echo_headline("\nStarting reconstruction...")
 
     # Load datasets
     transfer_function_dataset = open_ome_zarr(transfer_function_dirpath)
@@ -264,13 +266,14 @@ def apply_inverse_transfer_function_single_position(
         input_xa,
         output_position_dirpath,
         settings.input_channel_names,
+        verbose=verbose,
         **apply_inverse_args,
     )
 
     # Multiprocessing logic
     if num_processes > 1:
-        # Loop through T, processing and writing as we go
-        click.echo(f"\nStarting multiprocess pool with {num_processes} processes")
+        if verbose:
+            click.echo(f"\nStarting multiprocess pool with {num_processes} processes")
         with mp.Pool(num_processes) as p:
             p.starmap(
                 partial_apply_inverse_to_zyx_and_save,
@@ -283,14 +286,11 @@ def apply_inverse_transfer_function_single_position(
     # Save metadata at position level
     output_dataset.zattrs["settings"] = settings.model_dump()
 
-    echo_headline(f"Closing {output_position_dirpath}\n")
+    if verbose:
+        echo_headline(f"Closing {output_position_dirpath}\n")
 
     output_dataset.close()
     input_dataset.close()
-
-    echo_headline(
-        f"Recreate this reconstruction with:\n$ waveorder apply-inv-tf {input_position_dirpath} {transfer_function_dirpath} -c {config_filepath} -o {output_position_dirpath}"
-    )
 
 
 def apply_inverse_transfer_function_cli(

--- a/waveorder/cli/reconstruct.py
+++ b/waveorder/cli/reconstruct.py
@@ -96,6 +96,7 @@ def _run_optimization(settings, input_position_dirpath, config_filepath):
         num_iterations=opt.num_iterations,
         midband_fractions=opt.loss.midband_fractions,
         log_dir=opt.log_dir,
+        device=settings.device,
     )
 
     if settings.phase is not None:

--- a/waveorder/cli/settings.py
+++ b/waveorder/cli/settings.py
@@ -40,6 +40,7 @@ class ReconstructionSettings(MyBaseModel):
         default="all", description="time points to reconstruct"
     )
     reconstruction_dimension: Literal[2, 3] = Field(default=3, description="2 for thin samples, 3 for thick")
+    device: Optional[str] = Field(default=None, description="compute device: null=cpu, auto, cuda:0, mps, etc.")
     birefringence: Optional[BirefringenceSettings] = None
     phase: Optional[PhaseSettings] = None
     fluorescence: Optional[FluorescenceSettings] = None

--- a/waveorder/cli/utils.py
+++ b/waveorder/cli/utils.py
@@ -128,6 +128,7 @@ def apply_inverse_to_zyx_and_save(
     output_path: Path,
     input_channel_names: list[str],
     t_idx: int = 0,
+    verbose: bool = True,
     **kwargs,
 ) -> None:
     """Load a zyx array from an xarray DataArray, apply a transformation and save the result to file.
@@ -144,10 +145,13 @@ def apply_inverse_to_zyx_and_save(
         Channel names to select from input_data.
     t_idx : int
         Time index to process.
+    verbose : bool
+        Print progress messages per time point.
     **kwargs
         Additional arguments passed to func.
     """
-    click.echo(f"Reconstructing t={t_idx}")
+    if verbose:
+        click.echo(f"Reconstructing t={t_idx}")
 
     # Extract CZYX xarray slice
     czyx_slice = input_data.isel(t=t_idx).sel(c=input_channel_names)
@@ -170,7 +174,9 @@ def apply_inverse_to_zyx_and_save(
     # Write to file
     with open_ome_zarr(output_path, mode="r+") as output_position:
         output_position.write_xarray(output_xa)
-    click.echo(f"Finished Writing.. t={t_idx}")
+
+    if verbose:
+        click.echo(f"Finished writing t={t_idx}")
 
 
 def estimate_resources(shape, settings, num_processes):

--- a/waveorder/device.py
+++ b/waveorder/device.py
@@ -1,0 +1,41 @@
+"""Device selection for waveorder computations."""
+
+from __future__ import annotations
+
+import torch
+
+
+def auto_device() -> torch.device:
+    """Select the best available device.
+
+    Returns
+    -------
+    torch.device
+        ``cuda`` if available, then ``mps``, else ``cpu``.
+    """
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+        return torch.device("mps")
+    return torch.device("cpu")
+
+
+def resolve_device(device: str | torch.device | None = None) -> torch.device:
+    """Resolve a device specification to a torch.device.
+
+    Parameters
+    ----------
+    device : str, torch.device, or None
+        Device specification. ``None`` means CPU. ``"auto"`` selects
+        the best available device. Strings like ``"cuda:0"``,
+        ``"cuda:1"``, ``"mps"``, ``"cpu"`` are passed through.
+
+    Returns
+    -------
+    torch.device
+    """
+    if device is None or device == "cpu":
+        return torch.device("cpu")
+    if device == "auto":
+        return auto_device()
+    return torch.device(device)

--- a/waveorder/filter.py
+++ b/waveorder/filter.py
@@ -64,8 +64,6 @@ def apply_filter_bank(
     if io_filter_bank.shape[0] != i_input_array.shape[0]:
         raise ValueError("io_filter_bank.shape[0] and i_input_array.shape[0] must be the same.")
 
-    num_input_channels, num_output_channels = io_filter_bank.shape[:2]
-
     # Pad input_array until each dimension is divisible by transfer_function
     pad_sizes = [(0, (t - (i % t)) % t) for t, i in zip(io_filter_bank.shape[2:][::-1], i_input_array.shape[1:][::-1])]
     flat_pad_sizes = list(itertools.chain(*pad_sizes))
@@ -75,31 +73,61 @@ def apply_filter_bank(
     fft_dims = [d for d in range(1, i_input_array.ndim)]
     padded_input_spectrum = torch.fft.fftn(padded_input_array, dim=fft_dims)
 
-    # Matrix-vector multiplication over f
-    # If this is a bottleneck, consider extending `stretched_multiply` to
-    # a `stretched_matrix_multiply` that uses an call like
-    # torch.einsum('io..., i... -> o...', io_filter_bank, padded_input_spectrum)
-    #
-    # Further optimization is likely with a combination of
-    # torch.baddbmm, torch.pixel_shuffle, torch.pixel_unshuffle.
-    padded_output_spectrum = torch.zeros(
-        (num_output_channels,) + padded_input_spectrum.shape[1:],
-        dtype=padded_input_spectrum.dtype,
-        device=padded_input_spectrum.device,
-    )
-    for input_channel_idx in range(num_input_channels):
-        for output_channel_idx in range(num_output_channels):
-            padded_output_spectrum[output_channel_idx] += stretched_multiply(
-                io_filter_bank[input_channel_idx, output_channel_idx],
-                padded_input_spectrum[input_channel_idx],
-            )
+    # Batched matrix-vector multiply over all i/o channels at once
+    padded_output_spectrum = stretched_matrix_multiply(io_filter_bank, padded_input_spectrum)
 
     # Cast to real, ignoring imaginary part
     padded_result = torch.real(torch.fft.ifftn(padded_output_spectrum, dim=fft_dims))
 
-    # Remove padding and return
-    slices = tuple(slice(0, i) for i in i_input_array.shape)
+    # Remove padding and return (keep all output channels, unpad spatial dims)
+    slices = (slice(None),) + tuple(slice(0, s) for s in i_input_array.shape[1:])
     return padded_result[slices]
+
+
+def stretched_matrix_multiply(
+    io_filter_bank: torch.Tensor,
+    padded_input_spectrum: torch.Tensor,
+) -> torch.Tensor:
+    """Batched stretched multiply over input/output channels.
+
+    Equivalent to the double loop::
+
+        for i in range(I):
+            for o in range(O):
+                out[o] += stretched_multiply(filter[i, o], spectrum[i])
+
+    Parameters
+    ----------
+    io_filter_bank : torch.Tensor
+        Shape ``(I, O, s0, s1, ..., s_{n-1})``.
+    padded_input_spectrum : torch.Tensor
+        Shape ``(I, l0, l1, ..., l_{n-1})``, where each ``lk`` is
+        divisible by ``sk``.
+
+    Returns
+    -------
+    torch.Tensor
+        Shape ``(O, l0, l1, ..., l_{n-1})``.
+    """
+    num_input_channels, num_output_channels = io_filter_bank.shape[:2]
+    s_shape = io_filter_bank.shape[2:]
+    l_shape = padded_input_spectrum.shape[1:]
+    ndim = len(s_shape)
+
+    b_shape = tuple(l // s for l, s in zip(l_shape, s_shape))
+
+    # (I, l0, ...) -> (I, 1, s0, b0, s1, b1, ...)
+    interleaved_l = tuple(itertools.chain(*zip(s_shape, b_shape)))
+    spectrum_reshaped = padded_input_spectrum.reshape((num_input_channels, 1) + interleaved_l)
+
+    # (I, O, s0, ...) -> (I, O, s0, 1, s1, 1, ...)
+    interleaved_s = tuple(itertools.chain(*zip(s_shape, ndim * (1,))))
+    filter_reshaped = io_filter_bank.reshape((num_input_channels, num_output_channels) + interleaved_s)
+
+    # Multiply and contract over I -> (O, s0, b0, s1, b1, ...)
+    result_reshaped = (spectrum_reshaped * filter_reshaped).sum(dim=0)
+
+    return result_reshaped.reshape((num_output_channels,) + l_shape)
 
 
 def stretched_multiply(small_array: torch.Tensor, large_array: torch.Tensor) -> torch.Tensor:

--- a/waveorder/focus.py
+++ b/waveorder/focus.py
@@ -58,7 +58,7 @@ def compute_midband_power(
     device = input_tensor.device
 
     _, _, fxx, fyy = util.gen_coordinate((Y, X), pixel_size)
-    frr = torch.tensor(np.sqrt(fxx**2 + fyy**2), device=device)
+    frr = torch.sqrt(fxx**2 + fyy**2).to(device)
     cutoff = 2 * NA_det / lambda_ill
     mask = torch.logical_and(
         frr > cutoff * midband_fractions[0],

--- a/waveorder/focus.py
+++ b/waveorder/focus.py
@@ -57,8 +57,8 @@ def compute_midband_power(
     Z, Y, X = input_tensor.shape
     device = input_tensor.device
 
-    _, _, fxx, fyy = util.gen_coordinate((Y, X), pixel_size)
-    frr = torch.sqrt(fxx**2 + fyy**2).to(device)
+    _, _, fxx, fyy = util.gen_coordinate((Y, X), pixel_size, device=device)
+    frr = torch.sqrt(fxx**2 + fyy**2)
     cutoff = 2 * NA_det / lambda_ill
     mask = torch.logical_and(
         frr > cutoff * midband_fractions[0],

--- a/waveorder/models/inplane_oriented_thick_pol3d_vector.py
+++ b/waveorder/models/inplane_oriented_thick_pol3d_vector.py
@@ -59,9 +59,6 @@ def calculate_transfer_function(
     yx_factor = int(np.ceil(yx_pixel_size / transverse_nyquist))
     z_factor = int(np.ceil(z_pixel_size / axial_nyquist))
 
-    print("YX factor:", yx_factor)
-    print("Z factor:", z_factor)
-
     tf_calculation_shape = (
         int(zyx_shape[0] * z_factor / fourier_oversample_factor),
         int(np.ceil(zyx_shape[1] * yx_factor / fourier_oversample_factor)),
@@ -122,7 +119,6 @@ def _calculate_wrap_unsafe_transfer_function(
     numerical_aperture_detection,
     invert_phase_contrast=False,
 ):
-    print("Computing transfer function")
     intensity_to_stokes_matrix = stokes.calculate_intensity_to_stokes_matrix(swing, scheme=scheme)
 
     input_jones = torch.tensor([0.0 - 1.0j, 1.0 + 0j])  # circular
@@ -139,7 +135,6 @@ def _calculate_wrap_unsafe_transfer_function(
     z_frequencies = torch.fft.fftfreq(z_total, d=z_pixel_size)
 
     # 2D pupils
-    print("\tCalculating pupils...")
     ill_pupil = optics.generate_pupil(
         radial_frequencies,
         numerical_aperture_illumination,
@@ -186,7 +181,6 @@ def _calculate_wrap_unsafe_transfer_function(
     P_3D = torch.abs(torch.fft.ifft(P, dim=-3)).type(torch.complex64)
     S_3D = torch.fft.ifft(S, dim=-3)
 
-    print("\tCalculating greens tensor spectrum...")
     G_3D = optics.generate_greens_tensor_spectrum(
         zyx_shape=(z_total, zyx_shape[1], zyx_shape[2]),
         zyx_pixel_size=(z_pixel_size, yx_pixel_size, yx_pixel_size),
@@ -199,13 +193,11 @@ def _calculate_wrap_unsafe_transfer_function(
 
     del P_3D, G_3D, S_3D
 
-    print("\tComputing pg and ps...")
     pg = torch.fft.fftn(PG_3D, dim=(-3, -2, -1))
     ps = torch.fft.fftn(PS_3D, dim=(-3, -2, -1))
 
     del PG_3D, PS_3D
 
-    print("\tComputing H1 and H2...")
     H1 = torch.fft.ifftn(
         torch.einsum("ipzyx,jkzyx->ijpkzyx", pg, torch.conj(ps)),
         dim=(-3, -2, -1),
@@ -227,7 +219,6 @@ def _calculate_wrap_unsafe_transfer_function(
     Y = util.gellmann()[[0, 4, 8]]
     # select phase f00 and transverse linear isotropic terms 2-2, and f22
 
-    print("\tComputing final transfer function...")
     sfZYX_transfer_function = torch.einsum("sik,ikpjzyx,lpj->slzyx", s, H_re, Y)
     return (
         sfZYX_transfer_function,
@@ -237,7 +228,6 @@ def _calculate_wrap_unsafe_transfer_function(
 
 def calculate_singular_system(sfZYX_transfer_function):
     # Compute regularized inverse filter
-    print("Computing SVD")
     ZYXsf_transfer_function = sfZYX_transfer_function.permute(2, 3, 4, 0, 1)
     U, S, Vh = torch.linalg.svd(ZYXsf_transfer_function, full_matrices=False)
     singular_system = (
@@ -285,7 +275,6 @@ def apply_inverse_transfer_function(
     TV_iterations: int = 10,
 ):
     # Key computation
-    print("Computing inverse filter")
     U, S, Vh = singular_system
     S_reg = S / (S**2 + regularization_strength)
     sfzyx_inverse_filter = torch.einsum("sjzyx,jzyx,jfzyx->sfzyx", U, S_reg, Vh)

--- a/waveorder/models/isotropic_fluorescent_thin_3d.py
+++ b/waveorder/models/isotropic_fluorescent_thin_3d.py
@@ -171,7 +171,8 @@ def _calculate_wrap_unsafe_transfer_function(
     numerical_aperture_detection: Union[float, Tensor],
 ) -> Tensor:
     """Calculate wrap-unsafe transfer function for fluorescent imaging."""
-    radial_frequencies = util.generate_radial_frequencies(yx_shape, yx_pixel_size)
+    z_positions = torch.as_tensor(z_position_list, dtype=torch.float32)
+    radial_frequencies = util.generate_radial_frequencies(yx_shape, yx_pixel_size).to(z_positions.device)
 
     det_pupil = optics.generate_pupil(
         radial_frequencies,
@@ -183,7 +184,7 @@ def _calculate_wrap_unsafe_transfer_function(
         radial_frequencies,
         det_pupil,
         wavelength_emission / index_of_refraction_media,
-        torch.as_tensor(z_position_list, dtype=torch.float32),
+        z_positions,
     )
 
     parts = []

--- a/waveorder/models/isotropic_fluorescent_thin_3d.py
+++ b/waveorder/models/isotropic_fluorescent_thin_3d.py
@@ -172,7 +172,7 @@ def _calculate_wrap_unsafe_transfer_function(
 ) -> Tensor:
     """Calculate wrap-unsafe transfer function for fluorescent imaging."""
     z_positions = torch.as_tensor(z_position_list, dtype=torch.float32)
-    radial_frequencies = util.generate_radial_frequencies(yx_shape, yx_pixel_size).to(z_positions.device)
+    radial_frequencies = util.generate_radial_frequencies(yx_shape, yx_pixel_size, device=z_positions.device)
 
     det_pupil = optics.generate_pupil(
         radial_frequencies,

--- a/waveorder/models/isotropic_fluorescent_thin_3d.py
+++ b/waveorder/models/isotropic_fluorescent_thin_3d.py
@@ -302,7 +302,6 @@ def apply_inverse_transfer_function(
         TV is not implemented
     """
     if reconstruction_algorithm == "Tikhonov":
-        print("Computing inverse filter")
         U, S, Vh = singular_system
         S_reg = S / (S**2 + regularization_strength)
         sfyx_inverse_filter = torch.einsum("sj...,j...,jf...->fs...", U, S_reg, Vh)

--- a/waveorder/models/isotropic_thin_3d.py
+++ b/waveorder/models/isotropic_thin_3d.py
@@ -151,8 +151,9 @@ def _calculate_wrap_unsafe_transfer_function(
     if invert_phase_contrast:
         z_positions = -z_positions
 
-    fyy, fxx = util.generate_frequencies(yx_shape, yx_pixel_size)
-    radial_frequencies = torch.sqrt(fyy**2 + fxx**2)
+    with torch.no_grad():
+        fyy, fxx = util.generate_frequencies(yx_shape, yx_pixel_size)
+        radial_frequencies = torch.sqrt(fyy**2 + fxx**2)
 
     illumination_pupil = optics.generate_tilted_pupil(
         fxx,

--- a/waveorder/models/isotropic_thin_3d.py
+++ b/waveorder/models/isotropic_thin_3d.py
@@ -366,7 +366,6 @@ def apply_inverse_transfer_function(
 
     # TODO Consider refactoring with vectorial transfer function SVD
     if reconstruction_algorithm == "Tikhonov":
-        print("Computing inverse filter")
         U, S, Vh = singular_system
         S_reg = S / (S**2 + regularization_strength)
         sfyx_inverse_filter = torch.einsum("sj...,j...,jf...->fs...", U, S_reg, Vh)

--- a/waveorder/models/isotropic_thin_3d.py
+++ b/waveorder/models/isotropic_thin_3d.py
@@ -111,18 +111,9 @@ def calculate_transfer_function(
         pupil_steepness=pupil_steepness,
     )
 
-    absorption_parts = []
-    phase_parts = []
-    for z in range(len(z_position_list)):
-        absorption_parts.append(sampling.nd_fourier_central_cuboid(absorption_2d_to_3d_transfer_function[z], yx_shape))
-        phase_parts.append(sampling.nd_fourier_central_cuboid(phase_2d_to_3d_transfer_function[z], yx_shape))
-
-    absorption_2d_to_3d_transfer_function_out = torch.stack(absorption_parts, dim=0)
-    phase_2d_to_3d_transfer_function_out = torch.stack(phase_parts, dim=0)
-
     return (
-        absorption_2d_to_3d_transfer_function_out,
-        phase_2d_to_3d_transfer_function_out,
+        sampling.nd_fourier_central_cuboid(absorption_2d_to_3d_transfer_function, yx_shape),
+        sampling.nd_fourier_central_cuboid(phase_2d_to_3d_transfer_function, yx_shape),
     )
 
 
@@ -186,22 +177,9 @@ def _calculate_wrap_unsafe_transfer_function(
         z_positions,
     )
 
-    # Build transfer functions without in-place ops (gradient-friendly)
-    abs_parts = []
-    phase_parts = []
-    for z in range(z_positions.shape[0]):
-        abs_tf_z, phase_tf_z = optics.compute_weak_object_transfer_function_2d(
-            illumination_pupil, detection_pupil * propagation_kernel[z]
-        )
-        abs_parts.append(abs_tf_z)
-        phase_parts.append(phase_tf_z)
-
-    absorption_2d_to_3d_transfer_function = torch.stack(abs_parts, dim=0)
-    phase_2d_to_3d_transfer_function = torch.stack(phase_parts, dim=0)
-
-    return (
-        absorption_2d_to_3d_transfer_function,
-        phase_2d_to_3d_transfer_function,
+    # Batched WOTF: (Y,X) * (Z,Y,X) broadcasts to (Z,Y,X)
+    return optics.compute_weak_object_transfer_function_2d(
+        illumination_pupil, detection_pupil.unsqueeze(0) * propagation_kernel
     )
 
 

--- a/waveorder/models/isotropic_thin_3d.py
+++ b/waveorder/models/isotropic_thin_3d.py
@@ -153,6 +153,7 @@ def _calculate_wrap_unsafe_transfer_function(
 
     with torch.no_grad():
         fyy, fxx = util.generate_frequencies(yx_shape, yx_pixel_size)
+        fyy, fxx = fyy.to(z_positions.device), fxx.to(z_positions.device)
         radial_frequencies = torch.sqrt(fyy**2 + fxx**2)
 
     illumination_pupil = optics.generate_tilted_pupil(

--- a/waveorder/models/isotropic_thin_3d.py
+++ b/waveorder/models/isotropic_thin_3d.py
@@ -152,8 +152,7 @@ def _calculate_wrap_unsafe_transfer_function(
         z_positions = -z_positions
 
     with torch.no_grad():
-        fyy, fxx = util.generate_frequencies(yx_shape, yx_pixel_size)
-        fyy, fxx = fyy.to(z_positions.device), fxx.to(z_positions.device)
+        fyy, fxx = util.generate_frequencies(yx_shape, yx_pixel_size, device=z_positions.device)
         radial_frequencies = torch.sqrt(fyy**2 + fxx**2)
 
     illumination_pupil = optics.generate_tilted_pupil(

--- a/waveorder/optics.py
+++ b/waveorder/optics.py
@@ -188,14 +188,13 @@ def generate_tilted_pupil(
     K = n / lamb_in
     cos_alpha_max = torch.sqrt(torch.clamp(1 - (NA / n) ** 2, min=0.0))
 
-    # Pixel-based slope: slope / df gives steepness per frequency unit
-    df = torch.abs(fxx[0, 1] - fxx[0, 0])
-    pixel_slope = slope / df
-
-    # fz on the Ewald sphere
-    fz_sq = K**2 - fxx**2 - fyy**2
-    fz = torch.sqrt(torch.clamp(fz_sq, min=0.0))
-    inside_sphere = (fz_sq >= 0).to(fxx.dtype)
+    # Grid-derived quantities don't need gradients
+    with torch.no_grad():
+        df = torch.abs(fxx[0, 1] - fxx[0, 0])
+        pixel_slope = slope / df
+        fz_sq = K**2 - fxx**2 - fyy**2
+        inside_sphere = (fz_sq >= 0).to(fxx.dtype)
+        fz = torch.sqrt(torch.clamp(fz_sq, min=0.0))
 
     # Tilt direction unit vector
     sx = torch.sin(tilt_angle_zenith) * torch.cos(tilt_angle_azimuth)

--- a/waveorder/optics.py
+++ b/waveorder/optics.py
@@ -792,9 +792,13 @@ def compute_weak_object_transfer_function_2d(illumination_pupil, detection_pupil
 
     H1 = torch.fft.ifft2(torch.conj(SP_hat) * P_hat)
     H2 = torch.fft.ifft2(SP_hat * torch.conj(P_hat))
-    I_norm = torch.sum(illumination_pupil * detection_pupil * torch.conj(detection_pupil))
-    absorption_transfer_function = (H1 + H2) / I_norm
-    phase_transfer_function = 1j * (H1 - H2) / I_norm
+    inv_I_norm = 1 / torch.sum(
+        illumination_pupil * detection_pupil * torch.conj(detection_pupil),
+        dim=(-2, -1),
+        keepdim=True,
+    )
+    absorption_transfer_function = (H1 + H2) * inv_I_norm
+    phase_transfer_function = (H1 - H2) * (inv_I_norm * 1j)
 
     return absorption_transfer_function, phase_transfer_function
 

--- a/waveorder/optim/__init__.py
+++ b/waveorder/optim/__init__.py
@@ -6,13 +6,14 @@ from waveorder.optim._types import (
     extract_optimizable_params,
     has_optimizable_params,
 )
-from waveorder.optim.logging import OptimLogger, PrintLogger, TensorBoardLogger
+from waveorder.optim.logging import NullLogger, OptimLogger, PrintLogger, TensorBoardLogger
 from waveorder.optim.optimize import OptimizationResult, optimize_reconstruction
 
 __all__ = [
     "OptimizableFloat",
     "OptimizableValue",
     "OptimizationResult",
+    "NullLogger",
     "OptimLogger",
     "PrintLogger",
     "TensorBoardLogger",

--- a/waveorder/optim/logging.py
+++ b/waveorder/optim/logging.py
@@ -13,6 +13,19 @@ class OptimLogger(Protocol):
     def close(self) -> None: ...
 
 
+class NullLogger:
+    """Silent logger (default)."""
+
+    def log_scalar(self, tag: str, value: float, step: int) -> None:
+        pass
+
+    def log_image(self, tag: str, image: Tensor, step: int) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+
 class PrintLogger:
     """Logger that prints to stdout."""
 

--- a/waveorder/optim/optimize.py
+++ b/waveorder/optim/optimize.py
@@ -11,7 +11,7 @@ import torch
 from torch import Tensor
 from tqdm import tqdm
 
-from waveorder.optim.logging import OptimLogger, PrintLogger
+from waveorder.optim.logging import NullLogger, OptimLogger
 
 
 @dataclass
@@ -62,7 +62,7 @@ def optimize_reconstruction(
         Contains optimized parameter values, loss history, and final reconstruction.
     """
     if logger is None:
-        logger = PrintLogger()
+        logger = NullLogger()
 
     if fixed_params is None:
         fixed_params = {}

--- a/waveorder/sampling.py
+++ b/waveorder/sampling.py
@@ -70,17 +70,26 @@ def axial_nyquist(
 def nd_fourier_central_cuboid(source, target_shape):
     """Central cuboid of an N-D Fourier transform.
 
+    If ``target_shape`` has fewer dimensions than ``source``, the
+    central cuboid is taken from the last ``len(target_shape)``
+    dimensions, preserving leading (batch) dimensions.
+
     Parameters
     ----------
     source : torch.Tensor
-        Source tensor
+        Source tensor.
     target_shape : tuple of int
+        Target spatial shape.
 
     Returns
     -------
     torch.Tensor
-        Center cuboid in Fourier space
-
+        Center cuboid in Fourier space.
     """
-    center_slices = tuple(slice((s - o) // 2, (s - o) // 2 + o) for s, o in zip(source.shape, target_shape))
-    return torch.fft.ifftshift(torch.fft.fftshift(source)[center_slices])
+    n_dim = len(target_shape)
+    dims = tuple(range(source.ndim))[-n_dim:]
+    center_slices = tuple(
+        slice((s - o) // 2, (s - o) // 2 + o) for s, o in zip(source.shape[-n_dim:], target_shape, strict=True)
+    )
+    center_slices = (slice(None),) * (source.ndim - n_dim) + center_slices
+    return torch.fft.ifftshift(torch.fft.fftshift(source, dim=dims)[center_slices], dim=dims)

--- a/waveorder/util.py
+++ b/waveorder/util.py
@@ -292,6 +292,7 @@ def gen_coordinate(
         y spatial frequency array with shape ``(Ny, Nx)``.
     """
     N, M = img_dim
+    ps = float(ps)
 
     fx = torch.fft.fftfreq(M, ps)
     fy = torch.fft.fftfreq(N, ps)

--- a/waveorder/util.py
+++ b/waveorder/util.py
@@ -268,42 +268,38 @@ def generate_sphere_target(zyx_shape, yx_pixel_size, z_pixel_size, radius, blur_
     return sphere, azimuth, inc_angle
 
 
-def gen_coordinate(img_dim, ps):
+def gen_coordinate(
+    img_dim: tuple[int, int], ps: float
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Generate spatial and spatial frequency coordinate arrays.
+
+    Parameters
+    ----------
+    img_dim : tuple of int
+        Shape of the computed 2D space ``(Ny, Nx)``.
+    ps : float
+        Transverse pixel size of the image space.
+
+    Returns
+    -------
+    xx : torch.Tensor
+        x coordinate array with shape ``(Ny, Nx)``.
+    yy : torch.Tensor
+        y coordinate array with shape ``(Ny, Nx)``.
+    fxx : torch.Tensor
+        x spatial frequency array with shape ``(Ny, Nx)``.
+    fyy : torch.Tensor
+        y spatial frequency array with shape ``(Ny, Nx)``.
     """
-
-    generate spatial and spatial frequency coordinate arrays
-
-    Input:
-        img_dim : tuple
-                  shape of the computed 2D space with size of (Ny, Nx)
-
-        ps      : float
-                  transverse pixel size of the image space
-
-    Output:
-        xx      : numpy.ndarray
-                  x coordinate array with the size of (Ny, Nx)
-
-        yy      : numpy.ndarray
-                  y coordinate array with the size of (Ny, Nx)
-
-        fxx     : numpy.ndarray
-                  x component of 2D spatial frequency array with the size of (Ny, Nx)
-
-        fyy     : numpy.ndarray
-                  y component of 2D spatial frequency array with the size of (Ny, Nx)
-
-    """
-
     N, M = img_dim
 
-    fx = ifftshift((np.r_[:M] - M / 2) / M / ps)
-    fy = ifftshift((np.r_[:N] - N / 2) / N / ps)
-    x = ifftshift((np.r_[:M] - M / 2) * ps)
-    y = ifftshift((np.r_[:N] - N / 2) * ps)
+    fx = torch.fft.fftfreq(M, ps)
+    fy = torch.fft.fftfreq(N, ps)
+    x = torch.fft.ifftshift((torch.arange(M, dtype=torch.float64) - M / 2) * ps)
+    y = torch.fft.ifftshift((torch.arange(N, dtype=torch.float64) - N / 2) * ps)
 
-    xx, yy = np.meshgrid(x, y)
-    fxx, fyy = np.meshgrid(fx, fy)
+    xx, yy = torch.meshgrid(x, y, indexing="xy")
+    fxx, fyy = torch.meshgrid(fx, fy, indexing="xy")
 
     return (xx, yy, fxx, fyy)
 

--- a/waveorder/util.py
+++ b/waveorder/util.py
@@ -269,7 +269,9 @@ def generate_sphere_target(zyx_shape, yx_pixel_size, z_pixel_size, radius, blur_
 
 
 def gen_coordinate(
-    img_dim: tuple[int, int], ps: float
+    img_dim: tuple[int, int],
+    ps: float,
+    device: str | torch.device | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """Generate spatial and spatial frequency coordinate arrays.
 
@@ -279,6 +281,8 @@ def gen_coordinate(
         Shape of the computed 2D space ``(Ny, Nx)``.
     ps : float
         Transverse pixel size of the image space.
+    device : str, torch.device, or None
+        Output tensor device.
 
     Returns
     -------
@@ -294,10 +298,10 @@ def gen_coordinate(
     N, M = img_dim
     ps = float(ps)
 
-    fx = torch.fft.fftfreq(M, ps)
-    fy = torch.fft.fftfreq(N, ps)
-    x = torch.fft.ifftshift((torch.arange(M, dtype=torch.float64) - M / 2) * ps)
-    y = torch.fft.ifftshift((torch.arange(N, dtype=torch.float64) - N / 2) * ps)
+    fx = torch.fft.fftfreq(M, ps, device=device)
+    fy = torch.fft.fftfreq(N, ps, device=device)
+    x = torch.fft.ifftshift((torch.arange(M, dtype=torch.float32, device=device) - M / 2) * ps)
+    y = torch.fft.ifftshift((torch.arange(N, dtype=torch.float32, device=device) - N / 2) * ps)
 
     xx, yy = torch.meshgrid(x, y, indexing="xy")
     fxx, fyy = torch.meshgrid(fx, fy, indexing="xy")
@@ -305,15 +309,15 @@ def gen_coordinate(
     return (xx, yy, fxx, fyy)
 
 
-def generate_frequencies(img_dim, ps):
-    fy = torch.fft.fftfreq(img_dim[0], ps)
-    fx = torch.fft.fftfreq(img_dim[1], ps)
+def generate_frequencies(img_dim, ps, device=None):
+    fy = torch.fft.fftfreq(img_dim[0], ps, device=device)
+    fx = torch.fft.fftfreq(img_dim[1], ps, device=device)
     fyy, fxx = torch.meshgrid(fy, fx, indexing="ij")
     return fyy, fxx
 
 
-def generate_radial_frequencies(img_dim, ps):
-    fyy, fxx = generate_frequencies(img_dim, ps)
+def generate_radial_frequencies(img_dim, ps, device=None):
+    fyy, fxx = generate_frequencies(img_dim, ps, device=device)
     return torch.sqrt(fyy**2 + fxx**2)
 
 

--- a/waveorder/waveorder_reconstructor.py
+++ b/waveorder/waveorder_reconstructor.py
@@ -387,7 +387,9 @@ class waveorder_microscopy:
 
         if QLIPP_birefringence_only == False:
             # setup microscocpe variables
-            self.xx, self.yy, self.fxx, self.fyy = gen_coordinate((self.N, self.M), ps)
+            xx, yy, fxx, fyy = gen_coordinate((self.N, self.M), ps)
+            self.xx, self.yy = xx.numpy(), yy.numpy()
+            self.fxx, self.fyy = fxx.numpy(), fyy.numpy()
             self.frr = torch.sqrt(torch.as_tensor(self.fxx**2 + self.fyy**2, dtype=torch.float32))
             self.Pupil_obj = generate_pupil(self.frr, self.NA_obj, self.lambda_illu).numpy()
             self.Pupil_support = self.Pupil_obj.copy()
@@ -3130,7 +3132,9 @@ class fluorescence_microscopy:
         self.deconv_mode = deconv_mode
 
         # setup microscocpe variables
-        self.xx, self.yy, self.fxx, self.fyy = gen_coordinate((self.N, self.M), ps)
+        xx, yy, fxx, fyy = gen_coordinate((self.N, self.M), ps)
+        self.xx, self.yy = xx.numpy(), yy.numpy()
+        self.fxx, self.fyy = fxx.numpy(), fyy.numpy()
 
         # Setup defocus kernel
         self.Hz_det_setup(deconv_mode)

--- a/waveorder/waveorder_simulator.py
+++ b/waveorder/waveorder_simulator.py
@@ -99,7 +99,9 @@ class waveorder_microscopy_simulator:
         self.chi = chi
 
         # setup microscocpe variables
-        self.xx, self.yy, self.fxx, self.fyy = gen_coordinate((self.N, self.M), ps)
+        xx, yy, fxx, fyy = gen_coordinate((self.N, self.M), ps)
+        self.xx, self.yy = xx.numpy(), yy.numpy()
+        self.fxx, self.fyy = fxx.numpy(), fyy.numpy()
         self.frr = torch.sqrt(torch.as_tensor(self.fxx**2 + self.fyy**2, dtype=torch.float32))
 
         self.Pupil_obj = generate_pupil(self.frr, self.NA_obj, self.lambda_illu).numpy()


### PR DESCRIPTION
Supersedes #528 and the computation speedup portions of #526 (both had stale targets). The CUDA streaming pipeline from #526 will follow as a separate PR from @srivarra.

**Contributions**

This PR integrates optimizations from @jookuma (#528) and @mark-a-potts (#526), rebased onto current main and adapted to work with the API layer from #525.

- @jookuma: batched WOTF, batched `nd_fourier_central_cuboid`, `stretched_matrix_multiply`, `gen_coordinate` → torch, `torch.no_grad()` for grid quantities, z-index pre-allocation
- @mark-a-potts: verbose print removal, device placement pattern

**Speedup per commit at (9, 410, 410)**

| Commit | Iter time | vs main |
|--------|-----------|---------|
| **main** (baseline) | 270ms | 1.0x |
| batch WOTF + fourier cuboid | 208ms | 1.3x |
| batch filter bank (`stretched_matrix_multiply`) | 159ms | 1.7x |
| `gen_coordinate` → torch (fftfreq) | 150ms | 1.8x |
| `torch.no_grad()` for grid quantities | ~150ms | 1.8x |
| NullLogger (silent by default) | ~145ms | 1.9x |
| `device="mps"` (Apple Silicon) | **80ms** | **3.4x** |

Reconstruction outputs are unchanged, all diffs are floating-point noise.