### PR TITLE
Warn on pixel size mismatch and add `--write-config-scale-to-output` flag

### DIFF
--- a/tests/cli_tests/test_reconstruct.py
+++ b/tests/cli_tests/test_reconstruct.py
@@ -339,6 +339,7 @@ def test_cli_apply_inv_tf_mock(tmp_input_path_zarr):
             Path(tmp_config_yml),
             Path(result_path),
             1,
+            False,
         )
         assert result_inv.exit_code == 0
 
@@ -375,3 +376,109 @@ def test_cli_apply_inv_tf_output(tmp_input_path_zarr, capsys):
 
         # Check scale transformations pass through
         assert input_scale == result_dataset.scale
+
+
+def test_pixel_size_mismatch_warning(tmp_path):
+    """Warn when input zarr scale and config pixel sizes differ by >5%."""
+    import warnings as _warnings
+
+    input_path = tmp_path / "mismatch_input.zarr"
+    output_path = tmp_path / "mismatch_output.zarr"
+
+    channel_names = ["Brightfield"]
+    # Input scale with pixel sizes that differ from default config values
+    mismatched_scale = [1, 1, 0.5, 0.2, 0.2]  # z=0.5, yx=0.2
+    dataset = open_ome_zarr(input_path, layout="hcs", mode="w", channel_names=channel_names)
+    position = dataset.create_position("0", "0", "0")
+    position.create_zeros(
+        "0",
+        (1, 1, 4, 5, 6),
+        dtype=np.uint16,
+        transform=[TransformationMeta(type="scale", scale=mismatched_scale)],
+    )
+    dataset.close()
+
+    # Config with default pixel sizes (z=0.25, yx=0.1) — differ from input by 100%
+    recon_settings = settings.ReconstructionSettings(
+        input_channel_names=channel_names,
+        time_indices="all",
+        reconstruction_dimension=3,
+        phase=settings.PhaseSettings(),
+    )
+    config_path = tmp_path / "mismatch.yml"
+    utils.model_to_yaml(recon_settings, config_path)
+
+    runner = CliRunner()
+    with _warnings.catch_warnings(record=True) as caught:
+        _warnings.simplefilter("always")
+        runner.invoke(
+            cli,
+            [
+                "reconstruct",
+                "-i",
+                str(input_path / "0" / "0" / "0"),
+                "-c",
+                str(config_path),
+                "-o",
+                str(output_path),
+            ],
+            catch_exceptions=False,
+        )
+
+    mismatch_warnings = [w for w in caught if "do not match" in str(w.message).lower()]
+    assert len(mismatch_warnings) > 0, "Expected pixel size mismatch warning"
+
+
+def test_overwrite_scale(tmp_path):
+    """--overwrite-scale should use config pixel sizes in the output."""
+    input_path = tmp_path / "overwrite_input.zarr"
+    output_path = tmp_path / "overwrite_output.zarr"
+
+    channel_names = ["Brightfield"]
+    original_scale = [1, 1, 0.5, 0.2, 0.2]
+    dataset = open_ome_zarr(input_path, layout="hcs", mode="w", channel_names=channel_names)
+    position = dataset.create_position("0", "0", "0")
+    position.create_zeros(
+        "0",
+        (1, 1, 4, 5, 6),
+        dtype=np.uint16,
+        transform=[TransformationMeta(type="scale", scale=original_scale)],
+    )
+    dataset.close()
+
+    # Config with z=0.25, yx=0.1
+    recon_settings = settings.ReconstructionSettings(
+        input_channel_names=channel_names,
+        time_indices="all",
+        reconstruction_dimension=3,
+        phase=settings.PhaseSettings(),
+    )
+    config_path = tmp_path / "overwrite.yml"
+    utils.model_to_yaml(recon_settings, config_path)
+
+    runner = CliRunner()
+    runner.invoke(
+        cli,
+        [
+            "reconstruct",
+            "-i",
+            str(input_path / "0" / "0" / "0"),
+            "-c",
+            str(config_path),
+            "-o",
+            str(output_path),
+            "--overwrite-scale",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert output_path.exists()
+    with open_ome_zarr(output_path) as result:
+        result_scale = result["0/0/0"].scale
+        # T and C scales should be unchanged
+        assert result_scale[0] == original_scale[0]
+        assert result_scale[1] == original_scale[1]
+        # Z, Y, X should match config pixel sizes
+        assert result_scale[2] == 0.25  # z_pixel_size default
+        assert result_scale[3] == 0.1  # yx_pixel_size default
+        assert result_scale[4] == 0.1

--- a/tests/cli_tests/test_reconstruct.py
+++ b/tests/cli_tests/test_reconstruct.py
@@ -429,8 +429,8 @@ def test_pixel_size_mismatch_warning(tmp_path):
     assert len(mismatch_warnings) > 0, "Expected pixel size mismatch warning"
 
 
-def test_overwrite_scale(tmp_path):
-    """--overwrite-scale should use config pixel sizes in the output."""
+def test_write_config_scale_to_output(tmp_path):
+    """--write-config-scale-to-output should use config pixel sizes in the output."""
     input_path = tmp_path / "overwrite_input.zarr"
     output_path = tmp_path / "overwrite_output.zarr"
 
@@ -467,7 +467,7 @@ def test_overwrite_scale(tmp_path):
             str(config_path),
             "-o",
             str(output_path),
-            "--overwrite-scale",
+            "--write-config-scale-to-output",
         ],
         catch_exceptions=False,
     )

--- a/waveorder/cli/apply_inverse_transfer_function.py
+++ b/waveorder/cli/apply_inverse_transfer_function.py
@@ -81,6 +81,15 @@ def _load_transfer_function_dataset(
     return xr.Dataset(variables)
 
 
+class PixelSizeMismatchWarning(UserWarning):
+    """Input zarr pixel sizes disagree with the reconstruction config."""
+
+
+# The CLI suppresses UserWarning at startup to silence torch/CUDA noise;
+# carve out this subclass so the mismatch warning is still shown to the user.
+warnings.filterwarnings("always", category=PixelSizeMismatchWarning)
+
+
 def _get_config_pixel_sizes(settings):
     """Return (z_pixel_size, yx_pixel_size) from config, or None for birefringence-only.
 
@@ -129,7 +138,7 @@ def _warn_pixel_size_mismatch(input_scale, config_pixel_sizes):
             f"(>{rel_tol:.0%} relative difference):\n{detail}\n"
             f"The input zarr's pixel sizes will be used in the output. "
             f"Use --write-config-scale-to-output to use the config's pixel sizes instead.",
-            UserWarning,
+            PixelSizeMismatchWarning,
             stacklevel=2,
         )
 

--- a/waveorder/cli/apply_inverse_transfer_function.py
+++ b/waveorder/cli/apply_inverse_transfer_function.py
@@ -1,3 +1,4 @@
+import math
 import warnings
 from pathlib import Path
 from typing import Literal
@@ -8,6 +9,7 @@ from waveorder.cli.parsing import (
     config_filepath,
     input_position_dirpaths,
     output_dirpath,
+    overwrite_scale,
     processes_option,
     transfer_function_dirpath,
 )
@@ -79,7 +81,64 @@ def _load_transfer_function_dataset(
     return xr.Dataset(variables)
 
 
-def get_reconstruction_output_metadata(position_path: Path, config_path: Path):
+def _get_config_pixel_sizes(settings):
+    """Return (z_pixel_size, yx_pixel_size) from config, or None for birefringence-only.
+
+    Parameters
+    ----------
+    settings : ReconstructionSettings
+        Top-level reconstruction settings.
+
+    Returns
+    -------
+    tuple[float, float] or None
+        (z_pixel_size, yx_pixel_size) if available, None otherwise.
+    """
+    for attr in ("phase", "fluorescence"):
+        sub = getattr(settings, attr, None)
+        if sub is not None:
+            tf = sub.transfer_function
+            return tf.z_pixel_size, tf.yx_pixel_size
+    return None
+
+
+def _warn_pixel_size_mismatch(input_scale, config_pixel_sizes):
+    """Warn if input zarr scale and config pixel sizes differ by more than 5%.
+
+    Parameters
+    ----------
+    input_scale : tuple[float, ...]
+        TCZYX scale from the input dataset.
+    config_pixel_sizes : tuple[float, float]
+        (z_pixel_size, yx_pixel_size) from the reconstruction config.
+    """
+    rel_tol = 0.05
+    z_pixel_size, yx_pixel_size = config_pixel_sizes
+    _, _, z_scale, yx_scale, _ = input_scale
+
+    mismatches = []
+    if not math.isclose(z_scale, z_pixel_size, rel_tol=rel_tol):
+        mismatches.append(f"  z: input={z_scale}, config={z_pixel_size}")
+    if not math.isclose(yx_scale, yx_pixel_size, rel_tol=rel_tol):
+        mismatches.append(f"  yx: input={yx_scale}, config={yx_pixel_size}")
+
+    if mismatches:
+        detail = "\n".join(mismatches)
+        warnings.warn(
+            f"Input pixel sizes do not match reconstruction config "
+            f"(>{rel_tol:.0%} relative difference):\n{detail}\n"
+            f"The input zarr's pixel sizes will be used in the output. "
+            f"Use --overwrite-scale to use the config's pixel sizes instead.",
+            UserWarning,
+            stacklevel=2,
+        )
+
+
+def get_reconstruction_output_metadata(
+    position_path: Path,
+    config_path: Path,
+    overwrite_scale: bool = False,
+):
     # Deferred imports for fast CLI help
     import numpy as np
     from iohub import open_ome_zarr
@@ -111,10 +170,19 @@ def get_reconstruction_output_metadata(position_path: Path, config_path: Path):
     channel_names = settings.output_channel_names
     output_z_shape = 1 if settings.output_z_is_singleton else Z
 
+    scale = input_dataset.scale
+    config_pixel_sizes = _get_config_pixel_sizes(settings)
+    if config_pixel_sizes is not None:
+        if overwrite_scale:
+            z_pixel_size, yx_pixel_size = config_pixel_sizes
+            scale = (scale[0], scale[1], z_pixel_size, yx_pixel_size, yx_pixel_size)
+        else:
+            _warn_pixel_size_mismatch(scale, config_pixel_sizes)
+
     return {
         "shape": (T, len(channel_names), output_z_shape, Y, X),
         "chunks": (1, 1, 1, Y, X),
-        "scale": input_dataset.scale,
+        "scale": scale,
         "channel_names": channel_names,
         "dtype": np.float32,
         "plate_metadata": plate_metadata,
@@ -309,6 +377,7 @@ def apply_inverse_transfer_function_cli(
     config_filepath: Path,
     output_dirpath: Path,
     num_processes,
+    overwrite_scale: bool = False,
 ) -> None:
     # Deferred imports for fast CLI help
     import torch
@@ -320,7 +389,7 @@ def apply_inverse_transfer_function_cli(
     )
 
     # Prepare output store
-    output_metadata = get_reconstruction_output_metadata(input_position_dirpaths[0], config_filepath)
+    output_metadata = get_reconstruction_output_metadata(input_position_dirpaths[0], config_filepath, overwrite_scale)
 
     # Generate position keys - use valid HCS keys for single-position stores
     position_keys = []
@@ -369,12 +438,14 @@ def apply_inverse_transfer_function_cli(
 @config_filepath()
 @output_dirpath()
 @processes_option(default=1)
+@overwrite_scale()
 def _apply_inverse_transfer_function_cli(
     input_position_dirpaths: list[Path],
     transfer_function_dirpath: Path,
     config_filepath: Path,
     output_dirpath: Path,
     num_processes,
+    overwrite_scale: bool,
 ) -> None:
     """Apply an inverse transfer function to a dataset.
 
@@ -391,4 +462,5 @@ def _apply_inverse_transfer_function_cli(
         config_filepath,
         output_dirpath,
         num_processes,
+        overwrite_scale,
     )

--- a/waveorder/cli/apply_inverse_transfer_function.py
+++ b/waveorder/cli/apply_inverse_transfer_function.py
@@ -9,9 +9,9 @@ from waveorder.cli.parsing import (
     config_filepath,
     input_position_dirpaths,
     output_dirpath,
-    overwrite_scale,
     processes_option,
     transfer_function_dirpath,
+    write_config_scale_to_output,
 )
 
 
@@ -128,7 +128,7 @@ def _warn_pixel_size_mismatch(input_scale, config_pixel_sizes):
             f"Input pixel sizes do not match reconstruction config "
             f"(>{rel_tol:.0%} relative difference):\n{detail}\n"
             f"The input zarr's pixel sizes will be used in the output. "
-            f"Use --overwrite-scale to use the config's pixel sizes instead.",
+            f"Use --write-config-scale-to-output to use the config's pixel sizes instead.",
             UserWarning,
             stacklevel=2,
         )
@@ -137,7 +137,7 @@ def _warn_pixel_size_mismatch(input_scale, config_pixel_sizes):
 def get_reconstruction_output_metadata(
     position_path: Path,
     config_path: Path,
-    overwrite_scale: bool = False,
+    write_config_scale_to_output: bool = False,
 ):
     # Deferred imports for fast CLI help
     import numpy as np
@@ -173,7 +173,7 @@ def get_reconstruction_output_metadata(
     scale = input_dataset.scale
     config_pixel_sizes = _get_config_pixel_sizes(settings)
     if config_pixel_sizes is not None:
-        if overwrite_scale:
+        if write_config_scale_to_output:
             z_pixel_size, yx_pixel_size = config_pixel_sizes
             scale = (scale[0], scale[1], z_pixel_size, yx_pixel_size, yx_pixel_size)
         else:
@@ -377,7 +377,7 @@ def apply_inverse_transfer_function_cli(
     config_filepath: Path,
     output_dirpath: Path,
     num_processes,
-    overwrite_scale: bool = False,
+    write_config_scale_to_output: bool = False,
 ) -> None:
     # Deferred imports for fast CLI help
     import torch
@@ -389,7 +389,9 @@ def apply_inverse_transfer_function_cli(
     )
 
     # Prepare output store
-    output_metadata = get_reconstruction_output_metadata(input_position_dirpaths[0], config_filepath, overwrite_scale)
+    output_metadata = get_reconstruction_output_metadata(
+        input_position_dirpaths[0], config_filepath, write_config_scale_to_output
+    )
 
     # Generate position keys - use valid HCS keys for single-position stores
     position_keys = []
@@ -438,14 +440,14 @@ def apply_inverse_transfer_function_cli(
 @config_filepath()
 @output_dirpath()
 @processes_option(default=1)
-@overwrite_scale()
+@write_config_scale_to_output()
 def _apply_inverse_transfer_function_cli(
     input_position_dirpaths: list[Path],
     transfer_function_dirpath: Path,
     config_filepath: Path,
     output_dirpath: Path,
     num_processes,
-    overwrite_scale: bool,
+    write_config_scale_to_output: bool,
 ) -> None:
     """Apply an inverse transfer function to a dataset.
 
@@ -462,5 +464,5 @@ def _apply_inverse_transfer_function_cli(
         config_filepath,
         output_dirpath,
         num_processes,
-        overwrite_scale,
+        write_config_scale_to_output,
     )

--- a/waveorder/cli/parsing.py
+++ b/waveorder/cli/parsing.py
@@ -111,13 +111,13 @@ def processes_option(default: int = None) -> Callable:
     return decorator
 
 
-def overwrite_scale() -> Callable:
+def write_config_scale_to_output() -> Callable:
     def decorator(f: Callable) -> Callable:
         return click.option(
-            "--overwrite-scale",
+            "--write-config-scale-to-output",
             is_flag=True,
             default=False,
-            help="Overwrite output pixel sizes with values from the reconstruction config.",
+            help="Write the reconstruction config's pixel sizes to the output zarr instead of copying from the input.",
         )(f)
 
     return decorator

--- a/waveorder/cli/parsing.py
+++ b/waveorder/cli/parsing.py
@@ -111,6 +111,18 @@ def processes_option(default: int = None) -> Callable:
     return decorator
 
 
+def overwrite_scale() -> Callable:
+    def decorator(f: Callable) -> Callable:
+        return click.option(
+            "--overwrite-scale",
+            is_flag=True,
+            default=False,
+            help="Overwrite output pixel sizes with values from the reconstruction config.",
+        )(f)
+
+    return decorator
+
+
 def unique_id() -> Callable:
     def decorator(f: Callable) -> Callable:
         return click.option(

--- a/waveorder/cli/reconstruct.py
+++ b/waveorder/cli/reconstruct.py
@@ -6,9 +6,9 @@ from waveorder.cli.parsing import (
     config_filepath,
     input_position_dirpaths,
     output_dirpath,
-    overwrite_scale,
     processes_option,
     unique_id,
+    write_config_scale_to_output,
 )
 
 
@@ -18,14 +18,14 @@ from waveorder.cli.parsing import (
 @output_dirpath()
 @processes_option(default=1)
 @unique_id()
-@overwrite_scale()
+@write_config_scale_to_output()
 def _reconstruct_cli(
     input_position_dirpaths,
     config_filepath,
     output_dirpath,
     num_processes,
     unique_id,
-    overwrite_scale,
+    write_config_scale_to_output,
 ):
     """
     Reconstruct a dataset using a configuration file. This is a
@@ -79,7 +79,7 @@ def _reconstruct_cli(
         config_filepath,
         output_dirpath,
         num_processes,
-        overwrite_scale,
+        write_config_scale_to_output,
     )
 
 

--- a/waveorder/cli/reconstruct.py
+++ b/waveorder/cli/reconstruct.py
@@ -6,6 +6,7 @@ from waveorder.cli.parsing import (
     config_filepath,
     input_position_dirpaths,
     output_dirpath,
+    overwrite_scale,
     processes_option,
     unique_id,
 )
@@ -17,12 +18,14 @@ from waveorder.cli.parsing import (
 @output_dirpath()
 @processes_option(default=1)
 @unique_id()
+@overwrite_scale()
 def _reconstruct_cli(
     input_position_dirpaths,
     config_filepath,
     output_dirpath,
     num_processes,
     unique_id,
+    overwrite_scale,
 ):
     """
     Reconstruct a dataset using a configuration file. This is a
@@ -76,6 +79,7 @@ def _reconstruct_cli(
         config_filepath,
         output_dirpath,
         num_processes,
+        overwrite_scale,
     )
 
 


### PR DESCRIPTION
Closes #545, #215, #210.

**Adds a warning:** When pixel sizes in the input zarr's scale metadata differ from the reconstruction config by >5%, a clear warning is emitted showing both values and suggesting `--write-config-scale-to-output`.

**Adds a `--write-config-scale-to-output` flag:** Added to both `reconstruct` and `apply-inv-tf` commands. When set, the output zarr uses the config's pixel sizes (z_pixel_size, yx_pixel_size) instead of copying from the input.