### PR TITLE
Namespace reconstruction settings by output channel names

### DIFF
--- a/tests/cli_tests/test_reconstruct.py
+++ b/tests/cli_tests/test_reconstruct.py
@@ -184,6 +184,12 @@ def test_append_channel_reconstruction(tmp_input_path_zarr):
         assert dataset.channel_names[-1] == "GFP_Density3D"
         assert dataset.channel_names[-2] == "Depolarization"
 
+        # Check that both reconstructions have separate metadata entries (#206)
+        position = dataset["0/0/0"]
+        waveorder_meta = dict(position.zattrs["waveorder"])
+        assert "Retardance,Orientation,Transmittance,Depolarization" in waveorder_meta
+        assert "GFP_Density3D" in waveorder_meta
+
 
 def test_fluorescence_2d_reconstruction(tmp_input_path_zarr):
     """Test 2D fluorescence reconstruction through CLI"""

--- a/waveorder/cli/apply_inverse_transfer_function.py
+++ b/waveorder/cli/apply_inverse_transfer_function.py
@@ -283,8 +283,11 @@ def apply_inverse_transfer_function_single_position(
         for t_idx in time_indices:
             partial_apply_inverse_to_zyx_and_save(t_idx)
 
-    # Save metadata at position level
-    output_dataset.zattrs["settings"] = settings.model_dump()
+    # Save metadata at position level, keyed by output channel names
+    waveorder_meta = dict(output_dataset.zattrs.get("waveorder", {}))
+    channel_key = ",".join(output_channel_names)
+    waveorder_meta[channel_key] = settings.model_dump()
+    output_dataset.zattrs["waveorder"] = waveorder_meta
 
     if verbose:
         echo_headline(f"Closing {output_position_dirpath}\n")


### PR DESCRIPTION
Closes #206

Previously `output_dataset.zattrs["settings"]` was overwritten by consecutive reconstructions, leading to incomplete metadata for multi-reconstructions stores. Now settings are stored under a `"waveorder"` namespace, keyed by output channel names:

```python
from iohub.ngff import open_ome_zarr

dataset = open_ome_zarr("output.zarr")
position = dataset["0/0/0"]
waveorder_meta = position.zattrs["waveorder"]

# Each reconstruction is keyed by its output channel names
fluor_settings = waveorder_meta["GFP_Density3D"]
biref_settings = waveorder_meta["Retardance,Orientation,Transmittance,Depolarization"]
```

Verified with both OME-NGFF v0.4 (zarr v2) and v0.5 (zarr v3).