### PR TITLE
Fix dynamic versioning pattern to match unversioned tags

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,7 @@ vcs = "git"
 style = "pep440"
 bump = true
 fallback-version = "0.0.0"
+pattern = "(?P<base>\\d+\\.\\d+\\.\\d+)"
 
 [tool.ruff]
 line-length = 120


### PR DESCRIPTION
uv-dynamic-versioning defaults to matching tags with a `v` prefix. Our tags don't use a `v` prefix, so I'm adding an explicit pattern.