### PR TITLE
Add benchmarking suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,6 @@ waveorder/_version.py
 /examples/data_temp/*
 /logs/*
 scripts/
+
+# benchmark results
+runs/

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,83 @@
+# WaveOrder Benchmarks
+
+Tracks reconstruction quality and performance. Synthetic cases
+generate a phantom, simulate a measurement, reconstruct via `wo rec`, and
+score against ground truth. Real cases require access to the Biohub HPC and
+reconstruct existing data.
+
+## Install (from scratch)
+
+    git clone https://github.com/mehta-lab/waveorder && cd waveorder
+    uv sync --group bench
+    source .venv/bin/activate  # or prepend `uv run` to commands
+
+`wo bm` / `wo benchmark` appears once the `bench` group is installed
+and the venv is active.
+
+## First run
+
+    export WAVEORDER_BENCH_OUTPUT=/hpc/projects/waveorder/benchmarks  # on biohub HPC
+    wo bm run
+    wo bm latest
+
+## Commands
+
+    wo bm run [--scope synthetic|all] [-e EXPERIMENT] [--save-all]
+        Run cases. Default scope is synthetic (skips hpc cases).
+
+    wo bm latest
+        Summary table (timing, metrics, histograms) for the newest run.
+
+    wo bm history [-n N]
+        List recent run directories.
+
+    wo bm compare [RUN_A RUN_B]
+        Diff metrics between two runs (default: the two newest).
+
+    wo bm view [latest|RUN_NAME][/CASE_NAME]
+        Open raw input + reconstruction side-by-side in napari grid mode.
+
+## Adding a benchmark case
+
+1. Add a reconstruction config to `benchmarks/configs/`.
+2. Add a case to `benchmarks/experiments/regression.yml`:
+
+        my_case:
+          type: synthetic
+          phantom:
+            function: single_bead
+            shape: [64, 128, 128]
+            pixel_sizes: [0.25, 0.1, 0.1]
+            bead_radius_um: 2.5
+          config: ../configs/my_case.yml
+
+   For HPC: `type: hpc`, plus `input` (path to an OME-Zarr) and `position`.
+
+3. `wo bm run --scope synthetic` to run it.
+
+## Custom experiments
+
+Point `-e` at any experiment YAML:
+
+    wo bm run -e my_sweep.yml
+
+Cases can share a `base_phantom` and `base_config` and apply per-case
+`overrides` via dotted keys. See `benchmarks/experiments/regression.yml`
+for the registered suite.
+
+## Output layout
+
+    <output_root>/
+    └── <timestamp>_<experiment>/
+        ├── metadata.json              # git hash, branch, gpu, versions
+        ├── experiment.yml             # copy of the experiment input
+        ├── summary.json               # per-case metrics
+        └── cases/<case>/
+            ├── config.yml             # recon config (after overrides)
+            ├── phantom_config.json    # synthetic only — phantom params
+            ├── phantom.zarr           # synthetic only — ground truth
+            ├── simulated.zarr         # synthetic only — forward model
+            ├── reconstruction.zarr    # `wo rec` output
+            ├── cli_command.sh         # the exact `wo rec` call
+            ├── timing.json
+            └── metrics.json

--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""WaveOrder benchmarking suite."""

--- a/benchmarks/config.py
+++ b/benchmarks/config.py
@@ -1,0 +1,163 @@
+"""Experiment YAML loading, validation, and config management.
+
+An experiment consists of named cases, each specifying a phantom,
+reconstruction config, and case type. Cases can inherit shared
+``base_phantom`` and ``base_config`` from the experiment level.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Literal
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, PositiveFloat, PositiveInt, model_validator
+
+
+class PhantomConfig(BaseModel):
+    """Configuration for phantom generation.
+
+    Parameters
+    ----------
+    function : str
+        Name of the phantom function ("single_bead" or "random_beads").
+    shape : tuple[int, int, int]
+        Volume shape (Z, Y, X) in pixels.
+    pixel_sizes : tuple[float, float, float]
+        (z, y, x) pixel sizes in um.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    function: Literal["single_bead", "random_beads"]
+    shape: tuple[PositiveInt, PositiveInt, PositiveInt] = (64, 128, 128)
+    pixel_sizes: tuple[PositiveFloat, PositiveFloat, PositiveFloat] = (0.25, 0.1, 0.1)
+
+
+class CaseConfig(BaseModel):
+    """Configuration for a single benchmark case."""
+
+    model_config = ConfigDict(extra="allow")
+
+    type: Literal["synthetic", "hpc"] = "synthetic"
+    phantom: PhantomConfig | None = None
+    config: str | None = None
+    overrides: dict[str, Any] | None = None
+    input: str | None = None
+    position: str | None = None
+
+
+class ExperimentConfig(BaseModel):
+    """Top-level experiment configuration.
+
+    Parameters
+    ----------
+    name : str
+        Experiment name (used in output directory naming).
+    base_phantom : PhantomConfig or None
+        Default phantom inherited by cases that don't define their own.
+    base_config : str or None
+        Path to base reconstruction YAML. Cases inherit and can override.
+    cases : dict[str, CaseConfig]
+        Named benchmark cases.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    base_phantom: PhantomConfig | None = None
+    base_config: str | None = None
+    cases: dict[str, CaseConfig] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def inherit_base_phantom(self):
+        """Copy base_phantom into cases that don't define their own."""
+        if self.base_phantom is not None:
+            for case in self.cases.values():
+                if case.phantom is None:
+                    case.phantom = self.base_phantom.model_copy(deep=True)
+        return self
+
+    @model_validator(mode="after")
+    def inherit_base_config(self):
+        """Copy base_config into cases that don't define their own."""
+        if self.base_config is not None:
+            for case in self.cases.values():
+                if case.config is None:
+                    case.config = self.base_config
+        return self
+
+
+def load_experiment(path: str | Path) -> ExperimentConfig:
+    """Load and validate an experiment YAML file.
+
+    Parameters
+    ----------
+    path : str or Path
+        Path to the experiment YAML.
+
+    Returns
+    -------
+    ExperimentConfig
+        Validated experiment configuration.
+    """
+    path = Path(path)
+    with open(path) as f:
+        raw = yaml.safe_load(f)
+    return ExperimentConfig(**raw)
+
+
+def resolve_recon_config(case: CaseConfig, experiment_dir: Path) -> dict:
+    """Resolve the reconstruction config for a case.
+
+    Loads the base config YAML and applies any overrides.
+
+    Parameters
+    ----------
+    case : CaseConfig
+        Case configuration.
+    experiment_dir : Path
+        Directory of the experiment YAML (for resolving relative paths).
+
+    Returns
+    -------
+    dict
+        Resolved reconstruction config dict.
+    """
+    if case.config is None:
+        return {}
+
+    config_path = Path(case.config)
+    if not config_path.is_absolute():
+        config_path = experiment_dir / config_path
+
+    with open(config_path) as f:
+        config = yaml.safe_load(f)
+
+    if case.overrides:
+        for dotted_key, value in case.overrides.items():
+            _deep_set(config, dotted_key.split("."), value)
+
+    return config
+
+
+def infer_modality(recon_config: dict) -> str:
+    """Return ``"phase"`` if the recon config has a phase block, else ``"fluorescence"``."""
+    return "phase" if "phase" in recon_config else "fluorescence"
+
+
+def _deep_set(d: dict, keys: list[str], value: Any):
+    """Set a nested dict value by key path.
+
+    Parameters
+    ----------
+    d : dict
+        Target dict (modified in-place).
+    keys : list[str]
+        Key path, e.g. ["phase", "apply_inverse", "regularization_strength"].
+    value : Any
+        Value to set.
+    """
+    for key in keys[:-1]:
+        d = d.setdefault(key, {})
+    d[keys[-1]] = value

--- a/benchmarks/configs/fluor_3d_beads.yml
+++ b/benchmarks/configs/fluor_3d_beads.yml
@@ -1,0 +1,9 @@
+reconstruction_dimension: 3
+input_channel_names: [GFP]
+fluorescence:
+  transfer_function:
+    yx_pixel_size: 0.1
+    z_pixel_size: 0.25
+    wavelength_emission: 0.532
+    index_of_refraction_media: 1.3
+    numerical_aperture_detection: 1.2

--- a/benchmarks/configs/ops_pheno_phase_2d.yml
+++ b/benchmarks/configs/ops_pheno_phase_2d.yml
@@ -1,0 +1,13 @@
+reconstruction_dimension: 2
+input_channel_names: [BF]
+phase:
+  transfer_function:
+    yx_pixel_size: 0.325
+    z_pixel_size: 2.0
+    wavelength_illumination: 0.45
+    index_of_refraction_media: 1.0
+    numerical_aperture_illumination: 0.4
+    numerical_aperture_detection: 0.55
+    invert_phase_contrast: false
+  apply_inverse:
+    regularization_strength: 0.001

--- a/benchmarks/configs/phase_3d_beads.yml
+++ b/benchmarks/configs/phase_3d_beads.yml
@@ -1,0 +1,10 @@
+reconstruction_dimension: 3
+input_channel_names: [Brightfield]
+phase:
+  transfer_function:
+    yx_pixel_size: 0.1
+    z_pixel_size: 0.25
+    wavelength_illumination: 0.532
+    index_of_refraction_media: 1.3
+    numerical_aperture_illumination: 0.9
+    numerical_aperture_detection: 1.2

--- a/benchmarks/experiments/regression.yml
+++ b/benchmarks/experiments/regression.yml
@@ -1,0 +1,28 @@
+name: regression
+cases:
+  phase_3d_beads:
+    type: synthetic
+    phantom:
+      function: single_bead
+      shape: [64, 128, 128]
+      pixel_sizes: [0.25, 0.1, 0.1]
+      bead_radius_um: 2.5
+      refractive_index_diff: 0.05
+    config: ../configs/phase_3d_beads.yml
+
+  fluor_3d_beads:
+    type: synthetic
+    phantom:
+      function: single_bead
+      shape: [64, 128, 128]
+      pixel_sizes: [0.25, 0.1, 0.1]
+      bead_radius_um: 2.5
+      fluorescence_intensity: 1.0
+      fluorescence_background: 10.0
+    config: ../configs/fluor_3d_beads.yml
+
+  ops_pheno_center:
+    type: hpc
+    input: /hpc/projects/intracellular_dashboard/ops/ops0105_20260106/0-convert/live_imaging/phenotyping_transform.zarr
+    position: A/1/029029
+    config: ../configs/ops_pheno_phase_2d.yml

--- a/benchmarks/metrics.py
+++ b/benchmarks/metrics.py
@@ -1,0 +1,171 @@
+"""Metric computation for benchmarks.
+
+Three metric groups:
+- image_quality (always): distribution stats + self-consistency metrics
+- with_reference (when annotated reference available): ssim, mse, correlation
+- with_phantom (when simulated phantom available): mse vs ground truth
+
+Self-consistency metrics reuse the loss functions from
+``waveorder.optim.losses``, which properly mask to the optical passband.
+"""
+
+from __future__ import annotations
+
+import torch
+from skimage.metrics import structural_similarity
+from torch import Tensor
+from torch.nn.functional import mse_loss
+
+from waveorder.optim.losses import (
+    MidbandPowerLossSettings,
+    SpectralFlatnessLossSettings,
+    TotalVariationLossSettings,
+    build_loss_fn,
+)
+
+# --- image_quality: self-metrics (always computed) ---
+
+
+def distribution_stats(volume: Tensor, n_bins: int = 50) -> dict:
+    """Compute distribution stats: max, min, mean, and histogram.
+
+    Parameters
+    ----------
+    volume : Tensor
+        Input volume of any shape.
+    n_bins : int
+        Number of histogram bins.
+
+    Returns
+    -------
+    dict
+        Keys: max, min, mean, histogram (with bin_edges and counts).
+    """
+    v = volume.float().flatten()
+    hist = torch.histogram(v.cpu(), bins=n_bins)
+    return {
+        "max": volume.max().item(),
+        "min": volume.min().item(),
+        "mean": volume.mean().item(),
+        "histogram": {
+            "bin_edges": hist.bin_edges.tolist(),
+            "counts": hist.hist.tolist(),
+        },
+    }
+
+
+# --- with_reference / with_phantom: comparison metrics ---
+
+
+def comparison_metrics(recon: Tensor, target: Tensor) -> dict:
+    """Compute MSE, SSIM, and Pearson correlation between two volumes.
+
+    Parameters
+    ----------
+    recon : Tensor
+        Reconstruction volume.
+    target : Tensor
+        Target volume (same shape). Can be an annotated reference
+        or simulated phantom ground truth.
+
+    Returns
+    -------
+    dict
+        Keys: mse, ssim, correlation.
+    """
+    a, b = recon.float(), target.float()
+
+    # Pearson correlation via torch.corrcoef
+    corr_matrix = torch.corrcoef(torch.stack([a.flatten(), b.flatten()]))
+    corr = corr_matrix[0, 1].item()
+
+    # SSIM via scikit-image (windowed, proper constants)
+    a_np, b_np = a.cpu().numpy(), b.cpu().numpy()
+    data_range = b_np.max() - b_np.min()
+    ssim_val = structural_similarity(a_np, b_np, data_range=data_range)
+
+    return {
+        "mse": mse_loss(a, b).item(),
+        "ssim": float(ssim_val),
+        "correlation": corr,
+    }
+
+
+# --- Aggregation ---
+
+
+def compute_metrics(
+    recon: Tensor,
+    NA_det: float,
+    wavelength: float,
+    pixel_size: float,
+    reference: Tensor | None = None,
+    phantom: Tensor | None = None,
+    n_bins: int = 50,
+    midband_fractions: tuple[float, float] = (0.125, 0.25),
+) -> dict:
+    """Compute all applicable metric groups.
+
+    Parameters
+    ----------
+    recon : Tensor
+        Reconstruction volume, 2D (Y, X) or 3D (Z, Y, X).
+    NA_det : float
+        Detection numerical aperture.
+    wavelength : float
+        Illumination/emission wavelength (same units as pixel_size).
+    pixel_size : float
+        Object-space pixel size (same units as wavelength).
+    reference : Tensor or None
+        Annotated reference for with_reference comparison.
+    phantom : Tensor or None
+        Ground truth from simulated phantom for with_phantom comparison.
+    n_bins : int
+        Number of histogram bins.
+    midband_fractions : tuple[float, float]
+        Inner and outer fractions of the diffraction-limited cutoff
+        frequency for midband power and spectral flatness.
+
+    Returns
+    -------
+    dict
+        Nested dict with image_quality, and optionally with_reference,
+        with_phantom.
+    """
+    v = recon.float()
+
+    # Reuse loss functions from waveorder.optim.losses — these mask to
+    # the optical passband defined by NA_det / wavelength.
+    # Losses are negated (for minimization), so we negate back.
+    fracs = list(midband_fractions)
+    mbp_fn = build_loss_fn(
+        MidbandPowerLossSettings(midband_fractions=fracs),
+        NA_det,
+        wavelength,
+        pixel_size,
+    )
+    sf_fn = build_loss_fn(
+        SpectralFlatnessLossSettings(midband_fractions=fracs),
+        NA_det,
+        wavelength,
+        pixel_size,
+    )
+    # TV is a real-space metric (optical params unused but required by API)
+    tv_fn = build_loss_fn(TotalVariationLossSettings(), NA_det, wavelength, pixel_size)
+
+    result = {
+        "image_quality": {
+            **distribution_stats(v, n_bins=n_bins),
+            "midband_power": -mbp_fn(v).item(),
+            "spectral_flatness": -sf_fn(v).item(),
+            "total_variation": -tv_fn(v).item(),
+        },
+    }
+
+    if reference is not None:
+        result["with_reference"] = comparison_metrics(v, reference)
+
+    if phantom is not None:
+        result["with_phantom"] = comparison_metrics(v, phantom)
+
+    return result

--- a/benchmarks/runner.py
+++ b/benchmarks/runner.py
@@ -1,0 +1,349 @@
+"""Core benchmark runner: phantom → simulate → wo rec → metrics.
+
+Each synthetic case shells out to ``wo rec`` so the benchmark proves
+the exact CLI workflow. The ``cli_command.sh`` saved alongside each
+case can be copy-pasted for production use.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shlex
+import shutil
+import subprocess
+from pathlib import Path
+
+logging.getLogger("iohub").setLevel(logging.ERROR)
+logging.getLogger("iohub.ngff").setLevel(logging.ERROR)
+logging.getLogger("iohub.ngff.nodes").setLevel(logging.ERROR)
+
+import numpy as np
+import torch
+import yaml
+from iohub.ngff import open_ome_zarr
+from iohub.ngff.models import TransformationMeta
+
+from benchmarks.config import PhantomConfig, infer_modality
+from benchmarks.metrics import compute_metrics
+from benchmarks.simulate import simulate_fluorescence_3d, simulate_phase_3d
+from benchmarks.utils import TimingTree
+from waveorder import phantoms
+
+_PHANTOM_FUNCTIONS = {
+    "single_bead": phantoms.single_bead,
+    "random_beads": phantoms.random_beads,
+}
+
+
+def _extract_optics(tf_settings: dict) -> tuple[float, float, float]:
+    """Pull ``(NA_det, wavelength, pixel_size)`` from a transfer_function block.
+
+    Falls back to values appropriate for a typical microscope when keys
+    are missing. Covers both illumination and emission wavelength keys.
+    """
+    NA_det = tf_settings.get("numerical_aperture_detection", 1.2)
+    wavelength = tf_settings.get(
+        "wavelength_illumination",
+        tf_settings.get("wavelength_emission", 0.532),
+    )
+    pixel_size = tf_settings.get("yx_pixel_size", 0.1)
+    return NA_det, wavelength, pixel_size
+
+
+_SIM_KWARGS = {
+    "phase": {
+        "wavelength_illumination",
+        "index_of_refraction_media",
+        "numerical_aperture_illumination",
+        "numerical_aperture_detection",
+    },
+    "fluorescence": {
+        "wavelength_emission",
+        "index_of_refraction_media",
+        "numerical_aperture_detection",
+    },
+}
+
+_DEFAULT_CHANNEL = {"phase": "Brightfield", "fluorescence": "GFP"}
+
+
+def _sim_kwargs(modality: str, tf_settings: dict) -> dict:
+    """Filter ``tf_settings`` to kwargs accepted by ``simulate_{modality}_3d``."""
+    return {k: v for k, v in tf_settings.items() if k in _SIM_KWARGS[modality]}
+
+
+def _wo_rec_argv(position_path: Path, config_path: Path, recon_path: Path) -> list[str]:
+    """Build the ``wo rec`` argv list shared by subprocess exec and cli_command.sh."""
+    return ["wo", "rec", "-i", str(position_path), "-c", str(config_path), "-o", str(recon_path)]
+
+
+def _run_wo_rec(argv: list[str]) -> None:
+    """Invoke ``wo rec`` via ``argv``, raising on non-zero exit."""
+    env = {**os.environ, "PYTHONWARNINGS": "ignore::UserWarning,ignore::DeprecationWarning"}
+    result = subprocess.run(argv, capture_output=True, text=True, env=env)
+    if result.returncode != 0:
+        raise RuntimeError(f"wo rec failed:\n{result.stderr}")
+
+
+# Storage cap applied to per-case output zarrs. Small synthetic outputs
+# (~4 MB for a bead phantom) pass through; large HPC 3D recons and big
+# simulations are deleted after their metrics are computed. Override
+# with ``save_all=True``.
+SIZE_LIMIT_BYTES = 25 * 1024 * 1024
+
+
+def _dir_size_bytes(path: Path) -> int:
+    """Sum the sizes of all files under ``path`` (recursive)."""
+    if not path.exists():
+        return 0
+    return sum(p.stat().st_size for p in path.rglob("*") if p.is_file())
+
+
+def _cleanup_large_outputs(case_dir: Path, save_all: bool) -> None:
+    """Remove transfer-function zarrs and oversized output zarrs.
+
+    Transfer-function zarrs are always deleted when ``save_all`` is
+    False — they can be regenerated from config and are typically the
+    largest intermediate. ``simulated.zarr`` and ``reconstruction.zarr``
+    are deleted only if they exceed :data:`SIZE_LIMIT_BYTES`.
+    """
+    if save_all:
+        return
+    for p in case_dir.glob("transfer_function_*.zarr"):
+        if p.is_dir():
+            shutil.rmtree(p)
+    for name in ("simulated.zarr", "reconstruction.zarr"):
+        p = case_dir / name
+        if p.is_dir() and _dir_size_bytes(p) > SIZE_LIMIT_BYTES:
+            shutil.rmtree(p)
+
+
+def _build_phantom(phantom_config: PhantomConfig | dict) -> phantoms.Phantom:
+    """Build a phantom from a config.
+
+    Parameters
+    ----------
+    phantom_config : PhantomConfig or dict
+        Phantom configuration. If dict, will be validated as PhantomConfig.
+
+    Returns
+    -------
+    Phantom
+        Generated phantom.
+    """
+    if isinstance(phantom_config, dict):
+        phantom_config = PhantomConfig(**phantom_config)
+    kwargs = phantom_config.model_dump()
+    func_name = kwargs.pop("function")
+    func = _PHANTOM_FUNCTIONS[func_name]
+    return func(**kwargs)
+
+
+def _write_zarr(data: torch.Tensor, path: Path, channel_name: str, pixel_sizes: tuple[float, float, float]):
+    """Write a ZYX tensor as an HCS OME-Zarr readable by ``wo rec``.
+
+    Parameters
+    ----------
+    data : Tensor
+        3D volume (Z, Y, X).
+    path : Path
+        Output zarr path.
+    channel_name : str
+        Name for the single channel.
+    pixel_sizes : tuple[float, float, float]
+        (z, y, x) pixel sizes.
+    """
+    czyx = data.numpy()[None, ...]  # (1, Z, Y, X)
+    dataset = open_ome_zarr(path, layout="hcs", mode="w", channel_names=[channel_name])
+    position = dataset.create_position("0", "0", "0")
+    position.create_zeros(
+        "0",
+        (1, *czyx.shape),
+        dtype=np.float32,
+        transform=[
+            TransformationMeta(
+                type="scale",
+                scale=[1, 1, float(pixel_sizes[0]), float(pixel_sizes[1]), float(pixel_sizes[2])],
+            )
+        ],
+    )
+    position["0"][0] = czyx
+    dataset.close()
+
+
+def _read_zarr(path: Path) -> torch.Tensor:
+    """Read first position, first timepoint from an HCS OME-Zarr.
+
+    Parameters
+    ----------
+    path : Path
+        Path to OME-Zarr.
+
+    Returns
+    -------
+    Tensor
+        Volume as (Z, Y, X) or (C, Z, Y, X) float32 tensor.
+    """
+    dataset = open_ome_zarr(path, layout="hcs", mode="r")
+    position = list(dataset.positions())[0][1]
+    data = torch.tensor(np.array(position["0"][0]), dtype=torch.float32)
+    dataset.close()
+    return data
+
+
+def _run_and_measure(
+    position_path: Path,
+    recon_config: dict,
+    case_dir: Path,
+    tt: TimingTree,
+    ground_truth: torch.Tensor | None = None,
+) -> dict:
+    """Write config, shell out to ``wo rec``, read output, compute metrics.
+
+    Must be called from inside a ``with tt.time("total"):`` block — it
+    adds ``reconstruct`` and ``metrics`` sub-timings.
+    """
+    modality = infer_modality(recon_config)
+    tf_settings = recon_config.get(modality, {}).get("transfer_function", {})
+
+    config_path = case_dir / "config.yml"
+    config_path.write_text(yaml.dump(recon_config, default_flow_style=False))
+
+    recon_path = case_dir / "reconstruction.zarr"
+    argv = _wo_rec_argv(position_path, config_path, recon_path)
+    (case_dir / "cli_command.sh").write_text(f"#!/bin/bash\n{shlex.join(argv)}\n")
+
+    with tt.time("reconstruct"):
+        _run_wo_rec(argv)
+
+    with tt.time("metrics"):
+        recon_data = _read_zarr(recon_path)
+        while recon_data.ndim > 3:
+            recon_data = recon_data[0]
+        NA_det, wavelength, pixel_size = _extract_optics(tf_settings)
+        return compute_metrics(
+            recon_data,
+            NA_det=NA_det,
+            wavelength=wavelength,
+            pixel_size=pixel_size,
+            phantom=ground_truth,
+        )
+
+
+def _finalize_case(case_dir: Path, tt: TimingTree, metrics: dict, save_all: bool) -> None:
+    """Persist timing + metrics and run the storage-cap cleanup."""
+    tt.save(case_dir / "timing.json")
+    (case_dir / "metrics.json").write_text(json.dumps(metrics, indent=2))
+    _cleanup_large_outputs(case_dir, save_all)
+
+
+def run_synthetic_case(
+    phantom_config: dict,
+    recon_config: dict,
+    case_dir: Path,
+    modality: str = "phase",
+    save_all: bool = False,
+) -> dict:
+    """Run a single synthetic benchmark case via ``wo rec``.
+
+    Parameters
+    ----------
+    phantom_config : dict
+        Phantom generation parameters (see experiment YAML).
+    recon_config : dict
+        Reconstruction config dict (parsed from YAML).
+    case_dir : Path
+        Output directory for this case.
+    modality : str
+        "phase" or "fluorescence".
+    save_all : bool
+        Keep all intermediate outputs. When False (default), transfer
+        function zarrs are deleted and ``simulated.zarr`` /
+        ``reconstruction.zarr`` larger than
+        :data:`SIZE_LIMIT_BYTES` are deleted after metrics are computed.
+
+    Returns
+    -------
+    dict
+        Metrics dict from compute_metrics.
+    """
+    case_dir.mkdir(parents=True, exist_ok=True)
+    tt = TimingTree()
+
+    with tt.time("total"):
+        with tt.time("phantom"):
+            phantom = _build_phantom(phantom_config)
+        (case_dir / "phantom_config.json").write_text(json.dumps(phantom.metadata, indent=2))
+
+        with tt.time("simulate"):
+            tf_settings = recon_config.get(modality, {}).get("transfer_function", {})
+            sim_kwargs = _sim_kwargs(modality, tf_settings)
+            if modality == "phase":
+                data = simulate_phase_3d(phantom, **sim_kwargs)
+            elif modality == "fluorescence":
+                data = simulate_fluorescence_3d(phantom, background=0, **sim_kwargs)
+            else:
+                raise ValueError(f"Unknown modality: {modality}")
+            channel_name = recon_config.get("input_channel_names", [_DEFAULT_CHANNEL[modality]])[0]
+
+        simulated_path = case_dir / "simulated.zarr"
+        _write_zarr(data, simulated_path, channel_name, phantom.pixel_sizes)
+
+        ground_truth = phantom.phase if modality == "phase" else phantom.fluorescence
+        metrics = _run_and_measure(
+            position_path=simulated_path / "0" / "0" / "0",
+            recon_config=recon_config,
+            case_dir=case_dir,
+            tt=tt,
+            ground_truth=ground_truth,
+        )
+
+    _finalize_case(case_dir, tt, metrics, save_all)
+    return metrics
+
+
+def run_hpc_case(
+    input_path: str,
+    position: str,
+    recon_config: dict,
+    case_dir: Path,
+    save_all: bool = False,
+) -> dict:
+    """Run a single HPC benchmark case on existing data via ``wo rec``.
+
+    Parameters
+    ----------
+    input_path : str
+        Path to input OME-Zarr store.
+    position : str
+        Position key within the store (e.g. "A/1/029029").
+    recon_config : dict
+        Reconstruction config dict.
+    case_dir : Path
+        Output directory for this case.
+    save_all : bool
+        Keep all intermediate outputs. When False (default), the
+        transfer function zarr is deleted and ``reconstruction.zarr``
+        is deleted if it exceeds :data:`SIZE_LIMIT_BYTES` after metrics
+        are computed.
+
+    Returns
+    -------
+    dict
+        Metrics dict from compute_metrics.
+    """
+    case_dir.mkdir(parents=True, exist_ok=True)
+    tt = TimingTree()
+
+    with tt.time("total"):
+        metrics = _run_and_measure(
+            position_path=Path(input_path) / position,
+            recon_config=recon_config,
+            case_dir=case_dir,
+            tt=tt,
+        )
+
+    _finalize_case(case_dir, tt, metrics, save_all)
+    return metrics

--- a/benchmarks/simulate.py
+++ b/benchmarks/simulate.py
@@ -1,0 +1,110 @@
+"""Forward model simulation: phantom + config → simulated measurement."""
+
+from __future__ import annotations
+
+from torch import Tensor
+
+from waveorder.models import isotropic_fluorescent_thick_3d, phase_thick_3d
+from waveorder.phantoms import Phantom
+
+
+def simulate_phase_3d(
+    phantom: Phantom,
+    wavelength_illumination: float = 0.532,
+    index_of_refraction_media: float = 1.3,
+    numerical_aperture_illumination: float = 0.9,
+    numerical_aperture_detection: float = 1.2,
+    brightness: float = 1e3,
+) -> Tensor:
+    """Simulate 3D phase measurement from a phantom.
+
+    Applies the weak object transfer function to the phantom's phase
+    channel to produce a simulated brightfield measurement.
+
+    Parameters
+    ----------
+    phantom : Phantom
+        Ground truth phantom. Uses ``phantom.phase`` (units: dn).
+    wavelength_illumination : float
+        Illumination wavelength in um.
+    index_of_refraction_media : float
+        Refractive index of the surrounding medium.
+    numerical_aperture_illumination : float
+        Condenser NA.
+    numerical_aperture_detection : float
+        Objective NA.
+    brightness : float
+        Brightness scaling for the forward model.
+
+    Returns
+    -------
+    Tensor
+        Simulated 3D brightfield data, shape (Z, Y, X).
+    """
+    z_pixel_size, yx_pixel_size, _ = phantom.pixel_sizes
+    zyx_shape = tuple(phantom.phase.shape)
+
+    # Convert dn to phase in cycles per voxel
+    wavelength_medium = wavelength_illumination / index_of_refraction_media
+    zyx_phase = phantom.phase * z_pixel_size / wavelength_medium
+
+    real_tf, _ = phase_thick_3d.calculate_transfer_function(
+        zyx_shape,
+        yx_pixel_size,
+        z_pixel_size,
+        wavelength_illumination=wavelength_illumination,
+        z_padding=0,
+        index_of_refraction_media=index_of_refraction_media,
+        numerical_aperture_illumination=numerical_aperture_illumination,
+        numerical_aperture_detection=numerical_aperture_detection,
+    )
+
+    return phase_thick_3d.apply_transfer_function(zyx_phase, real_tf, z_padding=0, brightness=brightness)
+
+
+def simulate_fluorescence_3d(
+    phantom: Phantom,
+    wavelength_emission: float = 0.532,
+    index_of_refraction_media: float = 1.3,
+    numerical_aperture_detection: float = 1.2,
+    background: int = 10,
+) -> Tensor:
+    """Simulate 3D fluorescence measurement from a phantom.
+
+    Applies the optical transfer function to the phantom's fluorescence
+    channel to produce a simulated widefield measurement.
+
+    Parameters
+    ----------
+    phantom : Phantom
+        Ground truth phantom. Uses ``phantom.fluorescence``.
+    wavelength_emission : float
+        Emission wavelength in um.
+    index_of_refraction_media : float
+        Refractive index of the surrounding medium.
+    numerical_aperture_detection : float
+        Objective NA.
+    background : int
+        Background offset added to the simulated data.
+
+    Returns
+    -------
+    Tensor
+        Simulated 3D fluorescence data, shape (Z, Y, X).
+    """
+    z_pixel_size, yx_pixel_size, _ = phantom.pixel_sizes
+    zyx_shape = tuple(phantom.fluorescence.shape)
+
+    otf = isotropic_fluorescent_thick_3d.calculate_transfer_function(
+        zyx_shape,
+        yx_pixel_size,
+        z_pixel_size,
+        wavelength_emission=wavelength_emission,
+        z_padding=0,
+        index_of_refraction_media=index_of_refraction_media,
+        numerical_aperture_detection=numerical_aperture_detection,
+    )
+
+    return isotropic_fluorescent_thick_3d.apply_transfer_function(
+        phantom.fluorescence, otf, z_padding=0, background=background
+    )

--- a/benchmarks/utils.py
+++ b/benchmarks/utils.py
@@ -1,0 +1,161 @@
+"""Shared utilities for benchmarks: timing, metadata, and formatting."""
+
+import json
+import platform
+import subprocess
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import numpy as np
+import torch
+
+# --- TimingTree ---
+
+
+@dataclass
+class TimingNode:
+    """A single timing measurement, possibly with children."""
+
+    name: str
+    elapsed: float = 0.0
+    children: list["TimingNode"] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        """Serialize to a JSON-compatible dict."""
+        d = {"name": self.name, "elapsed_s": round(self.elapsed, 4)}
+        if self.children:
+            d["children"] = [c.to_dict() for c in self.children]
+        return d
+
+
+class TimingTree:
+    """Nested timing context manager.
+
+    Examples
+    --------
+    >>> tt = TimingTree()
+    >>> with tt.time("total"):
+    ...     with tt.time("step_a"):
+    ...         pass
+    ...     with tt.time("step_b"):
+    ...         pass
+    >>> tt.root.name
+    'total'
+    >>> len(tt.root.children)
+    2
+    """
+
+    def __init__(self):
+        self.root: TimingNode | None = None
+        self._stack: list[TimingNode] = []
+
+    @contextmanager
+    def time(self, name: str):
+        """Time a named block. Blocks can be nested."""
+        node = TimingNode(name=name)
+        if self._stack:
+            self._stack[-1].children.append(node)
+        else:
+            self.root = node
+        self._stack.append(node)
+        start = time.perf_counter()
+        try:
+            yield node
+        finally:
+            node.elapsed = time.perf_counter() - start
+            self._stack.pop()
+
+    def to_dict(self) -> dict:
+        """Serialize the full tree."""
+        if self.root is None:
+            return {}
+        return self.root.to_dict()
+
+    def save(self, path: Path):
+        """Write timing tree to JSON."""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(self.to_dict(), indent=2))
+
+
+# --- Metadata collection ---
+
+
+# Path to the waveorder repo root (two levels up from this file)
+_REPO_ROOT = str(Path(__file__).resolve().parent.parent)
+
+
+def _run_git(*args: str) -> str:
+    """Run a git command in the waveorder repo and return stripped stdout, or '' on failure."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", _REPO_ROOT, *args],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        return result.stdout.strip()
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return ""
+
+
+def collect_metadata() -> dict:
+    """Collect environment metadata for a benchmark run.
+
+    Returns
+    -------
+    dict
+        Git info, hardware, Python/torch versions, hostname.
+    """
+    git_hash = _run_git("rev-parse", "--short", "HEAD")
+    git_branch = _run_git("rev-parse", "--abbrev-ref", "HEAD")
+    git_dirty = _run_git("status", "--porcelain") != ""
+
+    gpu_name = ""
+    gpu_count = 0
+    if torch.cuda.is_available():
+        gpu_count = torch.cuda.device_count()
+        gpu_name = torch.cuda.get_device_name(0)
+
+    return {
+        "git_hash": git_hash,
+        "git_branch": git_branch,
+        "git_dirty": git_dirty,
+        "hostname": platform.node(),
+        "python_version": platform.python_version(),
+        "torch_version": torch.__version__,
+        "gpu_name": gpu_name,
+        "gpu_count": gpu_count,
+        "platform": platform.platform(),
+    }
+
+
+# --- Formatting ---
+
+
+def render_histogram(hist: dict) -> str:
+    """Render a histogram as an inline sparkline.
+
+    Parameters
+    ----------
+    hist : dict
+        Histogram with "bin_edges" and "counts" keys.
+
+    Returns
+    -------
+    str
+        Single-line sparkline with range labels,
+        e.g. ``[0.00] ▁▃█▇▃▁ [1.00]``
+    """
+    counts = np.array(hist["counts"])
+    edges = np.array(hist["bin_edges"])
+
+    if counts.max() == 0:
+        return "(empty)"
+
+    blocks = "▁▂▃▄▅▆▇█"
+    normalized = counts / counts.max()
+    bars = "".join(blocks[int(v * 7)] for v in normalized)
+
+    return f"[{edges[0]:.3g}] {bars} [{edges[-1]:.3g}]"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,8 +96,14 @@ docs = [
   "matplotlib",
   "importlib_metadata",
 ]
+bench = [
+  { include-group = "test" },
+  "pyyaml",
+  "scikit-image",
+]
 dev = [
   { include-group = "test" },
+  { include-group = "bench" },
   { include-group = "docs" },
   "pre-commit",
 ]

--- a/tests/test_benchmark_cleanup.py
+++ b/tests/test_benchmark_cleanup.py
@@ -1,0 +1,61 @@
+"""Tests for the --save-all cleanup behavior in benchmarks.runner."""
+
+from benchmarks.runner import SIZE_LIMIT_BYTES, _cleanup_large_outputs, _dir_size_bytes
+
+
+def _make_zarr_dir(path, size_bytes):
+    """Write a fake zarr directory with a file of approximately size_bytes."""
+    path.mkdir(parents=True)
+    (path / "0").write_bytes(b"x" * size_bytes)
+
+
+class TestCleanupLargeOutputs:
+    def test_save_all_keeps_everything(self, tmp_path):
+        _make_zarr_dir(tmp_path / "transfer_function_cfg.zarr", 100)
+        _make_zarr_dir(tmp_path / "reconstruction.zarr", SIZE_LIMIT_BYTES * 2)
+        _make_zarr_dir(tmp_path / "simulated.zarr", SIZE_LIMIT_BYTES * 2)
+        _cleanup_large_outputs(tmp_path, save_all=True)
+        assert (tmp_path / "transfer_function_cfg.zarr").exists()
+        assert (tmp_path / "reconstruction.zarr").exists()
+        assert (tmp_path / "simulated.zarr").exists()
+
+    def test_default_deletes_tf(self, tmp_path):
+        _make_zarr_dir(tmp_path / "transfer_function_cfg.zarr", 100)
+        _cleanup_large_outputs(tmp_path, save_all=False)
+        assert not (tmp_path / "transfer_function_cfg.zarr").exists()
+
+    def test_default_keeps_small_recon(self, tmp_path):
+        _make_zarr_dir(tmp_path / "reconstruction.zarr", 100)
+        _cleanup_large_outputs(tmp_path, save_all=False)
+        assert (tmp_path / "reconstruction.zarr").exists()
+
+    def test_default_deletes_large_recon(self, tmp_path):
+        _make_zarr_dir(tmp_path / "reconstruction.zarr", SIZE_LIMIT_BYTES + 1)
+        _cleanup_large_outputs(tmp_path, save_all=False)
+        assert not (tmp_path / "reconstruction.zarr").exists()
+
+    def test_default_deletes_large_simulated(self, tmp_path):
+        _make_zarr_dir(tmp_path / "simulated.zarr", SIZE_LIMIT_BYTES + 1)
+        _cleanup_large_outputs(tmp_path, save_all=False)
+        assert not (tmp_path / "simulated.zarr").exists()
+
+    def test_default_keeps_small_simulated(self, tmp_path):
+        _make_zarr_dir(tmp_path / "simulated.zarr", 100)
+        _cleanup_large_outputs(tmp_path, save_all=False)
+        assert (tmp_path / "simulated.zarr").exists()
+
+
+class TestDirSizeBytes:
+    def test_missing(self, tmp_path):
+        assert _dir_size_bytes(tmp_path / "missing") == 0
+
+    def test_empty(self, tmp_path):
+        (tmp_path / "empty").mkdir()
+        assert _dir_size_bytes(tmp_path / "empty") == 0
+
+    def test_sums_recursive(self, tmp_path):
+        d = tmp_path / "data"
+        (d / "sub").mkdir(parents=True)
+        (d / "a").write_bytes(b"x" * 100)
+        (d / "sub" / "b").write_bytes(b"x" * 50)
+        assert _dir_size_bytes(d) == 150

--- a/tests/test_benchmark_cli.py
+++ b/tests/test_benchmark_cli.py
@@ -1,0 +1,211 @@
+"""Tests for the ``wo bm`` click commands."""
+
+import json
+from unittest.mock import patch
+
+import yaml
+from click.testing import CliRunner
+
+from waveorder.cli.bench import benchmark
+
+
+def _make_run_dir(base, name, metadata=None, summary=None):
+    d = base / name
+    d.mkdir(parents=True)
+    if metadata is not None:
+        (d / "metadata.json").write_text(json.dumps(metadata))
+    if summary is not None:
+        (d / "summary.json").write_text(json.dumps(summary))
+    return d
+
+
+class TestHistory:
+    def test_empty(self, tmp_path):
+        result = CliRunner().invoke(benchmark, ["history", "-o", str(tmp_path)])
+        assert result.exit_code == 0
+        assert "No benchmark runs found" in result.output
+
+    def test_lists_runs(self, tmp_path):
+        _make_run_dir(
+            tmp_path,
+            "2026-04-20T10-00-00_regression",
+            metadata={"git_hash": "abc123"},
+            summary={"case_a": {}},
+        )
+        _make_run_dir(
+            tmp_path,
+            "2026-04-20T11-00-00_regression",
+            metadata={"git_hash": "def456"},
+            summary={"case_a": {}, "case_b": {}},
+        )
+        result = CliRunner().invoke(benchmark, ["history", "-o", str(tmp_path)])
+        assert result.exit_code == 0
+        assert "2026-04-20T10-00-00_regression" in result.output
+        assert "2026-04-20T11-00-00_regression" in result.output
+
+
+class TestLatest:
+    def test_empty(self, tmp_path):
+        result = CliRunner().invoke(benchmark, ["latest", "-o", str(tmp_path)])
+        assert result.exit_code == 0
+        assert "No benchmark runs found" in result.output
+
+    def test_shows_latest(self, tmp_path):
+        summary = {
+            "case_a": {
+                "image_quality": {
+                    "midband_power": 0.01,
+                    "histogram": {"bin_edges": [0.0, 0.5, 1.0], "counts": [5, 10]},
+                },
+                "elapsed_s": 2.5,
+            },
+        }
+        _make_run_dir(
+            tmp_path,
+            "2026-04-20T10-00-00_regression",
+            metadata={"git_hash": "abc", "git_branch": "main"},
+            summary=summary,
+        )
+        result = CliRunner().invoke(benchmark, ["latest", "-o", str(tmp_path)])
+        assert result.exit_code == 0
+        assert "2026-04-20T10-00-00_regression" in result.output
+        assert "case_a" in result.output
+
+
+class TestCompare:
+    def test_needs_two_runs(self, tmp_path):
+        result = CliRunner().invoke(benchmark, ["compare", "-o", str(tmp_path)])
+        assert "Need at least 2 runs" in result.output
+
+    def test_compares_two_latest(self, tmp_path):
+        summary_a = {"case_a": {"image_quality": {"midband_power": 0.01}, "with_phantom": {"mse": 0.1, "ssim": 0.9}}}
+        summary_b = {"case_a": {"image_quality": {"midband_power": 0.02}, "with_phantom": {"mse": 0.05, "ssim": 0.95}}}
+        _make_run_dir(tmp_path, "2026-04-20T10-00-00_regression", metadata={"git_hash": "a"}, summary=summary_a)
+        _make_run_dir(tmp_path, "2026-04-20T11-00-00_regression", metadata={"git_hash": "b"}, summary=summary_b)
+        result = CliRunner().invoke(benchmark, ["compare", "-o", str(tmp_path)])
+        assert result.exit_code == 0
+        assert "case_a" in result.output
+        assert "ssim" in result.output
+
+
+class TestOutputDirResolution:
+    def test_cli_arg_wins_over_env(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("WAVEORDER_BENCH_OUTPUT", "/nonexistent/path")
+        result = CliRunner().invoke(benchmark, ["history", "-o", str(tmp_path)])
+        assert result.exit_code == 0
+        assert "No benchmark runs found" in result.output
+
+    def test_env_var_used_when_no_cli(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("WAVEORDER_BENCH_OUTPUT", str(tmp_path))
+        result = CliRunner().invoke(benchmark, ["history"])
+        assert result.exit_code == 0
+        assert "No benchmark runs found" in result.output
+
+
+class TestRun:
+    """Mock-driven tests of the run command's orchestration."""
+
+    def _write_experiment(self, tmp_path, cases):
+        exp = {"name": "test_exp", "cases": cases}
+        exp_yml = tmp_path / "exp.yml"
+        exp_yml.write_text(yaml.dump(exp))
+        (tmp_path / "recon.yml").write_text(yaml.dump({"phase": {"transfer_function": {}}}))
+        return exp_yml
+
+    def test_synthetic_scope_skips_hpc(self, tmp_path):
+        exp_yml = self._write_experiment(
+            tmp_path,
+            {
+                "syn_case": {
+                    "type": "synthetic",
+                    "phantom": {"function": "single_bead", "shape": [16, 32, 32]},
+                    "config": "recon.yml",
+                },
+                "hpc_case": {
+                    "type": "hpc",
+                    "input": "/fake/input.zarr",
+                    "position": "A/1/000000",
+                    "config": "recon.yml",
+                },
+            },
+        )
+
+        with (
+            patch("benchmarks.runner.run_synthetic_case") as mock_syn,
+            patch("benchmarks.runner.run_hpc_case") as mock_hpc,
+        ):
+            mock_syn.return_value = {"image_quality": {"midband_power": 0.01}}
+            mock_hpc.return_value = {"image_quality": {"midband_power": 0.01}}
+            with CliRunner().isolated_filesystem():
+                # Need to create timing.json for the bench.run post-case readback
+                def _side_effect(**kwargs):
+                    case_dir = kwargs["case_dir"]
+                    case_dir.mkdir(parents=True, exist_ok=True)
+                    (case_dir / "timing.json").write_text(json.dumps({"elapsed_s": 0.1}))
+                    return {"image_quality": {"midband_power": 0.01}}
+
+                mock_syn.side_effect = _side_effect
+                result = CliRunner().invoke(
+                    benchmark,
+                    ["run", "-e", str(exp_yml), "--scope", "synthetic", "-o", str(tmp_path)],
+                )
+
+        assert result.exit_code == 0, result.output
+        assert mock_syn.call_count == 1
+        assert mock_hpc.call_count == 0
+        assert "skipping 1 hpc" in result.output
+
+    def test_all_scope_runs_hpc(self, tmp_path):
+        exp_yml = self._write_experiment(
+            tmp_path,
+            {
+                "hpc_case": {
+                    "type": "hpc",
+                    "input": "/fake/input.zarr",
+                    "position": "A/1/000000",
+                    "config": "recon.yml",
+                },
+            },
+        )
+
+        def _side_effect(**kwargs):
+            case_dir = kwargs["case_dir"]
+            case_dir.mkdir(parents=True, exist_ok=True)
+            (case_dir / "timing.json").write_text(json.dumps({"elapsed_s": 0.1}))
+            return {"image_quality": {"midband_power": 0.01}}
+
+        with patch("benchmarks.runner.run_hpc_case") as mock_hpc:
+            mock_hpc.side_effect = _side_effect
+            result = CliRunner().invoke(
+                benchmark,
+                ["run", "-e", str(exp_yml), "--scope", "all", "-o", str(tmp_path)],
+            )
+        assert result.exit_code == 0, result.output
+        assert mock_hpc.call_count == 1
+
+    def test_records_error_on_failure(self, tmp_path):
+        exp_yml = self._write_experiment(
+            tmp_path,
+            {
+                "bad_case": {
+                    "type": "synthetic",
+                    "phantom": {"function": "single_bead", "shape": [16, 32, 32]},
+                    "config": "recon.yml",
+                },
+            },
+        )
+
+        with patch("benchmarks.runner.run_synthetic_case") as mock_syn:
+            mock_syn.side_effect = RuntimeError("boom")
+            result = CliRunner().invoke(
+                benchmark,
+                ["run", "-e", str(exp_yml), "--scope", "synthetic", "-o", str(tmp_path)],
+            )
+
+        assert result.exit_code == 0  # run continues past case failures
+        assert "FAILED" in result.output
+        # summary.json records the error
+        runs = [p for p in tmp_path.iterdir() if p.is_dir() and "test_exp" in p.name]
+        assert len(runs) == 1
+        summary = json.loads((runs[0] / "summary.json").read_text())
+        assert "error" in summary["bad_case"]

--- a/tests/test_benchmark_metrics.py
+++ b/tests/test_benchmark_metrics.py
@@ -1,0 +1,99 @@
+"""Tests for benchmarks.metrics."""
+
+import torch
+
+from benchmarks.metrics import (
+    comparison_metrics,
+    compute_metrics,
+    distribution_stats,
+)
+from benchmarks.utils import render_histogram
+
+# Shared optical parameters for tests
+_OPTICS = {"NA_det": 1.2, "wavelength": 0.532, "pixel_size": 0.1}
+
+
+def _random_volume(shape=(16, 32, 32), seed=0):
+    gen = torch.Generator().manual_seed(seed)
+    return torch.randn(shape, generator=gen)
+
+
+class TestDistributionStats:
+    def test_keys(self):
+        stats = distribution_stats(_random_volume())
+        assert {"max", "min", "mean", "histogram"} <= set(stats.keys())
+
+    def test_histogram_bins(self):
+        stats = distribution_stats(_random_volume(), n_bins=20)
+        assert len(stats["histogram"]["counts"]) == 20
+        assert len(stats["histogram"]["bin_edges"]) == 21
+
+    def test_values_correct(self):
+        v = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0])
+        stats = distribution_stats(v)
+        assert stats["max"] == 5.0
+        assert stats["min"] == 1.0
+        assert stats["mean"] == 3.0
+
+
+class TestComparisonMetrics:
+    def test_identical_volumes(self):
+        v = _random_volume()
+        m = comparison_metrics(v, v)
+        assert m["mse"] == 0.0
+        assert abs(m["ssim"] - 1.0) < 1e-5
+        assert abs(m["correlation"] - 1.0) < 1e-5
+
+    def test_different_volumes(self):
+        a = _random_volume(seed=0)
+        b = _random_volume(seed=1)
+        m = comparison_metrics(a, b)
+        assert m["mse"] > 0
+        assert -1 <= m["ssim"] <= 1
+        assert -1 <= m["correlation"] <= 1
+
+
+class TestComputeMetrics:
+    def test_image_quality_always_present(self):
+        result = compute_metrics(_random_volume(), **_OPTICS)
+        assert "image_quality" in result
+        assert "max" in result["image_quality"]
+        assert "midband_power" in result["image_quality"]
+        assert "spectral_flatness" in result["image_quality"]
+        assert "total_variation" in result["image_quality"]
+
+    def test_midband_power_positive(self):
+        result = compute_metrics(_random_volume(), **_OPTICS)
+        assert result["image_quality"]["midband_power"] > 0
+
+    def test_with_reference(self):
+        v = _random_volume()
+        result = compute_metrics(v, **_OPTICS, reference=v)
+        assert "with_reference" in result
+        assert "ssim" in result["with_reference"]
+
+    def test_with_reference_absent_without_reference(self):
+        result = compute_metrics(_random_volume(), **_OPTICS)
+        assert "with_reference" not in result
+
+    def test_with_phantom(self):
+        v = _random_volume()
+        result = compute_metrics(v, **_OPTICS, phantom=v)
+        assert "with_phantom" in result
+        assert "mse" in result["with_phantom"]
+
+    def test_with_phantom_absent_without_phantom(self):
+        result = compute_metrics(_random_volume(), **_OPTICS)
+        assert "with_phantom" not in result
+
+
+class TestRenderHistogram:
+    def test_renders_single_line(self):
+        stats = distribution_stats(_random_volume())
+        output = render_histogram(stats["histogram"])
+        assert isinstance(output, str)
+        assert "\n" not in output
+
+    def test_empty_histogram(self):
+        hist = {"bin_edges": [0, 1], "counts": [0]}
+        assert render_histogram(hist) == "(empty)"

--- a/tests/test_benchmark_runner.py
+++ b/tests/test_benchmark_runner.py
@@ -1,0 +1,212 @@
+"""Tests for benchmarks.runner and benchmarks.config."""
+
+import shutil
+
+import pytest
+import yaml
+
+from benchmarks.config import ExperimentConfig, PhantomConfig, load_experiment
+from benchmarks.runner import _build_phantom, run_synthetic_case
+
+
+class TestPhantomConfig:
+    def test_valid(self):
+        pc = PhantomConfig(function="single_bead", shape=(16, 32, 32))
+        assert pc.function == "single_bead"
+        assert pc.shape == (16, 32, 32)
+
+    def test_extra_kwargs_allowed(self):
+        pc = PhantomConfig(
+            function="single_bead",
+            shape=(16, 32, 32),
+            bead_radius_um=2.0,
+            refractive_index_diff=0.05,
+        )
+        assert pc.model_dump()["bead_radius_um"] == 2.0
+
+    def test_invalid_function_rejected(self):
+        with pytest.raises(Exception):
+            PhantomConfig(function="invalid_phantom")
+
+
+class TestExperimentConfig:
+    def test_valid(self):
+        exp = ExperimentConfig(
+            name="test",
+            cases={
+                "case_a": {
+                    "type": "synthetic",
+                    "phantom": {"function": "single_bead", "shape": [16, 32, 32]},
+                }
+            },
+        )
+        assert exp.name == "test"
+        assert exp.cases["case_a"].phantom.function == "single_bead"
+
+    def test_base_phantom_inherited(self):
+        exp = ExperimentConfig(
+            name="test",
+            base_phantom={"function": "single_bead", "shape": [16, 32, 32]},
+            cases={"case_a": {"type": "synthetic"}, "case_b": {"type": "synthetic"}},
+        )
+        assert exp.cases["case_a"].phantom.function == "single_bead"
+        assert exp.cases["case_b"].phantom.function == "single_bead"
+
+    def test_case_phantom_not_overwritten_by_base(self):
+        exp = ExperimentConfig(
+            name="test",
+            base_phantom={"function": "single_bead", "shape": [16, 32, 32]},
+            cases={
+                "custom": {
+                    "type": "synthetic",
+                    "phantom": {"function": "random_beads", "shape": [8, 16, 16], "n_beads": 3, "bead_radius_um": 0.3},
+                }
+            },
+        )
+        assert exp.cases["custom"].phantom.function == "random_beads"
+
+    def test_base_config_inherited(self):
+        exp = ExperimentConfig(
+            name="test",
+            base_config="configs/phase.yml",
+            cases={"case_a": {"type": "synthetic", "phantom": {"function": "single_bead"}}},
+        )
+        assert exp.cases["case_a"].config == "configs/phase.yml"
+
+
+class TestLoadExperiment:
+    def test_from_yaml(self, tmp_path):
+        exp_dict = {
+            "name": "test",
+            "cases": {
+                "case_a": {
+                    "type": "synthetic",
+                    "phantom": {"function": "single_bead", "shape": [16, 32, 32]},
+                }
+            },
+        }
+        path = tmp_path / "exp.yml"
+        path.write_text(yaml.dump(exp_dict))
+        exp = load_experiment(path)
+        assert isinstance(exp, ExperimentConfig)
+        assert exp.cases["case_a"].phantom.shape == (16, 32, 32)
+
+    def test_overrides(self, tmp_path):
+        base_config = {
+            "reconstruction_dimension": 3,
+            "phase": {"apply_inverse": {"regularization_strength": 0.01}},
+        }
+        config_path = tmp_path / "base.yml"
+        config_path.write_text(yaml.dump(base_config))
+
+        exp_dict = {
+            "name": "test",
+            "base_config": str(config_path),
+            "cases": {
+                "case_a": {
+                    "type": "synthetic",
+                    "phantom": {"function": "single_bead"},
+                    "overrides": {"phase.apply_inverse.regularization_strength": 0.001},
+                }
+            },
+        }
+        path = tmp_path / "exp.yml"
+        path.write_text(yaml.dump(exp_dict))
+        exp = load_experiment(path)
+
+        from benchmarks.config import resolve_recon_config
+
+        resolved = resolve_recon_config(exp.cases["case_a"], tmp_path)
+        assert resolved["phase"]["apply_inverse"]["regularization_strength"] == 0.001
+
+
+class TestBuildPhantom:
+    def test_from_config(self):
+        pc = PhantomConfig(function="single_bead", shape=(16, 32, 32), bead_radius_um=1.0)
+        phantom = _build_phantom(pc)
+        assert phantom.phase.shape == (16, 32, 32)
+
+    def test_from_dict(self):
+        phantom = _build_phantom({"function": "single_bead", "shape": [16, 32, 32]})
+        assert phantom.phase.shape == (16, 32, 32)
+
+
+class TestLoadRegressionExperiment:
+    def test_regression_yml_valid(self):
+        """Validate the committed regression.yml experiment."""
+        from pathlib import Path
+
+        regression_path = Path(__file__).parent.parent / "benchmarks" / "experiments" / "regression.yml"
+        if not regression_path.exists():
+            pytest.skip("regression.yml not found")
+        exp = load_experiment(regression_path)
+        assert exp.name == "regression"
+        assert "phase_3d_beads" in exp.cases
+        assert "fluor_3d_beads" in exp.cases
+
+
+@pytest.mark.skipif(not shutil.which("wo"), reason="wo CLI not installed")
+class TestRunSyntheticCase:
+    """End-to-end tests that shell out to ``wo rec``."""
+
+    def test_phase_end_to_end(self, tmp_path):
+        phantom_config = PhantomConfig(
+            function="single_bead",
+            shape=(32, 64, 64),
+            pixel_sizes=(0.25, 0.1, 0.1),
+            bead_radius_um=2.0,
+            refractive_index_diff=0.05,
+        )
+        recon_config = {
+            "reconstruction_dimension": 3,
+            "input_channel_names": ["Brightfield"],
+            "phase": {
+                "transfer_function": {
+                    "yx_pixel_size": 0.1,
+                    "z_pixel_size": 0.25,
+                    "wavelength_illumination": 0.532,
+                    "index_of_refraction_media": 1.3,
+                    "numerical_aperture_illumination": 0.9,
+                    "numerical_aperture_detection": 1.2,
+                },
+            },
+        }
+        case_dir = tmp_path / "phase_case"
+        metrics = run_synthetic_case(phantom_config, recon_config, case_dir, modality="phase")
+
+        assert "image_quality" in metrics
+        assert "with_phantom" in metrics
+        assert (case_dir / "timing.json").exists()
+        assert (case_dir / "metrics.json").exists()
+        assert (case_dir / "phantom_config.json").exists()
+        assert (case_dir / "cli_command.sh").exists()
+        assert (case_dir / "simulated.zarr").exists()
+        assert (case_dir / "reconstruction.zarr").exists()
+
+    def test_fluorescence_end_to_end(self, tmp_path):
+        phantom_config = PhantomConfig(
+            function="single_bead",
+            shape=(32, 64, 64),
+            pixel_sizes=(0.25, 0.1, 0.1),
+            bead_radius_um=2.0,
+            fluorescence_intensity=1.0,
+        )
+        recon_config = {
+            "reconstruction_dimension": 3,
+            "input_channel_names": ["GFP"],
+            "fluorescence": {
+                "transfer_function": {
+                    "yx_pixel_size": 0.1,
+                    "z_pixel_size": 0.25,
+                    "wavelength_emission": 0.532,
+                    "index_of_refraction_media": 1.3,
+                    "numerical_aperture_detection": 1.2,
+                },
+            },
+        }
+        case_dir = tmp_path / "fluor_case"
+        metrics = run_synthetic_case(phantom_config, recon_config, case_dir, modality="fluorescence")
+
+        assert "image_quality" in metrics
+        assert "with_phantom" in metrics
+        assert (case_dir / "cli_command.sh").exists()

--- a/tests/test_benchmark_simulate.py
+++ b/tests/test_benchmark_simulate.py
@@ -1,0 +1,55 @@
+"""Tests for benchmarks.simulate."""
+
+import torch
+
+from benchmarks.simulate import simulate_fluorescence_3d, simulate_phase_3d
+from waveorder.phantoms import single_bead
+
+
+def _small_phantom():
+    return single_bead(
+        shape=(32, 64, 64),
+        pixel_sizes=(0.25, 0.1, 0.1),
+        bead_radius_um=2.0,
+        refractive_index_diff=0.05,
+        fluorescence_intensity=1.0,
+    )
+
+
+class TestSimulatePhase3D:
+    def test_output_shape(self):
+        phantom = _small_phantom()
+        data = simulate_phase_3d(phantom)
+        assert data.shape == phantom.phase.shape
+
+    def test_output_finite(self):
+        phantom = _small_phantom()
+        data = simulate_phase_3d(phantom)
+        assert torch.all(torch.isfinite(data))
+
+    def test_output_not_constant(self):
+        phantom = _small_phantom()
+        data = simulate_phase_3d(phantom)
+        assert data.std() > 0
+
+
+class TestSimulateFluorescence3D:
+    def test_output_shape(self):
+        phantom = _small_phantom()
+        data = simulate_fluorescence_3d(phantom)
+        assert data.shape == phantom.fluorescence.shape
+
+    def test_output_finite(self):
+        phantom = _small_phantom()
+        data = simulate_fluorescence_3d(phantom)
+        assert torch.all(torch.isfinite(data))
+
+    def test_output_positive(self):
+        phantom = _small_phantom()
+        data = simulate_fluorescence_3d(phantom)
+        assert data.min() >= 0
+
+    def test_output_not_constant(self):
+        phantom = _small_phantom()
+        data = simulate_fluorescence_3d(phantom)
+        assert data.std() > 0

--- a/tests/test_benchmark_utils.py
+++ b/tests/test_benchmark_utils.py
@@ -1,0 +1,91 @@
+"""Tests for benchmarks.utils (TimingTree and metadata)."""
+
+import json
+import time
+
+from benchmarks.utils import TimingTree, collect_metadata
+
+
+class TestTimingTree:
+    def test_single_block(self):
+        tt = TimingTree()
+        with tt.time("total"):
+            time.sleep(0.01)
+        assert tt.root is not None
+        assert tt.root.name == "total"
+        assert tt.root.elapsed >= 0.01
+
+    def test_nested_blocks(self):
+        tt = TimingTree()
+        with tt.time("total"):
+            with tt.time("a"):
+                time.sleep(0.01)
+            with tt.time("b"):
+                time.sleep(0.01)
+        assert len(tt.root.children) == 2
+        assert tt.root.children[0].name == "a"
+        assert tt.root.children[1].name == "b"
+
+    def test_deep_nesting(self):
+        tt = TimingTree()
+        with tt.time("l0"):
+            with tt.time("l1"):
+                with tt.time("l2"):
+                    time.sleep(0.01)
+        assert tt.root.children[0].children[0].name == "l2"
+
+    def test_to_dict(self):
+        tt = TimingTree()
+        with tt.time("total"):
+            with tt.time("step"):
+                pass
+        d = tt.to_dict()
+        assert d["name"] == "total"
+        assert "elapsed_s" in d
+        assert len(d["children"]) == 1
+        assert d["children"][0]["name"] == "step"
+
+    def test_save(self, tmp_path):
+        tt = TimingTree()
+        with tt.time("total"):
+            pass
+        out = tmp_path / "timing.json"
+        tt.save(out)
+        loaded = json.loads(out.read_text())
+        assert loaded["name"] == "total"
+
+    def test_empty_tree(self):
+        tt = TimingTree()
+        assert tt.root is None
+        assert tt.to_dict() == {}
+
+
+class TestCollectMetadata:
+    def test_returns_dict(self):
+        meta = collect_metadata()
+        assert isinstance(meta, dict)
+
+    def test_required_keys(self):
+        meta = collect_metadata()
+        expected_keys = {
+            "git_hash",
+            "git_branch",
+            "git_dirty",
+            "hostname",
+            "python_version",
+            "torch_version",
+            "gpu_name",
+            "gpu_count",
+            "platform",
+        }
+        assert expected_keys <= set(meta.keys())
+
+    def test_git_hash_nonempty(self):
+        meta = collect_metadata()
+        # We're in a git repo, so this should be populated
+        assert len(meta["git_hash"]) > 0
+
+    def test_python_version_format(self):
+        meta = collect_metadata()
+        parts = meta["python_version"].split(".")
+        assert len(parts) == 3

--- a/tests/test_phantoms.py
+++ b/tests/test_phantoms.py
@@ -1,0 +1,163 @@
+"""Tests for waveorder.phantoms."""
+
+import pytest
+import torch
+
+from waveorder.phantoms import Phantom, random_beads, single_bead
+
+
+class TestSingleBead:
+    """Tests for single_bead phantom generation."""
+
+    def test_output_type(self):
+        phantom = single_bead(shape=(16, 32, 32))
+        assert isinstance(phantom, Phantom)
+
+    def test_shape(self):
+        shape = (16, 32, 32)
+        phantom = single_bead(shape=shape)
+        assert phantom.phase.shape == torch.Size(shape)
+        assert phantom.absorption.shape == torch.Size(shape)
+        assert phantom.fluorescence.shape == torch.Size(shape)
+
+    def test_dtype(self):
+        phantom = single_bead(shape=(16, 32, 32))
+        assert phantom.phase.dtype == torch.float32
+        assert phantom.absorption.dtype == torch.float32
+        assert phantom.fluorescence.dtype == torch.float32
+
+    def test_pixel_sizes_stored(self):
+        pixel_sizes = (0.5, 0.2, 0.2)
+        phantom = single_bead(shape=(16, 32, 32), pixel_sizes=pixel_sizes)
+        assert phantom.pixel_sizes == pixel_sizes
+
+    def test_metadata_complete(self):
+        phantom = single_bead(
+            shape=(16, 32, 32),
+            bead_radius_um=3.0,
+            refractive_index_diff=0.04,
+        )
+        assert phantom.metadata["type"] == "single_bead"
+        assert phantom.metadata["bead_radius_um"] == 3.0
+        assert phantom.metadata["refractive_index_diff"] == 0.04
+        assert phantom.metadata["shape"] == [16, 32, 32]
+
+    def test_phase_has_correct_sign(self):
+        phantom_pos = single_bead(shape=(16, 32, 32), refractive_index_diff=0.05)
+        phantom_neg = single_bead(shape=(16, 32, 32), refractive_index_diff=-0.05)
+        assert phantom_pos.phase.max() > 0
+        assert phantom_neg.phase.min() < 0
+
+    def test_fluorescence_non_negative(self):
+        phantom = single_bead(shape=(16, 32, 32))
+        assert phantom.fluorescence.min() >= 0
+
+    def test_peak_normalized(self):
+        phantom = single_bead(
+            shape=(16, 32, 32),
+            refractive_index_diff=0.05,
+            fluorescence_intensity=1.0,
+        )
+        # Blurred mask is normalized to [0, 1], then scaled
+        assert abs(phantom.phase.max().item() - 0.05) < 0.01
+        assert abs(phantom.fluorescence.max().item() - 1.0) < 0.1
+
+    def test_bead_at_center(self):
+        shape = (32, 64, 64)
+        phantom = single_bead(shape=shape, bead_radius_um=2.0)
+        center_z, center_y, center_x = shape[0] // 2, shape[1] // 2, shape[2] // 2
+        # Center voxel should be near peak
+        center_val = phantom.fluorescence[center_z, center_y, center_x].item()
+        assert center_val > 0.5
+
+    def test_custom_center(self):
+        shape = (32, 64, 64)
+        pixel_sizes = (0.25, 0.108, 0.108)
+        phantom = single_bead(
+            shape=shape,
+            pixel_sizes=pixel_sizes,
+            bead_radius_um=2.0,
+            center=(1.0, 0.0, 0.0),  # shifted +1 um in z
+        )
+        # Peak should be shifted from center
+        peak_z = phantom.fluorescence.sum(dim=(1, 2)).argmax().item()
+        assert peak_z != shape[0] // 2
+
+    def test_absorption(self):
+        phantom = single_bead(shape=(16, 32, 32), absorption_coefficient=0.1)
+        assert phantom.absorption.max().item() > 0
+        assert phantom.absorption.min() >= 0
+
+    def test_absorption_defaults_to_zero(self):
+        phantom = single_bead(shape=(16, 32, 32))
+        assert phantom.absorption.max().item() == 0.0
+
+    def test_fluorescence_background(self):
+        phantom = single_bead(
+            shape=(16, 32, 32),
+            fluorescence_intensity=1.0,
+            fluorescence_background=5.0,
+        )
+        assert abs(phantom.fluorescence.min().item() - 5.0) < 1e-5
+        assert phantom.fluorescence.max().item() > 5.0
+        assert phantom.metadata["fluorescence_background"] == 5.0
+
+    def test_finite(self):
+        phantom = single_bead(shape=(16, 32, 32))
+        assert torch.all(torch.isfinite(phantom.phase))
+        assert torch.all(torch.isfinite(phantom.absorption))
+        assert torch.all(torch.isfinite(phantom.fluorescence))
+
+
+class TestRandomBeads:
+    """Tests for random_beads phantom generation."""
+
+    def test_output_type(self):
+        phantom = random_beads(shape=(16, 32, 32), n_beads=3, bead_radius_um=0.3)
+        assert isinstance(phantom, Phantom)
+
+    def test_shape(self):
+        shape = (16, 32, 32)
+        phantom = random_beads(shape=shape, n_beads=3, bead_radius_um=0.3)
+        assert phantom.phase.shape == torch.Size(shape)
+        assert phantom.fluorescence.shape == torch.Size(shape)
+
+    def test_metadata_complete(self):
+        phantom = random_beads(shape=(16, 32, 32), n_beads=3, bead_radius_um=0.3, seed=123)
+        assert phantom.metadata["type"] == "random_beads"
+        assert phantom.metadata["n_beads"] == 3
+        assert phantom.metadata["seed"] == 123
+
+    def test_seed_reproducibility(self):
+        a = random_beads(shape=(16, 32, 32), n_beads=3, bead_radius_um=0.3, seed=42)
+        b = random_beads(shape=(16, 32, 32), n_beads=3, bead_radius_um=0.3, seed=42)
+        torch.testing.assert_close(a.phase, b.phase)
+        torch.testing.assert_close(a.fluorescence, b.fluorescence)
+
+    def test_different_seeds_differ(self):
+        a = random_beads(shape=(16, 32, 32), n_beads=3, bead_radius_um=0.3, seed=42)
+        b = random_beads(shape=(16, 32, 32), n_beads=3, bead_radius_um=0.3, seed=99)
+        assert not torch.allclose(a.phase, b.phase)
+
+    def test_fluorescence_non_negative(self):
+        phantom = random_beads(shape=(16, 32, 32), n_beads=3, bead_radius_um=0.3)
+        assert phantom.fluorescence.min() >= 0
+
+    def test_finite(self):
+        phantom = random_beads(shape=(16, 32, 32), n_beads=3, bead_radius_um=0.3)
+        assert torch.all(torch.isfinite(phantom.phase))
+        assert torch.all(torch.isfinite(phantom.fluorescence))
+
+    def test_multiple_beads_have_content(self):
+        phantom = random_beads(
+            shape=(64, 128, 128),
+            n_beads=5,
+            bead_radius_um=1.0,
+        )
+        # Should have significant nonzero content
+        nonzero_fraction = (phantom.fluorescence > 0.01).float().mean().item()
+        assert nonzero_fraction > 0.01
+
+    def test_too_many_beads_raises(self):
+        with pytest.raises(ValueError, match="non-overlapping"):
+            random_beads(shape=(8, 8, 8), n_beads=100, bead_radius_um=1.0)

--- a/uv.lock
+++ b/uv.lock
@@ -1479,22 +1479,71 @@ wheels = [
 
 [[package]]
 name = "iohub"
-version = "0.3.0a7.dev4+610d8a4"
-source = { git = "https://github.com/czbiohub-sf/iohub?branch=main#610d8a4f7ccce77d8b7472ea9148314997a6efdd" }
+version = "0.3.0a7"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12' and sys_platform == 'darwin'",
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten'",
+    "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
 dependencies = [
-    { name = "blosc2" },
-    { name = "dask", extra = ["array"] },
-    { name = "natsort" },
-    { name = "ndtiff" },
-    { name = "pandas" },
-    { name = "pillow" },
-    { name = "pydantic" },
-    { name = "pydantic-extra-types" },
-    { name = "rich" },
-    { name = "tifffile" },
-    { name = "tqdm" },
-    { name = "xarray" },
-    { name = "zarr" },
+    { name = "blosc2", marker = "python_full_version < '3.12'" },
+    { name = "dask", extra = ["array"], marker = "python_full_version < '3.12'" },
+    { name = "natsort", marker = "python_full_version < '3.12'" },
+    { name = "ndtiff", marker = "python_full_version < '3.12'" },
+    { name = "pandas", marker = "python_full_version < '3.12'" },
+    { name = "pillow", marker = "python_full_version < '3.12'" },
+    { name = "pydantic", marker = "python_full_version < '3.12'" },
+    { name = "pydantic-extra-types", marker = "python_full_version < '3.12'" },
+    { name = "rich", marker = "python_full_version < '3.12'" },
+    { name = "tifffile", marker = "python_full_version < '3.12'" },
+    { name = "tqdm", marker = "python_full_version < '3.12'" },
+    { name = "xarray", marker = "python_full_version < '3.12'" },
+    { name = "zarr", version = "3.1.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/35/65/440e76b98aa90d61c7a6a32ccdd3f62c3a1c85b4c167fdd7ca3805b56531/iohub-0.3.0a7.tar.gz", hash = "sha256:6a29dfbd33a362658052996f0493b4d999e9e1945c730be6f2ee7c3bb16cae3f", size = 450560, upload-time = "2026-03-23T17:37:00.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/0f/4893daeaf2e54ca05de7c6b4d122e19f271ea46c4184f409b6a68ad34c69/iohub-0.3.0a7-py3-none-any.whl", hash = "sha256:ab6881d9aaba8d50c7d06eba4b48233d1d4788d2ec993c8416c2f5be2a8db106", size = 65124, upload-time = "2026-03-23T17:36:58.422Z" },
+]
+
+[[package]]
+name = "iohub"
+version = "0.3.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "blosc2", marker = "python_full_version >= '3.12'" },
+    { name = "dask", extra = ["array"], marker = "python_full_version >= '3.12'" },
+    { name = "natsort", marker = "python_full_version >= '3.12'" },
+    { name = "ndtiff", marker = "python_full_version >= '3.12'" },
+    { name = "pandas", marker = "python_full_version >= '3.12'" },
+    { name = "pillow", marker = "python_full_version >= '3.12'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "pydantic-extra-types", marker = "python_full_version >= '3.12'" },
+    { name = "rich", marker = "python_full_version >= '3.12'" },
+    { name = "tifffile", marker = "python_full_version >= '3.12'" },
+    { name = "tqdm", marker = "python_full_version >= '3.12'" },
+    { name = "xarray", marker = "python_full_version >= '3.12'" },
+    { name = "zarr", version = "3.1.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "zarrs", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/d8/601a5a2d648370cd90825e3c51bc26155b223443ed936ec8e6d62135c871/iohub-0.3.2.tar.gz", hash = "sha256:54eb5a146efbc94375e2f40f51a98234a33a2e3820de7745fdcf06f33d86fef0", size = 289875, upload-time = "2026-04-10T04:16:50.515Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/cd/7c3fd9ecc51b598468d7702b69ab738d5cf9dbe6ffd22f96f26b2aca4ceb/iohub-0.3.2-py3-none-any.whl", hash = "sha256:6808e979ea229e569a627636a073c41e85c0f0224936ddaa952a30b157b79810", size = 84464, upload-time = "2026-04-10T04:16:49.111Z" },
 ]
 
 [[package]]
@@ -3077,7 +3126,8 @@ dependencies = [
     { name = "requests" },
     { name = "scikit-image" },
     { name = "toolz" },
-    { name = "zarr" },
+    { name = "zarr", version = "3.1.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "zarr", version = "3.1.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a4/44/647843d872aa136609e805c06e9f9b2cdcb6e2a58ec485322311dec7b64d/ome_zarr-0.12.2.tar.gz", hash = "sha256:834e801e9aa4b870bed3dde2dc2a3ad7f388f1a13ffa6b3d7aade90691b9de64", size = 69891, upload-time = "2025-08-22T08:57:13.64Z" }
 wheels = [
@@ -5012,6 +5062,12 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/8b/4b61d6e13f7108f36910df9ab4b58fd389cc2520d54d81b88660804aad99/torch-2.10.0-2-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:418997cb02d0a0f1497cf6a09f63166f9f5df9f3e16c8a716ab76a72127c714f", size = 79423467, upload-time = "2026-02-10T21:44:48.711Z" },
     { url = "https://files.pythonhosted.org/packages/d3/54/a2ba279afcca44bbd320d4e73675b282fcee3d81400ea1b53934efca6462/torch-2.10.0-2-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:13ec4add8c3faaed8d13e0574f5cd4a323c11655546f91fbe6afa77b57423574", size = 79498202, upload-time = "2026-02-10T21:44:52.603Z" },
     { url = "https://files.pythonhosted.org/packages/ec/23/2c9fe0c9c27f7f6cb865abcea8a4568f29f00acaeadfc6a37f6801f84cb4/torch-2.10.0-2-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:e521c9f030a3774ed770a9c011751fb47c4d12029a3d6522116e48431f2ff89e", size = 79498254, upload-time = "2026-02-10T21:44:44.095Z" },
+    { url = "https://files.pythonhosted.org/packages/36/ab/7b562f1808d3f65414cd80a4f7d4bb00979d9355616c034c171249e1a303/torch-2.10.0-3-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:ac5bdcbb074384c66fa160c15b1ead77839e3fe7ed117d667249afce0acabfac", size = 915518691, upload-time = "2026-03-11T14:15:43.147Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7a/abada41517ce0011775f0f4eacc79659bc9bc6c361e6bfe6f7052a6b9363/torch-2.10.0-3-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:98c01b8bb5e3240426dcde1446eed6f40c778091c8544767ef1168fc663a05a6", size = 915622781, upload-time = "2026-03-11T14:17:11.354Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/c6/4dfe238342ffdcec5aef1c96c457548762d33c40b45a1ab7033bb26d2ff2/torch-2.10.0-3-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:80b1b5bfe38eb0e9f5ff09f206dcac0a87aadd084230d4a36eea5ec5232c115b", size = 915627275, upload-time = "2026-03-11T14:16:11.325Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f0/72bf18847f58f877a6a8acf60614b14935e2f156d942483af1ffc081aea0/torch-2.10.0-3-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:46b3574d93a2a8134b3f5475cfb98e2eb46771794c57015f6ad1fb795ec25e49", size = 915523474, upload-time = "2026-03-11T14:17:44.422Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/39/590742415c3030551944edc2ddc273ea1fdfe8ffb2780992e824f1ebee98/torch-2.10.0-3-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:b1d5e2aba4eb7f8e87fbe04f86442887f9167a35f092afe4c237dfcaaef6e328", size = 915632474, upload-time = "2026-03-11T14:15:13.666Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/8e/34949484f764dde5b222b7fe3fede43e4a6f0da9d7f8c370bb617d629ee2/torch-2.10.0-3-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:0228d20b06701c05a8f978357f657817a4a63984b0c90745def81c18aedfa591", size = 915523882, upload-time = "2026-03-11T14:14:46.311Z" },
     { url = "https://files.pythonhosted.org/packages/78/89/f5554b13ebd71e05c0b002f95148033e730d3f7067f67423026cc9c69410/torch-2.10.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:3282d9febd1e4e476630a099692b44fdc214ee9bf8ee5377732d9d9dfe5712e4", size = 145992610, upload-time = "2026-01-21T16:25:26.327Z" },
     { url = "https://files.pythonhosted.org/packages/ae/30/a3a2120621bf9c17779b169fc17e3dc29b230c29d0f8222f499f5e159aa8/torch-2.10.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:a2f9edd8dbc99f62bc4dfb78af7bf89499bca3d753423ac1b4e06592e467b763", size = 915607863, upload-time = "2026-01-21T16:25:06.696Z" },
     { url = "https://files.pythonhosted.org/packages/6f/3d/c87b33c5f260a2a8ad68da7147e105f05868c281c63d65ed85aa4da98c66/torch-2.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:29b7009dba4b7a1c960260fc8ac85022c784250af43af9fb0ebafc9883782ebd", size = 113723116, upload-time = "2026-01-21T16:25:21.916Z" },
@@ -5214,7 +5270,8 @@ dependencies = [
     { name = "click" },
     { name = "colorspacious" },
     { name = "importlib-metadata" },
-    { name = "iohub" },
+    { name = "iohub", version = "0.3.0a7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "iohub", version = "0.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "ipywidgets" },
     { name = "matplotlib" },
     { name = "natsort" },
@@ -5249,6 +5306,17 @@ visual = [
 ]
 
 [package.dev-dependencies]
+bench = [
+    { name = "click" },
+    { name = "hypothesis" },
+    { name = "napari", extra = ["pyqt6"] },
+    { name = "pyqt6" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "pytest-qt" },
+    { name = "pyyaml" },
+    { name = "scikit-image" },
+]
 dev = [
     { name = "click" },
     { name = "hypothesis" },
@@ -5264,6 +5332,8 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-qt" },
+    { name = "pyyaml" },
+    { name = "scikit-image" },
     { name = "sphinx-copybutton" },
     { name = "sphinx-gallery" },
     { name = "sphinx-mdinclude" },
@@ -5298,7 +5368,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.0.1" },
     { name = "colorspacious", specifier = ">=1.1.2" },
     { name = "importlib-metadata" },
-    { name = "iohub", git = "https://github.com/czbiohub-sf/iohub?branch=main" },
+    { name = "iohub", specifier = ">=0.3.0a7,<0.4" },
     { name = "ipywidgets", specifier = ">=7.5.1" },
     { name = "jupyter", marker = "extra == 'all'" },
     { name = "jupyter", marker = "extra == 'visual'" },
@@ -5328,6 +5398,17 @@ requires-dist = [
 provides-extras = ["all", "visual"]
 
 [package.metadata.requires-dev]
+bench = [
+    { name = "click", specifier = ">=8.2.0" },
+    { name = "hypothesis" },
+    { name = "napari", extras = ["pyqt6"] },
+    { name = "pyqt6", specifier = ">=6.5,<6.8" },
+    { name = "pytest", specifier = ">=5.0.0" },
+    { name = "pytest-cov" },
+    { name = "pytest-qt" },
+    { name = "pyyaml" },
+    { name = "scikit-image" },
+]
 dev = [
     { name = "click", specifier = ">=8.2.0" },
     { name = "hypothesis" },
@@ -5343,6 +5424,8 @@ dev = [
     { name = "pytest", specifier = ">=5.0.0" },
     { name = "pytest-cov" },
     { name = "pytest-qt" },
+    { name = "pyyaml" },
+    { name = "scikit-image" },
     { name = "sphinx-copybutton" },
     { name = "sphinx-gallery" },
     { name = "sphinx-mdinclude" },
@@ -5626,17 +5709,76 @@ wheels = [
 name = "zarr"
 version = "3.1.5"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12' and sys_platform == 'darwin'",
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten'",
+    "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
 dependencies = [
-    { name = "donfig" },
-    { name = "google-crc32c" },
-    { name = "numcodecs" },
-    { name = "numpy" },
-    { name = "packaging" },
-    { name = "typing-extensions" },
+    { name = "donfig", marker = "python_full_version < '3.12'" },
+    { name = "google-crc32c", marker = "python_full_version < '3.12'" },
+    { name = "numcodecs", marker = "python_full_version < '3.12'" },
+    { name = "numpy", marker = "python_full_version < '3.12'" },
+    { name = "packaging", marker = "python_full_version < '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fc/76/7fa87f57c112c7b9c82f0a730f8b6f333e792574812872e2cd45ab604199/zarr-3.1.5.tar.gz", hash = "sha256:fbe0c79675a40c996de7ca08e80a1c0a20537bd4a9f43418b6d101395c0bba2b", size = 366825, upload-time = "2025-11-21T14:06:01.492Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/44/15/bb13b4913ef95ad5448490821eee4671d0e67673342e4d4070854e5fe081/zarr-3.1.5-py3-none-any.whl", hash = "sha256:29cd905afb6235b94c09decda4258c888fcb79bb6c862ef7c0b8fe009b5c8563", size = 284067, upload-time = "2025-11-21T14:05:59.235Z" },
+]
+
+[[package]]
+name = "zarr"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "donfig", marker = "python_full_version >= '3.12'" },
+    { name = "google-crc32c", marker = "python_full_version >= '3.12'" },
+    { name = "numcodecs", marker = "python_full_version >= '3.12'" },
+    { name = "numpy", marker = "python_full_version >= '3.12'" },
+    { name = "packaging", marker = "python_full_version >= '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/31/5a/b8a0cf39a14c770c30bd1f2d120c54000c8cd9e84e8e79f38d9a7ce58071/zarr-3.1.6.tar.gz", hash = "sha256:d95e72cbea4b90e9a70679468b8266400331756232576ae2b43400ac5108d0eb", size = 386531, upload-time = "2026-03-23T17:25:18.748Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/7c/ba8ca8cbe9dbef8e83a95fc208fed8e6686c98b4719aaa0aa7f3d31fe390/zarr-3.1.6-py3-none-any.whl", hash = "sha256:b5a82c5079d1c3d4ee8f06746fa3b9a98a7d804300fa3f4be154362a33e1207e", size = 295655, upload-time = "2026-03-23T17:25:17.189Z" },
+]
+
+[[package]]
+name = "zarrs"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", marker = "python_full_version >= '3.12'" },
+    { name = "zarr", version = "3.1.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f9/b3/9e088d4ab5c971e5d2b52cd4d58e3acce35acb3e131990fdc28b69366233/zarrs-0.2.3.tar.gz", hash = "sha256:61640dbbffb9a0b0ebd73f970ce97b52ef56df2828c2809058016d76da59ee60", size = 64827, upload-time = "2026-03-27T08:47:44.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/c0/e10e618293351247e948527c0d2b4c3d8fa9f7478e9f8e945755fc47ecdc/zarrs-0.2.3-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:b9470b17629961badf4261fb0d26ad5fcbe316b63c1b00fb0489a51c3f8ef157", size = 6276814, upload-time = "2026-03-27T08:47:24.992Z" },
+    { url = "https://files.pythonhosted.org/packages/80/ad/8a8525a72190db2c8d6807c69695ef0ea959fd50a4ac887af80803ff5487/zarrs-0.2.3-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:e6998bf1a61cd7c4afd3c263130317c1001599b37ff6f27082cc900a0ad48baa", size = 5776732, upload-time = "2026-03-27T08:47:26.685Z" },
+    { url = "https://files.pythonhosted.org/packages/56/63/27f9f7784006a900ffaa3d62d5c4d0dde98821683cd298cad79f66aa25c5/zarrs-0.2.3-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:19b194f80139b838bb4bf18ed6ef93ecb1904717a04695fbc50cdc0c6074f282", size = 6139081, upload-time = "2026-03-27T08:47:28.465Z" },
+    { url = "https://files.pythonhosted.org/packages/59/a9/28b91493c7db9f3db191a1bc396cd2e212559536f2bc7325e5d5cdbb8b53/zarrs-0.2.3-cp311-abi3-manylinux_2_28_armv7l.whl", hash = "sha256:59a29dfdea088bb25c1e9b5107cbb8de15c8d571d51484ff128cd526c40521b9", size = 5966557, upload-time = "2026-03-27T08:47:30.064Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/c1/0aba516796af22be08e82e37ded59f46cc7ffabf6932957455fccb9c6109/zarrs-0.2.3-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:1d387b75a19c31795cb2a81ef973c905c2c04ca3b1a4cca4bc84c81050974827", size = 6736692, upload-time = "2026-03-27T08:47:31.988Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/fa/471e2511b0c77419ac2228ce72770e94e994ab99c6b9275cb3de1dcead2d/zarrs-0.2.3-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:ab4074056f01f3292c89cd769e8c0db92c0df076e3d36665eec7fc557a62a2ed", size = 6467125, upload-time = "2026-03-27T08:47:34.107Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/6a/7a4230676bd66c0181b4e9000bec30deee1b1695557e5d245514f0454103/zarrs-0.2.3-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9db202e95c3b5c9116afdfebf9912e1faa5ab60e6a1982e0406953cdb47bec38", size = 12507436, upload-time = "2026-03-27T08:47:36.138Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/85/7ad323d428540ca7add343ade347841d181e4e3d73a69f39e34e447f0acc/zarrs-0.2.3-cp311-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:991556a7589e93bc5445da2b97e0c89d7d871e539b9ef28dae857b8573c65f5c", size = 12209703, upload-time = "2026-03-27T08:47:38.619Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/90/ca544236092ab4803d1c3c88ac7b143885e280a63954d454d60885784af8/zarrs-0.2.3-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:437dd4fcf74607480361f401f15b47416aa69f0ff4379c4ea330c453b7e05098", size = 13044036, upload-time = "2026-03-27T08:47:40.589Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/c1/be4e37d80a95347334c287cbb42d94c6181d447f1624c0c5354f593e1fda/zarrs-0.2.3-cp311-abi3-win_amd64.whl", hash = "sha256:72eb1f5c4ca8382cb9e38dd98a48a0e484170d703152110f32a39520c7fa570d", size = 5854312, upload-time = "2026-03-27T08:47:42.856Z" },
 ]
 
 [[package]]

--- a/waveorder/cli/apply_inverse_transfer_function.py
+++ b/waveorder/cli/apply_inverse_transfer_function.py
@@ -1,24 +1,9 @@
-import itertools
 import warnings
-from functools import partial
 from pathlib import Path
 from typing import Literal
 
 import click
-import numpy as np
-import torch
-import torch.multiprocessing as mp
-import xarray as xr
-from iohub import open_ome_zarr
-from iohub.ngff import Position
 
-from waveorder.api import (
-    birefringence,
-    birefringence_and_phase,
-    fluorescence,
-    phase,
-)
-from waveorder.api._utils import _named_dataarray
 from waveorder.cli.parsing import (
     config_filepath,
     input_position_dirpaths,
@@ -26,16 +11,6 @@ from waveorder.cli.parsing import (
     processes_option,
     transfer_function_dirpath,
 )
-from waveorder.cli.printing import echo_headline, echo_settings
-from waveorder.cli.settings import ReconstructionSettings
-from waveorder.cli.utils import (
-    apply_inverse_to_zyx_and_save,
-    create_empty_hcs_zarr,
-    generate_valid_position_key,
-    is_single_position_store,
-    resolve_time_indices,
-)
-from waveorder.io import utils
 
 
 def _check_background_consistency(background_shape, data_shape, input_channel_names):
@@ -45,18 +20,24 @@ def _check_background_consistency(background_shape, data_shape, input_channel_na
 
 
 def _load_transfer_function_dataset(
-    transfer_function_dataset: Position,
+    transfer_function_dataset,
     recon_biref: bool,
     recon_phase: bool,
     recon_fluo: bool,
     recon_dim: Literal[2, 3],
-) -> xr.Dataset:
+):
     """Load transfer function arrays from a zarr store into an xr.Dataset.
 
     Returns an xr.Dataset with the same variable names as produced by
     compute_transfer_function, so it can be passed directly to
     apply_inverse functions.
     """
+
+    # Deferred imports for fast CLI help
+    import numpy as np
+    import xarray as xr
+
+    from waveorder.api._utils import _named_dataarray
 
     def _load(key, idx):
         return _named_dataarray(np.array(transfer_function_dataset[key][idx]), key)
@@ -99,6 +80,13 @@ def _load_transfer_function_dataset(
 
 
 def get_reconstruction_output_metadata(position_path: Path, config_path: Path):
+    # Deferred imports for fast CLI help
+    import numpy as np
+    from iohub import open_ome_zarr
+
+    from waveorder.cli.settings import ReconstructionSettings
+    from waveorder.io import utils
+
     # Get non-OME-Zarr plate-level metadata if it's available
     plate_metadata = {}
     input_version = "0.4"
@@ -143,6 +131,28 @@ def apply_inverse_transfer_function_single_position(
     output_channel_names: list[str],
     verbose: bool = True,
 ) -> None:
+
+    # Deferred imports for fast CLI help
+    import itertools
+    from functools import partial
+
+    import numpy as np
+    import torch.multiprocessing as mp
+    from iohub import open_ome_zarr
+
+    from waveorder.api import (
+        birefringence,
+        birefringence_and_phase,
+        fluorescence,
+        phase,
+    )
+    from waveorder.cli.printing import echo_headline, echo_settings
+    from waveorder.cli.settings import ReconstructionSettings
+    from waveorder.cli.utils import (
+        apply_inverse_to_zyx_and_save,
+        resolve_time_indices,
+    )
+    from waveorder.io import utils
 
     if verbose:
         echo_headline("\nStarting reconstruction...")
@@ -300,6 +310,15 @@ def apply_inverse_transfer_function_cli(
     output_dirpath: Path,
     num_processes,
 ) -> None:
+    # Deferred imports for fast CLI help
+    import torch
+
+    from waveorder.cli.utils import (
+        create_empty_hcs_zarr,
+        generate_valid_position_key,
+        is_single_position_store,
+    )
+
     # Prepare output store
     output_metadata = get_reconstruction_output_metadata(input_position_dirpaths[0], config_filepath)
 
@@ -344,7 +363,7 @@ def apply_inverse_transfer_function_cli(
         )
 
 
-@click.command("apply-inv-tf")
+@click.command("apply-inv-tf", no_args_is_help=True)
 @input_position_dirpaths()
 @transfer_function_dirpath()
 @config_filepath()
@@ -357,17 +376,14 @@ def _apply_inverse_transfer_function_cli(
     output_dirpath: Path,
     num_processes,
 ) -> None:
-    """
-    Apply an inverse transfer function to a dataset using a configuration file.
+    """Apply an inverse transfer function to a dataset.
 
-    Applies a transfer function to all positions in the list `input-position-dirpaths`,
-    so all positions must have the same TCZYX shape.
+    Applies a transfer function to all positions in the list
+    `input-position-dirpaths`, so all positions must have the same TCZYX shape.
 
-    Appends channels to ./output.zarr, so multiple reconstructions can fill a single store.
-
-    See /examples for example configuration files.
-
-    >> waveorder apply-inv-tf -i ./input.zarr/*/*/* -t ./transfer-function.zarr -c /examples/birefringence.yml -o ./output.zarr
+    \b
+    Example:
+      \033[92mwo apply-inv-tf -i ./input.zarr/*/*/* -t ./tf.zarr -c ./config.yml -o ./output.zarr\033[0m
     """
     apply_inverse_transfer_function_cli(
         input_position_dirpaths,

--- a/waveorder/cli/bench.py
+++ b/waveorder/cli/bench.py
@@ -1,0 +1,522 @@
+"""CLI commands for the benchmarking suite.
+
+Available as ``wo benchmark`` / ``wo bm``.
+"""
+
+import json
+import os
+import shutil
+import traceback
+from datetime import datetime
+from pathlib import Path
+
+import click
+import numpy as np
+import yaml
+
+_DEFAULT_EXPERIMENT = Path(__file__).parent.parent.parent / "benchmarks" / "experiments" / "regression.yml"
+
+
+def _resolve_output_dir(cli_value: str | None) -> Path:
+    """Resolve the output directory.
+
+    Precedence: CLI argument > ``WAVEORDER_BENCH_OUTPUT`` env var > ``"."``.
+    """
+    if cli_value is not None:
+        return Path(cli_value)
+    env_value = os.environ.get("WAVEORDER_BENCH_OUTPUT")
+    if env_value:
+        return Path(env_value)
+    return Path(".")
+
+
+def _output_dir_help() -> str:
+    """Build --output-dir help text showing current env var value."""
+    env_value = os.environ.get("WAVEORDER_BENCH_OUTPUT")
+    if env_value:
+        return f"Root output directory. [default: $WAVEORDER_BENCH_OUTPUT = {env_value}]"
+    return "Root output directory. [default: $WAVEORDER_BENCH_OUTPUT if set, else '.']"
+
+
+def _output_dir_option():
+    """The shared ``--output-dir`` click option used by every bm command."""
+    return click.option(
+        "--output-dir",
+        "-o",
+        type=click.Path(),
+        default=None,
+        help=_output_dir_help(),
+    )
+
+
+@click.group("benchmark")
+def benchmark():
+    """Run and inspect reconstruction benchmarks."""
+    pass
+
+
+@benchmark.command()
+@click.option(
+    "--experiment",
+    "-e",
+    type=click.Path(exists=True),
+    default=None,
+    help="Path to experiment YAML. Default: regression suite.",
+)
+@click.option(
+    "--scope",
+    type=click.Choice(["synthetic", "all"]),
+    default="synthetic",
+    help="Which cases to run.",
+)
+@_output_dir_option()
+@click.option(
+    "--save-all",
+    is_flag=True,
+    default=False,
+    help=(
+        "Keep every intermediate output. By default transfer function "
+        "zarrs are always deleted and reconstruction/simulated zarrs "
+        "larger than 25 MB are deleted after metrics are computed."
+    ),
+)
+def run(experiment, scope, output_dir, save_all):
+    """Run benchmark cases.
+
+    By default only metrics, timing, configs, and small (<25 MB) output
+    zarrs are kept — transfer function zarrs and oversized
+    reconstruction/simulation zarrs are deleted after metrics are
+    computed to keep the benchmarks folder small. Pass --save-all to
+    keep every intermediate.
+
+    \b
+    Example:
+      \033[92mwo bm run --scope synthetic\033[0m
+      \033[92mwo bm run --save-all\033[0m
+    """
+    click.echo(click.style("Starting benchmark run...", fg="green"))
+
+    # Deferred imports: benchmarks.runner pulls in torch, iohub, etc.
+    from benchmarks.config import infer_modality, load_experiment, resolve_recon_config
+    from benchmarks.runner import run_hpc_case, run_synthetic_case
+    from benchmarks.utils import collect_metadata
+
+    if experiment is None:
+        experiment = str(_DEFAULT_EXPERIMENT)
+
+    experiment_path = Path(experiment)
+    output_dir = _resolve_output_dir(output_dir)
+    exp = load_experiment(experiment_path)
+
+    selected = {name: case for name, case in exp.cases.items() if not (case.type == "hpc" and scope == "synthetic")}
+    n_skipped_hpc = len(exp.cases) - len(selected)
+
+    metadata = collect_metadata()
+
+    timestamp = datetime.now().strftime("%Y-%m-%dT%H-%M-%S")
+    run_name = f"{timestamp}_{exp.name}"
+    run_dir = output_dir / run_name
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "metadata.json").write_text(json.dumps(metadata, indent=2))
+    shutil.copy2(experiment_path, run_dir / "experiment.yml")
+
+    summary = f"{len(selected)} case{'s' if len(selected) != 1 else ''}"
+    if n_skipped_hpc:
+        summary += f"; skipping {n_skipped_hpc} hpc"
+
+    click.echo(click.style(f"WaveOrder Benchmark — {exp.name}", fg="green", bold=True))
+    click.echo(f"  Git: {metadata['git_hash']} ({metadata['git_branch']}){' dirty' if metadata['git_dirty'] else ''}")
+    click.echo(f"  Experiment: {exp.name} ({summary})")
+    click.echo(f"  Output: {run_dir}")
+    click.echo()
+    _print_header()
+
+    results = {}
+    for case_name, case in selected.items():
+        case_dir = run_dir / "cases" / case_name
+        recon_config = resolve_recon_config(case, experiment_path.parent)
+
+        click.echo(f"  {case_name:24s} running...", nl=False)
+        try:
+            if case.type == "synthetic":
+                metrics = run_synthetic_case(
+                    phantom_config=case.phantom,
+                    recon_config=recon_config,
+                    case_dir=case_dir,
+                    modality=infer_modality(recon_config),
+                    save_all=save_all,
+                )
+            elif case.type == "hpc":
+                metrics = run_hpc_case(
+                    input_path=case.input,
+                    position=case.position,
+                    recon_config=recon_config,
+                    case_dir=case_dir,
+                    save_all=save_all,
+                )
+
+            results[case_name] = metrics
+
+            timing = json.loads((case_dir / "timing.json").read_text())
+            elapsed = timing.get("elapsed_s", 0)
+            metrics["elapsed_s"] = elapsed
+            click.echo("\033[2K\r", nl=False)
+            _print_row(case_name, metrics, elapsed=elapsed)
+        except Exception as e:
+            click.echo("\033[2K\r", nl=False)
+            click.echo(f"  {case_name:24s} " + click.style(f"FAILED: {e}", fg="red"))
+            tb = traceback.format_exc()
+            click.echo(tb, err=True)
+            results[case_name] = {"error": str(e), "traceback": tb}
+
+    # Save summary
+    (run_dir / "summary.json").write_text(json.dumps(results, indent=2))
+
+
+@benchmark.command()
+@_output_dir_option()
+def latest(output_dir):
+    """Show summary of the most recent benchmark run."""
+    click.echo(click.style("Loading latest benchmark...", fg="green"))
+
+    output_dir = _resolve_output_dir(output_dir)
+    run_dirs = _list_run_dirs(output_dir)
+    if not run_dirs:
+        click.echo("No benchmark runs found.")
+        return
+
+    run_dir = run_dirs[-1]
+    click.echo(click.style(f"Latest run: {run_dir.name}", fg="green", bold=True))
+
+    meta_path = run_dir / "metadata.json"
+    if meta_path.exists():
+        meta = json.loads(meta_path.read_text())
+        click.echo(f"  Git: {meta['git_hash']} ({meta['git_branch']})")
+
+    summary_path = run_dir / "summary.json"
+    if summary_path.exists():
+        results = json.loads(summary_path.read_text())
+        click.echo()
+        _print_summary(results)
+
+
+@benchmark.command()
+@_output_dir_option()
+@click.option("--limit", "-n", type=int, default=10, help="Number of runs to show.")
+def history(output_dir, limit):
+    """List recent benchmark runs."""
+    output_dir = _resolve_output_dir(output_dir)
+    run_dirs = _list_run_dirs(output_dir)
+    if not run_dirs:
+        click.echo("No benchmark runs found.")
+        return
+
+    for run_dir in run_dirs[-limit:]:
+        meta_path = run_dir / "metadata.json"
+        meta = json.loads(meta_path.read_text()) if meta_path.exists() else {}
+        summary_path = run_dir / "summary.json"
+        n_cases = 0
+        if summary_path.exists():
+            n_cases = len(json.loads(summary_path.read_text()))
+        click.echo(f"  {run_dir.name:50s} {n_cases} cases  git={meta.get('git_hash', '?')}")
+
+
+def _list_run_dirs(output_dir: str | Path) -> list[Path]:
+    """Return all run directories under output_dir (oldest first)."""
+    root = Path(output_dir)
+    if not root.exists():
+        return []
+    candidates = [p for p in root.iterdir() if p.is_dir() and not p.name.startswith(".")]
+    return sorted(candidates, key=lambda p: p.stat().st_mtime)
+
+
+def _find_runs(output_dir: str | Path, n: int = 1) -> list[Path]:
+    """Return the N most recent run directories, newest first."""
+    return list(reversed(_list_run_dirs(output_dir)))[:n]
+
+
+def _load_summary(run_dir: Path) -> dict:
+    """Load summary.json from a run directory."""
+    path = run_dir / "summary.json"
+    if path.exists():
+        return json.loads(path.read_text())
+    return {}
+
+
+@benchmark.command()
+@_output_dir_option()
+@click.argument("run_a", required=False)
+@click.argument("run_b", required=False)
+def compare(output_dir, run_a, run_b):
+    """Compare two benchmark runs side by side.
+
+    If no run names given, compares the two most recent runs.
+
+    \b
+    Example:
+      \033[92mwo bm compare\033[0m
+    """
+    output_dir = _resolve_output_dir(output_dir)
+
+    if run_a and run_b:
+        dirs = [output_dir / run_a, output_dir / run_b]
+    else:
+        dirs = _find_runs(output_dir, n=2)
+
+    if len(dirs) < 2:
+        click.echo("Need at least 2 runs to compare.")
+        return
+
+    dir_a, dir_b = dirs[1], dirs[0]  # older first
+    summary_a = _load_summary(dir_a)
+    summary_b = _load_summary(dir_b)
+
+    click.echo(click.style("Benchmark comparison", fg="green", bold=True))
+    click.echo(f"  A: {dir_a.name}")
+    click.echo(f"  B: {dir_b.name}")
+    click.echo()
+
+    # Find common cases
+    common = set(summary_a.keys()) & set(summary_b.keys())
+    if not common:
+        click.echo("No common cases between runs.")
+        return
+
+    # Header
+    click.echo(f"  {'case':24s} {'metric':>10s} {'A':>10s} {'B':>10s} {'delta':>10s}")
+    click.echo("  " + "─" * 66)
+
+    for case_name in sorted(common):
+        ma, mb = summary_a[case_name], summary_b[case_name]
+        if "error" in ma or "error" in mb:
+            continue
+
+        # Compare key metrics
+        pairs = []
+        iq_a, iq_b = ma.get("image_quality", {}), mb.get("image_quality", {})
+        for key in ["midband_power"]:
+            if key in iq_a and key in iq_b:
+                pairs.append(("midband", iq_a[key], iq_b[key]))
+
+        for group in ["with_phantom", "with_reference"]:
+            ga, gb = ma.get(group, {}), mb.get(group, {})
+            for key in ["mse", "ssim"]:
+                if key in ga and key in gb:
+                    pairs.append((key, ga[key], gb[key]))
+
+        for metric, va, vb in pairs:
+            delta = vb - va
+            click.echo(f"  {case_name:24s} {metric:>10s} {_fmt(va)} {_fmt(vb)} {_fmt(delta)}")
+            case_name = ""  # only show name on first row
+
+
+@benchmark.command()
+@_output_dir_option()
+@click.argument("path", required=False, default=None)
+def view(output_dir, path):
+    """Open benchmark results in napari.
+
+    PATH selects what to view: ``latest`` or a run name, optionally
+    followed by ``/case_name``. Nothing opens the most recent run.
+    Raw input and reconstruction are loaded as separate layers and
+    tiled side-by-side via napari's grid mode.
+
+    \b
+    Example:
+      \033[92mwo bm view\033[0m
+      \033[92mwo bm view latest/phase_3d_beads\033[0m
+      \033[92mwo bm view 2026-03-27T11-00-10_regression/reg_1e-3\033[0m
+    """
+    click.echo(click.style("Opening benchmark results...", fg="green"))
+
+    # Deferred imports
+    import napari
+    from iohub.ngff import open_ome_zarr
+
+    from benchmarks.config import load_experiment
+
+    # Parse path: nothing, "run_name", or "run_name/case_name"
+    run_name = None
+    case = None
+    if path:
+        parts = path.split("/", 1)
+        run_name = parts[0]
+        if len(parts) > 1:
+            case = parts[1]
+
+    output_dir = _resolve_output_dir(output_dir)
+    if run_name in (None, "latest"):
+        runs = _find_runs(output_dir, n=1)
+        if not runs:
+            click.echo("No benchmark runs found.")
+            return
+        run_dir = runs[0]
+    else:
+        run_dir = output_dir / run_name
+        if not run_dir.exists():
+            click.echo(f"Run not found: {run_dir}")
+            return
+
+    cases_dir = run_dir / "cases"
+    if not cases_dir.exists():
+        click.echo(f"No cases in run {run_dir.name}.")
+        return
+
+    # Load the experiment YAML saved with this run to locate raw inputs
+    exp_path = run_dir / "experiment.yml"
+    experiment = load_experiment(exp_path) if exp_path.exists() else None
+
+    viewer = napari.Viewer(title=f"wo bm view — {run_dir.name}")
+
+    case_dirs = [cases_dir / case] if case else sorted(cases_dir.iterdir())
+    for case_dir in case_dirs:
+        if not case_dir.is_dir():
+            continue
+        case_name = case_dir.name
+
+        # Raw input: simulated.zarr for synthetic, {input}/{position} for hpc
+        raw_path = _resolve_raw_path(case_dir, case_name, experiment)
+        channel_filter = _input_channel_names(case_dir)
+        if raw_path and raw_path.exists():
+            _add_zarr_to_viewer(
+                viewer,
+                raw_path,
+                f"{case_name}/raw",
+                open_ome_zarr,
+                channels=channel_filter,
+            )
+        else:
+            click.echo(f"  {case_name}: no raw input found")
+
+        # Reconstruction
+        recon_path = case_dir / "reconstruction.zarr"
+        if recon_path.exists():
+            _add_zarr_to_viewer(viewer, recon_path, f"{case_name}/recon", open_ome_zarr)
+
+    viewer.grid.enabled = True
+    napari.run()
+
+
+def _resolve_raw_path(case_dir: Path, case_name: str, experiment) -> Path | None:
+    """Locate the raw input for a case.
+
+    Synthetic cases store their simulated measurement as ``simulated.zarr``
+    in the case directory. HPC cases point at an external position, which
+    is reconstructed from the experiment YAML as ``{input}/{position}``.
+    """
+    sim_path = case_dir / "simulated.zarr"
+    if sim_path.exists():
+        return sim_path
+    if experiment is None or case_name not in experiment.cases:
+        return None
+    case_cfg = experiment.cases[case_name]
+    if case_cfg.type != "hpc":
+        return None
+    if not case_cfg.input or not case_cfg.position:
+        raise ValueError(f"hpc case '{case_name}' missing input or position in experiment.yml")
+    return Path(case_cfg.input) / case_cfg.position
+
+
+def _add_zarr_to_viewer(viewer, path, prefix, open_ome_zarr, channels=None):
+    """Add channels from an OME-Zarr to the viewer.
+
+    Handles both HCS (multi-position) and single-position (FOV) stores.
+    If ``channels`` is given, only channels whose names match are added.
+    """
+    dataset = open_ome_zarr(path, mode="r")
+    try:
+        positions = [pos for _, pos in dataset.positions()]
+    except (AttributeError, TypeError):
+        positions = [dataset]
+
+    for position in positions:
+        data = np.array(position["0"][0])  # CZYX at T=0
+        for c_idx, ch_name in enumerate(position.channel_names):
+            if channels is not None and ch_name not in channels:
+                continue
+            ch_data = data[c_idx]
+            if ch_data.shape[0] == 1:
+                ch_data = ch_data[0]
+            viewer.add_image(ch_data, name=f"{prefix}/{ch_name}")
+    dataset.close()
+
+
+def _input_channel_names(case_dir: Path) -> list[str] | None:
+    """Read ``input_channel_names`` from the case's saved config.yml."""
+    cfg_path = case_dir / "config.yml"
+    if not cfg_path.exists():
+        return None
+    cfg = yaml.safe_load(cfg_path.read_text())
+    names = cfg.get("input_channel_names")
+    return list(names) if names else None
+
+
+def _fmt(value, width=10):
+    """Format a float as fixed-width scientific notation with explicit sign."""
+    if value == 0:
+        return f"{' 0':>{width}s}"
+    sign = "+" if value > 0 else ""
+    return f"{sign}{value:.1e}".rjust(width)
+
+
+def _sparkline(hist, n_bins=10):
+    """Render a small inline sparkline (bars only)."""
+    counts = np.array(hist["counts"], dtype=float)
+    if len(counts) > n_bins:
+        factor = len(counts) // n_bins
+        counts = counts[: factor * n_bins].reshape(n_bins, factor).sum(axis=1)
+    if counts.max() == 0:
+        return ""
+    blocks = "▁▂▃▄▅▆▇█"
+    normalized = counts / counts.max()
+    return "".join(blocks[int(v * 7)] for v in normalized)
+
+
+_W = 10  # metric column width
+_H = 10  # min/max column width
+
+
+def _print_header():
+    """Print the summary table header."""
+    header = (
+        f"  {'case':24s} {'time':>6s}"
+        f" {'midband':>{_W}s} {'mse':>{_W}s} {'ssim':>{_W}s}"
+        f"  {'min':>{_H}s} {'histogram':^12s} {'max':>{_H}s}"
+    )
+    click.echo(header)
+    click.echo("  " + "─" * (len(header) - 2))
+
+
+def _print_row(case_name: str, metrics: dict, elapsed: float | None = None):
+    """Print a single summary table row."""
+    iq = metrics.get("image_quality", {})
+    mbp = _fmt(iq.get("midband_power", 0), _W)
+
+    phantom = metrics.get("with_phantom", {})
+    ssim_str = f"{phantom['ssim']:>{_W}.3f}" if "ssim" in phantom else f"{'—':>{_W}s}"
+    mse_str = _fmt(phantom["mse"], _W) if "mse" in phantom else f"{'—':>{_W}s}"
+
+    hist = iq.get("histogram", {})
+    if hist:
+        edges = np.array(hist["bin_edges"])
+        min_str = _fmt(edges[0], _H)
+        max_str = _fmt(edges[-1], _H)
+        spark = _sparkline(hist)
+    else:
+        min_str = f"{'—':>{_H}s}"
+        max_str = f"{'—':>{_H}s}"
+        spark = ""
+
+    time_str = f"{elapsed:5.1f}s" if elapsed is not None else f"{'—':>6s}"
+
+    click.echo(f"  {case_name:24s} {time_str} {mbp} {mse_str} {ssim_str}  {min_str} {spark:^12s} {max_str}")
+
+
+def _print_summary(results: dict):
+    """Print a full summary table (header + all rows)."""
+    _print_header()
+    for case_name, metrics in results.items():
+        if "error" in metrics:
+            click.echo(f"  {case_name:24s} " + click.style("ERROR", fg="red"))
+            continue
+        _print_row(case_name, metrics, elapsed=metrics.get("elapsed_s"))

--- a/waveorder/cli/compute_transfer_function.py
+++ b/waveorder/cli/compute_transfer_function.py
@@ -1,31 +1,20 @@
 from pathlib import Path
 
 import click
-import numpy as np
-from iohub.ngff import Position, open_ome_zarr
 
-from waveorder.api import (
-    birefringence,
-    birefringence_and_phase,
-    fluorescence,
-    phase,
-)
 from waveorder.cli.parsing import (
     config_filepath,
     input_position_dirpaths,
     output_dirpath,
 )
-from waveorder.cli.printing import echo_headline, echo_settings
-from waveorder.cli.settings import ReconstructionSettings
-from waveorder.io import utils
 
 
-def _write_birefringence_tf(dataset: Position, tf_ds):
+def _write_birefringence_tf(dataset, tf_ds):
     """Write birefringence TF arrays to zarr."""
     dataset["intensity_to_stokes_matrix"] = tf_ds["intensity_to_stokes_matrix"].values[None, None, None, ...]
 
 
-def _write_phase_tf(dataset: Position, tf_ds, zyx_shape, recon_dim):
+def _write_phase_tf(dataset, tf_ds, zyx_shape, recon_dim):
     """Write phase TF arrays to zarr."""
     if recon_dim == 2:
         dataset.create_image(
@@ -54,7 +43,7 @@ def _write_phase_tf(dataset: Position, tf_ds, zyx_shape, recon_dim):
         )
 
 
-def _write_fluorescence_tf(dataset: Position, tf_ds, zyx_shape, recon_dim):
+def _write_fluorescence_tf(dataset, tf_ds, zyx_shape, recon_dim):
     """Write fluorescence TF arrays to zarr."""
     yx_shape = zyx_shape[1:]
     if recon_dim == 2:
@@ -81,7 +70,7 @@ def _write_fluorescence_tf(dataset: Position, tf_ds, zyx_shape, recon_dim):
         )
 
 
-def _write_vector_birefringence_tf(dataset: Position, tf_ds, zyx_shape):
+def _write_vector_birefringence_tf(dataset, tf_ds, zyx_shape):
     """Write vector birefringence TF arrays to zarr."""
     chunks = (1, 1, 1, zyx_shape[1], zyx_shape[2])
 
@@ -114,6 +103,20 @@ def compute_transfer_function_cli(
     """CLI command to compute the transfer function given a configuration file path
     and a desired output path.
     """
+    # Deferred imports: these pull in torch, iohub, numpy, etc.
+    # Only loaded when the command runs, keeping wo compute-tf -h fast.
+    import numpy as np
+    from iohub.ngff import open_ome_zarr
+
+    from waveorder.api import (
+        birefringence,
+        birefringence_and_phase,
+        fluorescence,
+        phase,
+    )
+    from waveorder.cli.printing import echo_headline, echo_settings
+    from waveorder.cli.settings import ReconstructionSettings
+    from waveorder.io import utils
 
     # Load config file
     settings = utils.yaml_to_model(config_filepath, ReconstructionSettings)
@@ -208,7 +211,7 @@ def compute_transfer_function_cli(
     )
 
 
-@click.command("compute-tf")
+@click.command("compute-tf", no_args_is_help=True)
 @input_position_dirpaths()
 @config_filepath()
 @output_dirpath()
@@ -217,14 +220,13 @@ def _compute_transfer_function_cli(
     config_filepath: Path,
     output_dirpath: Path,
 ) -> None:
-    """
-    Compute a transfer function using a dataset and configuration file.
+    """Compute a transfer function using a dataset and configuration file.
 
     Calculates the transfer function based on the shape of the first position
     in the list `input-position-dirpaths`.
 
-    See /examples for example configuration files.
-
-    >> waveorder compute-tf -i ./input.zarr/0/0/0 -c ./examples/birefringence.yml -o ./transfer_function.zarr
+    \b
+    Example:
+      \033[92mwo compute-tf -i ./input.zarr/0/0/0 -c ./config.yml -o ./tf.zarr\033[0m
     """
     compute_transfer_function_cli(input_position_dirpaths[0], config_filepath, output_dirpath)

--- a/waveorder/cli/main.py
+++ b/waveorder/cli/main.py
@@ -1,109 +1,165 @@
+import importlib
+import logging
+import os
+import warnings
+
+# Suppress noisy CUDA and dependency warnings.
+# PYTHONWARNINGS env var catches warnings from torch's C++ queued callbacks
+# that fire after import but before Python filterwarnings can intercept them.
+os.environ.setdefault("PYTHONWARNINGS", "ignore::UserWarning,ignore::DeprecationWarning")
+warnings.filterwarnings("ignore", category=UserWarning)
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+logging.getLogger("iohub").setLevel(logging.ERROR)
+
 import click
-
-from waveorder.cli.apply_inverse_transfer_function import (
-    _apply_inverse_transfer_function_cli,
-)
-from waveorder.cli.compute_transfer_function import (
-    _compute_transfer_function_cli,
-)
-from waveorder.cli.reconstruct import _reconstruct_cli
-from waveorder.cli.simulate import _simulate_cli
-from waveorder.cli.view import _view_cli
-
-try:
-    from waveorder.cli.gui_widget import gui as _interactive_cli
-except:
-    _interactive_cli = None
 
 CONTEXT = {"help_option_names": ["-h", "--help"]}
 
+# Registry of commands: name → "module.path:attribute"
+# Modules are only imported when the command is actually invoked.
+_LAZY_COMMANDS = {
+    "simulate": "waveorder.cli.simulate:_simulate_cli",
+    "reconstruct": "waveorder.cli.reconstruct:_reconstruct_cli",
+    "compute-transfer-function": "waveorder.cli.compute_transfer_function:_compute_transfer_function_cli",
+    "apply-inverse-transfer-function": "waveorder.cli.apply_inverse_transfer_function:_apply_inverse_transfer_function_cli",
+    "view": "waveorder.cli.view:_view_cli",
+}
 
-class AliasGroup(click.Group):
-    """Click group with command aliases shown in help."""
+# Optional commands that may not be installed
+_OPTIONAL_LAZY_COMMANDS = {
+    "interactive": "waveorder.cli.gui_widget:gui",
+    "benchmark": "waveorder.cli.bench:benchmark",
+}
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._aliases: dict[str, str] = {}
-        self._reverse: dict[str, str] = {}
-        self._display_order: list[tuple[str, int]] = []
+_ALIASES = {
+    "rec": "reconstruct",
+    "sim": "simulate",
+    "v": "view",
+    "compute-tf": "compute-transfer-function",
+    "apply-inv-tf": "apply-inverse-transfer-function",
+    "gui": "interactive",
+    "bm": "benchmark",
+}
 
-    def add_alias(self, alias: str, command_name: str):
-        self._aliases[alias] = command_name
-        self._reverse[command_name] = alias
-
-    def get_command(self, ctx, cmd_name):
-        cmd_name = self._aliases.get(cmd_name, cmd_name)
-        return super().get_command(ctx, cmd_name)
-
-    def list_commands(self, ctx):
-        return list(self.commands.keys())
-
-    def format_usage(self, ctx, formatter):
-        formatter.write_usage(
-            "wo",
-            "[OPTIONS] COMMAND [ARGS]...",
-        )
-
-    def format_help(self, ctx, formatter):
-        self.format_usage(ctx, formatter)
-        formatter.write("\n")
-        formatter.write("  \033[92mwaveorder\033[0m [\033[92mwo\033[0m]: Wave-optical simulation and reconstruction\n")
-        formatter.write("\n")
-
-        # Options
-        formatter.write("Options:\n")
-        formatter.write("  -h, --help  Show this message and exit.\n")
-        formatter.write("\n")
-
-        # Commands with aliases, manually ordered
-        formatter.write("Commands:\n")
-        col = 40  # align aliases to this column
-        for name, indent in self._display_order:
-            if name not in self.commands:
-                continue
-            alias = self._reverse.get(name)
-            pad = " " * indent
-            label = f"  {pad}{name}"
-            if alias:
-                gap = " " * max(1, col + indent - len(label))
-                label += f"{gap}[{alias}]"
-            formatter.write(label + "\n")
-
-        formatter.write("\n")
-
-
-@click.group(context_settings=CONTEXT, cls=AliasGroup)
-def cli():
-    pass
-
-
-# Commands
-cli.add_command(_simulate_cli, "simulate")
-cli.add_command(_reconstruct_cli, "reconstruct")
-cli.add_command(_compute_transfer_function_cli, "compute-transfer-function")
-cli.add_command(_apply_inverse_transfer_function_cli, "apply-inverse-transfer-function")
-cli.add_command(_view_cli, "view")
-if _interactive_cli is not None:
-    cli.add_command(_interactive_cli, "interactive")
-
-# Display order: (command_name, indent)
-cli._display_order = [
+_DISPLAY_ORDER = [
     ("reconstruct", 0),
     ("compute-transfer-function", 2),
     ("apply-inverse-transfer-function", 2),
     ("simulate", 0),
     ("view", 0),
     ("interactive", 0),
+    ("benchmark", 0),
 ]
 
-# Aliases
-cli.add_alias("rec", "reconstruct")
-cli.add_alias("sim", "simulate")
-cli.add_alias("v", "view")
-cli.add_alias("compute-tf", "compute-transfer-function")
-cli.add_alias("apply-inv-tf", "apply-inverse-transfer-function")
-if _interactive_cli is not None:
-    cli.add_alias("gui", "interactive")
+
+def _import_command(import_path: str):
+    """Import a click command from a 'module.path:attribute' string."""
+    module_path, attr = import_path.rsplit(":", 1)
+    mod = importlib.import_module(module_path)
+    return getattr(mod, attr)
+
+
+class LazyAliasGroup(click.Group):
+    """Click group that defers subcommand imports until invocation.
+
+    Commands registered in ``_LAZY_COMMANDS`` are only imported when
+    actually invoked, avoiding heavy imports (torch, numpy, etc.) for
+    ``wo --help`` or unrelated subcommands.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._aliases: dict[str, str] = {}
+        self._reverse: dict[str, str] = {}
+        self._display_order: list[tuple[str, int]] = []
+        self._lazy: dict[str, str] = {}
+        self._optional_lazy: dict[str, str] = {}
+
+    def add_lazy(self, name: str, import_path: str):
+        self._lazy[name] = import_path
+
+    def add_optional_lazy(self, name: str, import_path: str):
+        self._optional_lazy[name] = import_path
+
+    def add_alias(self, alias: str, command_name: str):
+        self._aliases[alias] = command_name
+        self._reverse[command_name] = alias
+
+    def get_command(self, ctx, cmd_name):
+        # Resolve alias
+        cmd_name = self._aliases.get(cmd_name, cmd_name)
+
+        # Check if already loaded
+        cmd = super().get_command(ctx, cmd_name)
+        if cmd is not None:
+            return cmd
+
+        # Lazy load
+        import_path = self._lazy.get(cmd_name) or self._optional_lazy.get(cmd_name)
+        if import_path is not None:
+            try:
+                cmd = _import_command(import_path)
+                self.add_command(cmd, cmd_name)
+                return cmd
+            except Exception:
+                return None
+
+        return None
+
+    def list_commands(self, ctx):
+        # Registered + lazy (required) + optional (assume available for listing)
+        names = set(self.commands.keys()) | set(self._lazy.keys()) | set(self._optional_lazy.keys())
+        # Return in display order, then any extras
+        ordered = [name for name, _ in self._display_order if name in names]
+        for name in sorted(names - set(ordered)):
+            ordered.append(name)
+        return ordered
+
+    def format_usage(self, ctx, formatter):
+        formatter.write_usage("wo", "[OPTIONS] COMMAND [ARGS]...")
+
+    def format_help(self, ctx, formatter):
+        self.format_usage(ctx, formatter)
+        formatter.write("\n")
+        formatter.write("  waveorder [\033[92mwo\033[0m]: Wave-optical simulation and reconstruction\n")
+        formatter.write("\n")
+
+        formatter.write("Options:\n")
+        formatter.write("  -h, --help  Show this message and exit.\n")
+        formatter.write("\n")
+
+        formatter.write("Commands:\n")
+        col = 40
+        available = set(self.list_commands(ctx))
+        for name, indent in self._display_order:
+            if name not in available:
+                continue
+            alias = self._reverse.get(name)
+            pad = " " * indent
+            label = f"  {pad}{name}"
+            if alias:
+                gap = " " * max(1, col + indent - len(label))
+                label += f"{gap}[\033[92m{alias}\033[0m]"
+            formatter.write(label + "\n")
+
+        formatter.write("\n")
+
+
+@click.group(context_settings=CONTEXT, cls=LazyAliasGroup)
+def cli():
+    pass
+
+
+# Register lazy commands
+for name, path in _LAZY_COMMANDS.items():
+    cli.add_lazy(name, path)
+for name, path in _OPTIONAL_LAZY_COMMANDS.items():
+    cli.add_optional_lazy(name, path)
+
+# Display order and aliases
+cli._display_order = _DISPLAY_ORDER
+for alias, target in _ALIASES.items():
+    cli.add_alias(alias, target)
 
 if __name__ == "__main__":
     cli()

--- a/waveorder/cli/parsing.py
+++ b/waveorder/cli/parsing.py
@@ -2,14 +2,16 @@ from pathlib import Path
 from typing import Callable
 
 import click
-import torch.multiprocessing as mp
-from iohub.ngff import Plate, open_ome_zarr
-from natsort import natsorted
 
 from waveorder.cli.option_eat_all import OptionEatAll
 
 
 def _validate_and_process_paths(ctx: click.Context, opt: click.Option, value: str) -> list[Path]:
+    # Deferred imports: iohub and natsort are heavy (pull in torch via zarr/numpy chain).
+    # Only needed when the command actually runs, not for --help.
+    from iohub.ngff import Plate, open_ome_zarr
+    from natsort import natsorted
+
     # Sort and validate the input paths, expanding plates into lists of positions
     input_paths = [Path(path) for path in natsorted(value)]
     # Filter out non-directories (e.g., zarr.json files from glob expansion)
@@ -88,6 +90,9 @@ def output_dirpath() -> Callable:
 # TODO: this setting will have to be collected from SLURM?
 def processes_option(default: int = None) -> Callable:
     def check_processes_option(ctx, param, value):
+        # Deferred: torch.multiprocessing pulls in all of torch.
+        import torch.multiprocessing as mp
+
         max_processes = mp.cpu_count()
         if value > max_processes:
             raise click.BadParameter(f"Maximum number of processes is {max_processes}")
@@ -97,7 +102,7 @@ def processes_option(default: int = None) -> Callable:
         return click.option(
             "--num_processes",
             "-j",
-            default=default or mp.cpu_count(),
+            default=default or 1,
             type=int,
             help="Number of processes to run in parallel.",
             callback=check_processes_option,

--- a/waveorder/cli/reconstruct.py
+++ b/waveorder/cli/reconstruct.py
@@ -1,15 +1,7 @@
 from pathlib import Path
 
 import click
-from iohub.ngff import open_ome_zarr
 
-from waveorder.api import fluorescence, phase
-from waveorder.cli.apply_inverse_transfer_function import (
-    apply_inverse_transfer_function_cli,
-)
-from waveorder.cli.compute_transfer_function import (
-    compute_transfer_function_cli,
-)
 from waveorder.cli.parsing import (
     config_filepath,
     input_position_dirpaths,
@@ -17,13 +9,9 @@ from waveorder.cli.parsing import (
     processes_option,
     unique_id,
 )
-from waveorder.cli.settings import OptimizationSettings, ReconstructionSettings
-from waveorder.cli.utils import resolve_time_indices
-from waveorder.io import utils
-from waveorder.optim import has_optimizable_params
 
 
-@click.command("reconstruct")
+@click.command("reconstruct", no_args_is_help=True)
 @input_position_dirpaths()
 @config_filepath()
 @output_dirpath()
@@ -51,8 +39,20 @@ def _reconstruct_cli(
 
     See /examples for example configuration files.
 
-    >> waveorder reconstruct -i ./input.zarr/*/*/* -c ./examples/birefringence.yml -o ./output.zarr
+    \b
+    Example:
+      \033[92mwo rec -i ./input.zarr/*/*/* -c ./config.yml -o ./output.zarr\033[0m
     """
+    click.echo(click.style("Starting reconstruction...", fg="green"))
+
+    # Deferred imports: these pull in torch, iohub, numpy, etc.
+    # Only loaded when the command runs, keeping wo rec -h fast.
+    from waveorder.cli.apply_inverse_transfer_function import apply_inverse_transfer_function_cli
+    from waveorder.cli.compute_transfer_function import compute_transfer_function_cli
+    from waveorder.cli.settings import ReconstructionSettings
+    from waveorder.io import utils
+    from waveorder.optim import has_optimizable_params
+
     settings = utils.yaml_to_model(config_filepath, ReconstructionSettings)
 
     # Check for optimizable parameters and run optimization if needed
@@ -81,6 +81,14 @@ def _reconstruct_cli(
 
 def _run_optimization(settings, input_position_dirpath, config_filepath):
     """Run parameter optimization before standard reconstruction."""
+    # Deferred imports for the same reason as above
+    from iohub.ngff import open_ome_zarr
+
+    from waveorder.api import fluorescence, phase
+    from waveorder.cli.settings import OptimizationSettings
+    from waveorder.cli.utils import resolve_time_indices
+    from waveorder.io import utils
+
     if settings.birefringence is not None:
         raise NotImplementedError("Parameter optimization is not supported for birefringence reconstructions.")
 

--- a/waveorder/cli/simulate.py
+++ b/waveorder/cli/simulate.py
@@ -1,51 +1,11 @@
 from pathlib import Path
 
 import click
-import numpy as np
-import xarray as xr
-from iohub.ngff import open_ome_zarr
-from iohub.ngff.models import TransformationMeta
 
-from waveorder.api import (
-    birefringence,
-    birefringence_and_phase,
-    fluorescence,
-    phase,
-)
 from waveorder.cli.parsing import config_filepath, output_dirpath
-from waveorder.cli.printing import echo_headline
-from waveorder.cli.settings import ReconstructionSettings
-from waveorder.io import utils
 
 
-def _write_czyx(czyx: xr.DataArray, path: Path):
-    """Write a CZYX xr.DataArray to an HCS OME-Zarr."""
-    channel_names = list(czyx.coords["c"].values)
-    dataset = open_ome_zarr(path, layout="hcs", mode="w", channel_names=channel_names)
-    position = dataset.create_position("0", "0", "0")
-    position.create_zeros(
-        "0",
-        (1, *czyx.shape),
-        dtype=np.float32,
-        transform=[
-            TransformationMeta(
-                type="scale",
-                scale=[
-                    1,
-                    1,
-                    float(czyx.z[1] - czyx.z[0]),
-                    float(czyx.y[1] - czyx.y[0]),
-                    float(czyx.x[1] - czyx.x[0]),
-                ],
-            )
-        ],
-    )
-    position["0"][0] = czyx.values
-
-    dataset.close()
-
-
-@click.command("simulate")
+@click.command("simulate", no_args_is_help=True)
 @config_filepath()
 @output_dirpath()
 def _simulate_cli(config_filepath: Path, output_dirpath: Path):
@@ -55,8 +15,53 @@ def _simulate_cli(config_filepath: Path, output_dirpath: Path):
     simulated measurement as separate channels.
 
     \b
-    >> wo sim -c ./phase.yml -o ./phase.zarr
+    Example:
+      \033[92mwo sim -c ./phase.yml -o ./phase.zarr\033[0m
     """
+    click.echo(click.style("Starting simulation...", fg="green"))
+
+    # Deferred imports: these pull in torch, iohub, numpy, etc.
+    # Only loaded when the command runs, keeping wo sim -h fast.
+    import numpy as np
+    import xarray as xr
+    from iohub.ngff import open_ome_zarr
+    from iohub.ngff.models import TransformationMeta
+
+    from waveorder.api import (
+        birefringence,
+        birefringence_and_phase,
+        fluorescence,
+        phase,
+    )
+    from waveorder.cli.printing import echo_headline
+    from waveorder.cli.settings import ReconstructionSettings
+    from waveorder.io import utils
+
+    def _write_czyx(czyx: xr.DataArray, path: Path):
+        """Write a CZYX xr.DataArray to an HCS OME-Zarr."""
+        channel_names = list(czyx.coords["c"].values)
+        dataset = open_ome_zarr(path, layout="hcs", mode="w", channel_names=channel_names)
+        position = dataset.create_position("0", "0", "0")
+        position.create_zeros(
+            "0",
+            (1, *czyx.shape),
+            dtype=np.float32,
+            transform=[
+                TransformationMeta(
+                    type="scale",
+                    scale=[
+                        1,
+                        1,
+                        float(czyx.z[1] - czyx.z[0]),
+                        float(czyx.y[1] - czyx.y[0]),
+                        float(czyx.x[1] - czyx.x[0]),
+                    ],
+                )
+            ],
+        )
+        position["0"][0] = czyx.values
+        dataset.close()
+
     settings = utils.yaml_to_model(config_filepath, ReconstructionSettings)
 
     recon_dim = settings.reconstruction_dimension

--- a/waveorder/phantoms.py
+++ b/waveorder/phantoms.py
@@ -1,0 +1,339 @@
+"""Phantom generation for benchmarks, testing, and simulation.
+
+Provides explicit, reproducible phantom generation with full metadata.
+"""
+
+from dataclasses import dataclass
+
+import numpy as np
+import torch
+from torch import Tensor
+
+
+@dataclass
+class Phantom:
+    """A simulated sample with ground truth.
+
+    Attributes
+    ----------
+    phase : Tensor
+        Refractive index difference from background, shape ``(..., Y, X)``.
+        Units: dimensionless (dn). Positive = higher RI than medium.
+    absorption : Tensor
+        Absorption coefficient, shape ``(..., Y, X)``.
+        Units: arbitrary (non-negative).
+    fluorescence : Tensor
+        Fluorophore concentration, shape ``(..., Y, X)``.
+        Units: arbitrary (non-negative).
+    pixel_sizes : tuple[float, float, float]
+        (z, y, x) pixel sizes in um.
+    metadata : dict
+        All parameters used to generate this phantom, sufficient to
+        reproduce it exactly.
+    """
+
+    phase: Tensor
+    absorption: Tensor
+    fluorescence: Tensor
+    pixel_sizes: tuple[float, float, float]
+    metadata: dict
+
+
+def single_bead(
+    shape: tuple[int, int, int] = (64, 128, 128),
+    pixel_sizes: tuple[float, float, float] = (0.25, 0.1, 0.1),
+    bead_radius_um: float = 2.5,
+    refractive_index_diff: float = 0.05,
+    absorption_coefficient: float = 0.0,
+    fluorescence_intensity: float = 1.0,
+    fluorescence_background: float = 0.0,
+    center: tuple[float, float, float] | None = None,
+    blur_size_um: float = 0.1,
+) -> Phantom:
+    """Generate a single bead phantom.
+
+    Creates a sphere with specified refractive index difference,
+    absorption, and fluorescence intensity, blurred by a Gaussian
+    to avoid sharp edges.
+
+    Parameters
+    ----------
+    shape : tuple[int, int, int]
+        Volume shape (Z, Y, X) in pixels.
+    pixel_sizes : tuple[float, float, float]
+        (z, y, x) pixel sizes in um.
+    bead_radius_um : float
+        Bead radius in um.
+    refractive_index_diff : float
+        RI difference from background (dn). Can be positive or negative.
+    absorption_coefficient : float
+        Peak absorption coefficient inside the bead.
+    fluorescence_intensity : float
+        Peak fluorophore concentration inside the bead.
+    fluorescence_background : float
+        Constant baseline added to the fluorescence channel everywhere
+    center : tuple[float, float, float] or None
+        Bead center in um, relative to volume center. None = (0, 0, 0).
+    blur_size_um : float
+        Gaussian blur standard deviation in um.
+
+    Returns
+    -------
+    Phantom
+        Phase, absorption, and fluorescence ground truth with metadata.
+
+    Examples
+    --------
+    >>> phantom = single_bead(shape=(32, 64, 64), bead_radius_um=2.0)
+    >>> phantom.phase.shape
+    torch.Size([32, 64, 64])
+    >>> phantom.metadata["bead_radius_um"]
+    2.0
+    """
+    if center is None:
+        center = (0.0, 0.0, 0.0)
+
+    metadata = {
+        "type": "single_bead",
+        "shape": list(shape),
+        "pixel_sizes": list(pixel_sizes),
+        "bead_radius_um": bead_radius_um,
+        "refractive_index_diff": refractive_index_diff,
+        "absorption_coefficient": absorption_coefficient,
+        "fluorescence_intensity": fluorescence_intensity,
+        "fluorescence_background": fluorescence_background,
+        "center": list(center),
+        "blur_size_um": blur_size_um,
+    }
+
+    mask = _sphere_mask(shape, pixel_sizes, bead_radius_um, center)
+    blurred = _gaussian_blur(mask, pixel_sizes, blur_size_um)
+
+    phase = blurred * refractive_index_diff
+    absorption = blurred * absorption_coefficient
+    fluorescence = blurred * fluorescence_intensity + fluorescence_background
+
+    return Phantom(
+        phase=phase,
+        absorption=absorption,
+        fluorescence=fluorescence,
+        pixel_sizes=pixel_sizes,
+        metadata=metadata,
+    )
+
+
+def random_beads(
+    shape: tuple[int, int, int] = (64, 128, 128),
+    pixel_sizes: tuple[float, float, float] = (0.25, 0.1, 0.1),
+    n_beads: int = 10,
+    bead_radius_um: float = 1.0,
+    refractive_index_diff: float = 0.03,
+    absorption_coefficient: float = 0.0,
+    fluorescence_intensity: float = 1.0,
+    fluorescence_background: float = 0.0,
+    blur_size_um: float = 0.1,
+    seed: int = 42,
+) -> Phantom:
+    """Generate randomly placed beads.
+
+    Creates multiple spheres at random positions, with the same radius
+    and optical properties. Beads are placed with no overlap
+    (minimum center-to-center distance of 2 * bead_radius_um).
+
+    Parameters
+    ----------
+    shape : tuple[int, int, int]
+        Volume shape (Z, Y, X) in pixels.
+    pixel_sizes : tuple[float, float, float]
+        (z, y, x) pixel sizes in um.
+    n_beads : int
+        Number of beads.
+    bead_radius_um : float
+        Bead radius in um.
+    refractive_index_diff : float
+        RI difference from background (dn).
+    absorption_coefficient : float
+        Peak absorption coefficient inside each bead.
+    fluorescence_intensity : float
+        Peak fluorophore concentration inside each bead.
+    fluorescence_background : float
+        Constant baseline added to the fluorescence channel everywhere
+    blur_size_um : float
+        Gaussian blur standard deviation in um.
+        This blur softens the edges of the object e.g. from motion.
+        Optical blur comes later during imaging.
+    seed : int
+        Random seed for reproducibility.
+
+    Returns
+    -------
+    Phantom
+        Phase, absorption, and fluorescence ground truth with metadata.
+
+    Examples
+    --------
+    >>> phantom = random_beads(shape=(32, 64, 64), n_beads=5, seed=0)
+    >>> phantom.phase.shape
+    torch.Size([32, 64, 64])
+    >>> phantom.metadata["n_beads"]
+    5
+    """
+    metadata = {
+        "type": "random_beads",
+        "shape": list(shape),
+        "pixel_sizes": list(pixel_sizes),
+        "n_beads": n_beads,
+        "bead_radius_um": bead_radius_um,
+        "refractive_index_diff": refractive_index_diff,
+        "absorption_coefficient": absorption_coefficient,
+        "fluorescence_intensity": fluorescence_intensity,
+        "fluorescence_background": fluorescence_background,
+        "blur_size_um": blur_size_um,
+        "seed": seed,
+    }
+
+    rng = np.random.default_rng(seed)
+
+    # Volume extent in um
+    z_extent = shape[0] * pixel_sizes[0]
+    y_extent = shape[1] * pixel_sizes[1]
+    x_extent = shape[2] * pixel_sizes[2]
+
+    # Place beads with rejection sampling (no overlap)
+    margin = bead_radius_um
+    min_dist = 2 * bead_radius_um
+    bounds_z = (-z_extent / 2 + margin, z_extent / 2 - margin)
+    bounds_y = (-y_extent / 2 + margin, y_extent / 2 - margin)
+    bounds_x = (-x_extent / 2 + margin, x_extent / 2 - margin)
+
+    if bounds_z[0] >= bounds_z[1] or bounds_y[0] >= bounds_y[1] or bounds_x[0] >= bounds_x[1]:
+        raise ValueError(
+            f"Could only place 0/{n_beads} non-overlapping "
+            f"beads. Try fewer beads, a smaller radius, or a larger volume."
+        )
+
+    centers = []
+    max_attempts = n_beads * 1000
+    attempts = 0
+    while len(centers) < n_beads and attempts < max_attempts:
+        candidate = np.array(
+            [
+                rng.uniform(*bounds_z),
+                rng.uniform(*bounds_y),
+                rng.uniform(*bounds_x),
+            ]
+        )
+        if all(np.linalg.norm(candidate - c) >= min_dist for c in centers):
+            centers.append(candidate)
+        attempts += 1
+
+    if len(centers) < n_beads:
+        raise ValueError(
+            f"Could only place {len(centers)}/{n_beads} non-overlapping "
+            f"beads. Try fewer beads, a smaller radius, or a larger volume."
+        )
+
+    # Accumulate all beads into one mask
+    combined_mask = torch.zeros(shape, dtype=torch.float32)
+    for c in centers:
+        center = (float(c[0]), float(c[1]), float(c[2]))
+        mask = _sphere_mask(shape, pixel_sizes, bead_radius_um, center)
+        combined_mask = torch.maximum(combined_mask, mask)
+
+    blurred = _gaussian_blur(combined_mask, pixel_sizes, blur_size_um)
+
+    phase = blurred * refractive_index_diff
+    absorption = blurred * absorption_coefficient
+    fluorescence = blurred * fluorescence_intensity + fluorescence_background
+
+    return Phantom(
+        phase=phase,
+        absorption=absorption,
+        fluorescence=fluorescence,
+        pixel_sizes=pixel_sizes,
+        metadata=metadata,
+    )
+
+
+def _sphere_mask(
+    shape: tuple[int, int, int],
+    pixel_sizes: tuple[float, float, float],
+    radius_um: float,
+    center_um: tuple[float, float, float],
+) -> Tensor:
+    """Create a binary sphere mask.
+
+    Parameters
+    ----------
+    shape : tuple[int, int, int]
+        Volume shape (Z, Y, X).
+    pixel_sizes : tuple[float, float, float]
+        (z, y, x) pixel sizes in um.
+    radius_um : float
+        Sphere radius in um.
+    center_um : tuple[float, float, float]
+        Sphere center in um, relative to volume center.
+
+    Returns
+    -------
+    Tensor
+        Binary mask, shape (Z, Y, X), float32.
+    """
+    Z, Y, X = shape
+    z = (torch.arange(Z) - Z // 2) * pixel_sizes[0] - center_um[0]
+    y = (torch.arange(Y) - Y // 2) * pixel_sizes[1] - center_um[1]
+    x = (torch.arange(X) - X // 2) * pixel_sizes[2] - center_um[2]
+
+    zz, yy, xx = torch.meshgrid(z, y, x, indexing="ij")
+    r_sq = xx**2 + yy**2 + zz**2
+
+    mask = torch.zeros(shape, dtype=torch.float32)
+    mask[r_sq < radius_um**2] = 1.0
+    return mask
+
+
+def _gaussian_blur(
+    volume: Tensor,
+    pixel_sizes: tuple[float, float, float],
+    sigma_um: float,
+) -> Tensor:
+    """Apply Gaussian blur in Fourier domain.
+
+    Parameters
+    ----------
+    volume : Tensor
+        Input volume, shape (Z, Y, X).
+    pixel_sizes : tuple[float, float, float]
+        (z, y, x) pixel sizes in um.
+    sigma_um : float
+        Gaussian standard deviation in um.
+
+    Returns
+    -------
+    Tensor
+        Blurred volume, non-negative, peak-normalized to [0, 1].
+    """
+    if sigma_um <= 0:
+        peak = volume.max()
+        if peak > 0:
+            return volume / peak
+        return volume
+
+    Z, Y, X = volume.shape
+    z = (torch.arange(Z) - Z // 2) * pixel_sizes[0]
+    y = (torch.arange(Y) - Y // 2) * pixel_sizes[1]
+    x = (torch.arange(X) - X // 2) * pixel_sizes[2]
+
+    zz, yy, xx = torch.meshgrid(z, y, x, indexing="ij")
+    r_sq = xx**2 + yy**2 + zz**2
+
+    gaussian = torch.exp(-r_sq / (2 * sigma_um**2))
+
+    blurred = torch.real(torch.fft.ifftn(torch.fft.fftn(volume) * torch.fft.fftn(torch.fft.ifftshift(gaussian))))
+    blurred = torch.clamp(blurred, min=0)
+
+    peak = blurred.max()
+    if peak > 0:
+        blurred = blurred / peak
+
+    return blurred


### PR DESCRIPTION
**Benchmarking system for tracking reconstruction quality**

Synthetic cases generate phantoms, simulate measurements, reconstruct via `wo rec`, and compare against ground truth. HPC cases reconstruct existing data.

**Commands**

```
wo bm run                        # run registered benchmarks
wo bm run --scope synthetic      # synthetic only
wo bm run -e sweep.yml           # custom experiment
wo bm latest                     # show most recent results
wo bm compare                    # diff two most recent runs
wo bm history                    # list runs
wo bm view                       # open in napari
wo bm view run_name/case_name    # specific case
```

**Example output**

```
WaveOrder Benchmark — regression
  Git: ad3eece (benchmarks)
  Experiment: regression (3 cases)
  Output: runs/2026-03-27T12-00-00_regression

  case                       time    midband        mse       ssim         min  histogram          max
  ────────────────────────────────────────────────────────────────────────────────────────────────────
  phase_3d_beads             9.7s   +6.4e-02   +5.2e-05      0.729    -4.9e-03  ▁▁▁▁▁█▁▁▁▁    +3.9e-03
  fluor_3d_beads             8.2s   +4.1e+00   +1.0e+02      0.004    +9.8e+00  ▁█▁▁▁▁▁▁▁▁    +1.1e+01
  ops_pheno_center          55.8s   +7.6e+01          —          —    -4.0e+00  ▁▁▁█▁▁▁▁▁▁    +7.4e+00
```

**Files added**

- `waveorder/phantoms.py` — Phantom dataclass, `single_bead`, `random_beads`
- `waveorder/cli/bench.py` — CLI command group
- `benchmarks/` — configs, experiments, metrics, runner, simulate, utils

Also defers heavy imports in all CLI modules for instant `wo --help` (~0.1s).
