### PR TITLE
Use ProcessPoolExecutor with spawn for apply-inv-tf workers

### DIFF
--- a/waveorder/cli/apply_inverse_transfer_function.py
+++ b/waveorder/cli/apply_inverse_transfer_function.py
@@ -367,13 +367,8 @@ def apply_inverse_transfer_function_single_position(
         # (e.g. cgroup OOM-kill) surfaces as BrokenProcessPool instead
         # of hanging indefinitely on pool.starmap.
         context = mp.get_context("spawn")
-        with ProcessPoolExecutor(
-            max_workers=num_processes, mp_context=context
-        ) as p:
-            futures = [
-                p.submit(partial_apply_inverse_to_zyx_and_save, t_idx)
-                for t_idx in time_indices
-            ]
+        with ProcessPoolExecutor(max_workers=num_processes, mp_context=context) as p:
+            futures = [p.submit(partial_apply_inverse_to_zyx_and_save, t_idx) for t_idx in time_indices]
             for fut in as_completed(futures):
                 fut.result()
     else:

--- a/waveorder/cli/apply_inverse_transfer_function.py
+++ b/waveorder/cli/apply_inverse_transfer_function.py
@@ -209,7 +209,7 @@ def apply_inverse_transfer_function_single_position(
 ) -> None:
 
     # Deferred imports for fast CLI help
-    import itertools
+    from concurrent.futures import ProcessPoolExecutor, as_completed
     from functools import partial
 
     import numpy as np
@@ -360,11 +360,22 @@ def apply_inverse_transfer_function_single_position(
     if num_processes > 1:
         if verbose:
             click.echo(f"\nStarting multiprocess pool with {num_processes} processes")
-        with mp.Pool(num_processes) as p:
-            p.starmap(
-                partial_apply_inverse_to_zyx_and_save,
-                itertools.product(time_indices),
-            )
+        # NOTE: spawn (not fork) — tensorstore runs internal C++ threads
+        # that are not fork-safe, so a forked worker can deadlock or
+        # segfault before our code runs. See google/tensorstore#61.
+        # NOTE: ProcessPoolExecutor (not mp.Pool) so silent worker death
+        # (e.g. cgroup OOM-kill) surfaces as BrokenProcessPool instead
+        # of hanging indefinitely on pool.starmap.
+        context = mp.get_context("spawn")
+        with ProcessPoolExecutor(
+            max_workers=num_processes, mp_context=context
+        ) as p:
+            futures = [
+                p.submit(partial_apply_inverse_to_zyx_and_save, t_idx)
+                for t_idx in time_indices
+            ]
+            for fut in as_completed(futures):
+                fut.result()
     else:
         for t_idx in time_indices:
             partial_apply_inverse_to_zyx_and_save(t_idx)


### PR DESCRIPTION
## Summary

Replace `torch.multiprocessing.Pool().starmap()` with `ProcessPoolExecutor(mp_context=mp.get_context("spawn"))` in `apply_inverse_transfer_function_single_position`. Mirrors the pattern already used in `iohub.ngff.utils.process_single_position`.

Two motivations:

- **spawn (not fork)** — tensorstore runs internal C++ threads that are not fork-safe; a forked worker can deadlock or segfault before our code runs (see google/tensorstore#61).
- **`ProcessPoolExecutor` (not `mp.Pool`)** — a silently dying worker (e.g. cgroup OOM-kill) surfaces as `BrokenProcessPool` instead of hanging indefinitely on `pool.starmap`.

`-j` continues to flow through unchanged: `num_processes` becomes `max_workers`. The pool tops out at `len(time_indices)` workers (one task per timepoint), same as before.

## Test plan

- [x] Smoke-tested on a real HCS plate (8 positions, T=10, C=3, Z=86, Y=1600, X=1370) with `biahub reconstruct -j 16` on SLURM. All 6 SLURM jobs completed; outputs are bit-equivalent to the prior `mp.Pool` version (same logs, same data).
- [x] Verified inside a running job that 10 worker processes (capped by T=10) are spawned under the parent and consume all 16 allocated cores.
- [x] Verified `num_processes <= 1` path still runs serially in the calling process.
- [x] Reviewer to confirm CI passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)