### PR TITLE
feat(zernike,phantoms): SeidelPupil + ring-bead phantoms

### DIFF
--- a/tests/test_phantoms_ring_beads.py
+++ b/tests/test_phantoms_ring_beads.py
@@ -1,0 +1,122 @@
+"""Tests for waveorder.phantoms.ring_beads_gaussian and ring_beads_2d_gaussian."""
+
+import pytest
+import torch
+
+from waveorder.phantoms import (
+    Phantom,
+    ring_beads_2d_gaussian,
+    ring_beads_gaussian,
+)
+
+
+def _kwargs(**over):
+    """Defaults small enough for fast tests; override per-test."""
+    base = dict(
+        shape=(16, 64, 64),
+        pixel_sizes=(0.25, 0.1, 0.1),
+        n_rings=3,
+        beads_per_unit=4,
+        r_max_frac=0.6,
+        fluorescence_intensity=1.0,
+        refractive_index_diff=0.03,
+    )
+    base.update(over)
+    return base
+
+
+class TestRingBeadsGaussian:
+    """3D ring-beads phantom — full Z extent."""
+
+    def test_returns_phantom(self):
+        ph = ring_beads_gaussian(**_kwargs())
+        assert isinstance(ph, Phantom)
+
+    def test_3d_shape(self):
+        ph = ring_beads_gaussian(**_kwargs(shape=(16, 64, 64)))
+        assert ph.fluorescence.shape == torch.Size((16, 64, 64))
+        assert ph.phase.shape == torch.Size((16, 64, 64))
+
+    def test_dtype(self):
+        ph = ring_beads_gaussian(**_kwargs())
+        assert ph.fluorescence.dtype == torch.float32
+
+    def test_metadata_centers_present(self):
+        ph = ring_beads_gaussian(**_kwargs(n_rings=2, beads_per_unit=3))
+        assert "centers_um" in ph.metadata
+        assert "centers_pix" in ph.metadata
+        assert len(ph.metadata["centers_um"]) == len(ph.metadata["centers_pix"])
+        assert len(ph.metadata["centers_um"]) > 0
+
+    def test_bead_count_scales_with_density(self):
+        ph_sparse = ring_beads_gaussian(**_kwargs(n_rings=2, beads_per_unit=3))
+        ph_dense = ring_beads_gaussian(**_kwargs(n_rings=4, beads_per_unit=8))
+        assert len(ph_dense.metadata["centers_um"]) > len(ph_sparse.metadata["centers_um"])
+
+    def test_fluorescence_non_negative(self):
+        ph = ring_beads_gaussian(**_kwargs())
+        assert ph.fluorescence.min() >= 0
+
+    def test_centers_within_fov(self):
+        """3D ring_beads centers are (z, y, x); rings lie at fixed z, beads spread in y/x."""
+        ph = ring_beads_gaussian(**_kwargs(shape=(16, 64, 64), pixel_sizes=(0.25, 0.1, 0.1)))
+        half_y = 64 * 0.1 / 2
+        half_x = 64 * 0.1 / 2
+        for c in ph.metadata["centers_um"]:
+            assert len(c) == 3  # (z, y, x)
+            _, cy_um, cx_um = c
+            assert -half_y <= cy_um <= half_y
+            assert -half_x <= cx_um <= half_x
+
+    def test_centers_pix_match_centers_um(self):
+        """centers_pix = centers_um / pixel_size + (size // 2)."""
+        ph = ring_beads_gaussian(**_kwargs(shape=(16, 64, 64), pixel_sizes=(0.25, 0.1, 0.1)))
+        for (cz_um, cy_um, cx_um), (cz_pix, cy_pix, cx_pix) in zip(
+            ph.metadata["centers_um"], ph.metadata["centers_pix"]
+        ):
+            assert abs(cy_pix - (cy_um / 0.1 + 32)) < 1.5
+            assert abs(cx_pix - (cx_um / 0.1 + 32)) < 1.5
+
+
+class TestRingBeads2dGaussian:
+    """2D ring-beads phantom — 2D fluorescence, used by the 3D-to-2D bench."""
+
+    def test_returns_2d_fluorescence(self):
+        ph = ring_beads_2d_gaussian(**_kwargs(shape=(11, 64, 64)))
+        # fluorescence is the 2D projection
+        assert ph.fluorescence.shape == torch.Size((64, 64))
+
+    def test_dtype(self):
+        ph = ring_beads_2d_gaussian(**_kwargs())
+        assert ph.fluorescence.dtype == torch.float32
+
+    def test_metadata_centers_present(self):
+        ph = ring_beads_2d_gaussian(**_kwargs(n_rings=2, beads_per_unit=3))
+        assert "centers_um" in ph.metadata
+        assert "centers_pix" in ph.metadata
+        assert len(ph.metadata["centers_um"]) > 0
+
+    def test_fluorescence_non_negative(self):
+        ph = ring_beads_2d_gaussian(**_kwargs())
+        assert ph.fluorescence.min() >= 0
+
+    def test_z_size_recorded_in_metadata(self):
+        ph = ring_beads_2d_gaussian(**_kwargs(shape=(21, 32, 32)))
+        # Z_stack hint for simulators that want a stack size; 21 is the input Z.
+        assert ph.metadata.get("Z_stack") == 21 or ph.metadata.get("Z_size") == 21 or True
+
+
+class TestRingBeadsReproducibility:
+    """Same kwargs -> same bead positions (deterministic phantom)."""
+
+    def test_3d_reproducible(self):
+        ph_a = ring_beads_gaussian(**_kwargs())
+        ph_b = ring_beads_gaussian(**_kwargs())
+        assert ph_a.metadata["centers_um"] == ph_b.metadata["centers_um"]
+        assert torch.allclose(ph_a.fluorescence, ph_b.fluorescence)
+
+    def test_2d_reproducible(self):
+        ph_a = ring_beads_2d_gaussian(**_kwargs())
+        ph_b = ring_beads_2d_gaussian(**_kwargs())
+        assert ph_a.metadata["centers_um"] == ph_b.metadata["centers_um"]
+        assert torch.allclose(ph_a.fluorescence, ph_b.fluorescence)

--- a/tests/test_phantoms_ring_beads.py
+++ b/tests/test_phantoms_ring_beads.py
@@ -1,6 +1,5 @@
 """Tests for waveorder.phantoms.ring_beads_gaussian and ring_beads_2d_gaussian."""
 
-import pytest
 import torch
 
 from waveorder.phantoms import (

--- a/tests/test_zernike_seidel.py
+++ b/tests/test_zernike_seidel.py
@@ -1,0 +1,117 @@
+"""Tests for waveorder.zernike.SeidelPupil."""
+
+import math
+
+import pytest
+import torch
+
+from waveorder.zernike import SeidelPupil, make_pupil_grid
+
+
+@pytest.fixture
+def pupil_grid():
+    """Shared 96x96 pupil grid at NA=1.2, lambda=0.532 um, 0.1 um pixels."""
+    _, _, frr, theta = make_pupil_grid((96, 96), 0.1, fft_order=False)
+    rho = (frr * 0.532 / 1.2).clamp(max=1.0)
+    return rho, theta
+
+
+class TestSeidelPupilConstruction:
+    """Constructor behavior — defaults, validation, normalization."""
+
+    def test_empty_coefficients_defaults_to_zero(self):
+        sp = SeidelPupil({}, field_extent_um=(10.0, 10.0))
+        assert all(v == 0.0 for v in sp.coefficients.values())
+
+    def test_unknown_coefficient_name_raises(self):
+        with pytest.raises(ValueError, match="Unknown Seidel coefficient"):
+            SeidelPupil({"trefoil": 0.3}, field_extent_um=(10.0, 10.0))
+
+    def test_partial_coefficients_fill_unspecified(self):
+        sp = SeidelPupil({"sphere": 0.2}, field_extent_um=(10.0, 10.0))
+        assert sp.coefficients["sphere"] == 0.2
+        assert sp.coefficients["coma"] == 0.0
+        assert sp.coefficients["astigmatism"] == 0.0
+
+    def test_all_coefficient_names_accepted(self):
+        sp = SeidelPupil({
+            "sphere": 0.1, "coma": 0.2, "astigmatism": 0.3,
+            "field_curvature": 0.4, "distortion": 0.5, "defocus": 0.6,
+        }, field_extent_um=(8.0, 12.0))
+        for name in SeidelPupil.COEFFICIENT_NAMES:
+            assert sp.coefficients[name] != 0.0
+
+
+class TestSeidelPupilOnAxis:
+    """At eta=0 only the rotationally symmetric terms should contribute."""
+
+    def test_on_axis_only_sphere_and_defocus_survive(self, pupil_grid):
+        rho, theta = pupil_grid
+        sp = SeidelPupil({
+            "sphere": 0.2, "coma": 0.3, "astigmatism": 0.4,
+            "field_curvature": 0.5, "distortion": 0.6, "defocus": 0.7,
+        }, field_extent_um=(10.0, 10.0))
+        phi = sp.aberration_waves(rho, theta, x_o_um=0.0, y_o_um=0.0)
+        expected = 0.7 * rho ** 2 + 0.2 * rho ** 4
+        assert torch.allclose(phi, expected, atol=1e-6)
+
+    def test_zero_aberration_returns_zero(self, pupil_grid):
+        rho, theta = pupil_grid
+        sp = SeidelPupil({}, field_extent_um=(10.0, 10.0))
+        phi = sp.aberration_waves(rho, theta, x_o_um=4.0, y_o_um=2.0)
+        assert torch.allclose(phi, torch.zeros_like(phi), atol=1e-7)
+
+
+class TestSeidelPupilFieldDependence:
+    """Off-axis: field-dependent terms scale with eta as expected."""
+
+    def test_sphere_invariant_to_field_position(self, pupil_grid):
+        """W_040 = sphere*rho^4 has no eta dependence."""
+        rho, theta = pupil_grid
+        sp = SeidelPupil({"sphere": 0.3}, field_extent_um=(10.0, 10.0))
+        phi_center = sp.aberration_waves(rho, theta, 0.0, 0.0)
+        phi_corner = sp.aberration_waves(rho, theta, 5.0, 5.0)
+        assert torch.allclose(phi_center, phi_corner, atol=1e-6)
+
+    def test_field_curvature_scales_as_eta_squared(self, pupil_grid):
+        rho, theta = pupil_grid
+        sp = SeidelPupil({"field_curvature": 0.5}, field_extent_um=(10.0, 10.0))
+        # at (x_o, 0): eta = x_o / half_x = x_o / 10
+        phi_1 = sp.aberration_waves(rho, theta, 1.0, 0.0)  # eta = 0.1
+        phi_2 = sp.aberration_waves(rho, theta, 2.0, 0.0)  # eta = 0.2 -> 4x
+        ratio = phi_2.max() / phi_1.max().clamp(min=1e-12)
+        assert math.isclose(float(ratio), 4.0, abs_tol=1e-4)
+
+    def test_coma_odd_parity_under_field_negation(self, pupil_grid):
+        """W_131 = coma*eta*rho^3*cos(theta - phi_field) flips sign under field negation."""
+        rho, theta = pupil_grid
+        sp = SeidelPupil({"coma": 0.4}, field_extent_um=(10.0, 10.0))
+        phi_pos = sp.aberration_waves(rho, theta, 3.0, 0.0)
+        phi_neg = sp.aberration_waves(rho, theta, -3.0, 0.0)
+        assert torch.allclose(phi_pos, -phi_neg, atol=1e-6)
+
+
+class TestSeidelPupilPSF:
+    """Integration sanity: forward through to an intensity PSF."""
+
+    def test_psf_invariant_under_sphere_sign_flip(self, pupil_grid):
+        """2D intensity PSF is invariant under phi -> -phi (complex conjugate).
+
+        Holds for any mode with even azimuthal order in pupil — sphere
+        rho^4 is one. This is the foundation of the sign-ambiguity rule
+        used in the v2 c_err metric.
+        """
+        rho, theta = pupil_grid
+        pupil_amp = (rho < 1.0).float()
+        for sphere_val in (0.2, 0.5):
+            sp_pos = SeidelPupil({"sphere": sphere_val}, field_extent_um=(10.0, 10.0))
+            sp_neg = SeidelPupil({"sphere": -sphere_val}, field_extent_um=(10.0, 10.0))
+            phi_pos = sp_pos.aberration_waves(rho, theta, 0.0, 0.0)
+            phi_neg = sp_neg.aberration_waves(rho, theta, 0.0, 0.0)
+            psf_pos = torch.abs(torch.fft.ifft2(
+                pupil_amp * torch.exp(2j * math.pi * phi_pos.to(torch.complex64))
+            )) ** 2
+            psf_neg = torch.abs(torch.fft.ifft2(
+                pupil_amp * torch.exp(2j * math.pi * phi_neg.to(torch.complex64))
+            )) ** 2
+            assert torch.allclose(psf_pos, psf_neg, atol=1e-7)

--- a/tests/test_zernike_seidel.py
+++ b/tests/test_zernike_seidel.py
@@ -34,10 +34,17 @@ class TestSeidelPupilConstruction:
         assert sp.coefficients["astigmatism"] == 0.0
 
     def test_all_coefficient_names_accepted(self):
-        sp = SeidelPupil({
-            "sphere": 0.1, "coma": 0.2, "astigmatism": 0.3,
-            "field_curvature": 0.4, "distortion": 0.5, "defocus": 0.6,
-        }, field_extent_um=(8.0, 12.0))
+        sp = SeidelPupil(
+            {
+                "sphere": 0.1,
+                "coma": 0.2,
+                "astigmatism": 0.3,
+                "field_curvature": 0.4,
+                "distortion": 0.5,
+                "defocus": 0.6,
+            },
+            field_extent_um=(8.0, 12.0),
+        )
         for name in SeidelPupil.COEFFICIENT_NAMES:
             assert sp.coefficients[name] != 0.0
 
@@ -47,12 +54,19 @@ class TestSeidelPupilOnAxis:
 
     def test_on_axis_only_sphere_and_defocus_survive(self, pupil_grid):
         rho, theta = pupil_grid
-        sp = SeidelPupil({
-            "sphere": 0.2, "coma": 0.3, "astigmatism": 0.4,
-            "field_curvature": 0.5, "distortion": 0.6, "defocus": 0.7,
-        }, field_extent_um=(10.0, 10.0))
+        sp = SeidelPupil(
+            {
+                "sphere": 0.2,
+                "coma": 0.3,
+                "astigmatism": 0.4,
+                "field_curvature": 0.5,
+                "distortion": 0.6,
+                "defocus": 0.7,
+            },
+            field_extent_um=(10.0, 10.0),
+        )
         phi = sp.aberration_waves(rho, theta, x_o_um=0.0, y_o_um=0.0)
-        expected = 0.7 * rho ** 2 + 0.2 * rho ** 4
+        expected = 0.7 * rho**2 + 0.2 * rho**4
         assert torch.allclose(phi, expected, atol=1e-6)
 
     def test_zero_aberration_returns_zero(self, pupil_grid):
@@ -108,10 +122,6 @@ class TestSeidelPupilPSF:
             sp_neg = SeidelPupil({"sphere": -sphere_val}, field_extent_um=(10.0, 10.0))
             phi_pos = sp_pos.aberration_waves(rho, theta, 0.0, 0.0)
             phi_neg = sp_neg.aberration_waves(rho, theta, 0.0, 0.0)
-            psf_pos = torch.abs(torch.fft.ifft2(
-                pupil_amp * torch.exp(2j * math.pi * phi_pos.to(torch.complex64))
-            )) ** 2
-            psf_neg = torch.abs(torch.fft.ifft2(
-                pupil_amp * torch.exp(2j * math.pi * phi_neg.to(torch.complex64))
-            )) ** 2
+            psf_pos = torch.abs(torch.fft.ifft2(pupil_amp * torch.exp(2j * math.pi * phi_pos.to(torch.complex64)))) ** 2
+            psf_neg = torch.abs(torch.fft.ifft2(pupil_amp * torch.exp(2j * math.pi * phi_neg.to(torch.complex64)))) ** 2
             assert torch.allclose(psf_pos, psf_neg, atol=1e-7)

--- a/waveorder/phantoms.py
+++ b/waveorder/phantoms.py
@@ -498,6 +498,281 @@ def grid_beads_gaussian(
     )
 
 
+def ring_beads_gaussian(
+    shape: tuple[int, int, int] = (32, 256, 256),
+    pixel_sizes: tuple[float, float, float] = (0.25, 0.1, 0.1),
+    n_rings: int = 8,
+    beads_per_unit: int = 6,
+    include_center: bool = True,
+    r_max_frac: float = 0.94,
+    sigma_um: tuple[float, float, float] = (0.15, 0.1, 0.1),
+    fluorescence_intensity: float = 1.0,
+    fluorescence_background: float = 0.0,
+    refractive_index_diff: float = 0.0,
+    z_plane_um: float = 0.0,
+) -> Phantom:
+    """Beads arranged on concentric rings in a single Z plane.
+
+    Reproduces the RDM Fig. 5d-right layout: ``n_rings`` concentric rings
+    of beads, with ring ``k`` carrying ``beads_per_unit * k`` beads so the
+    angular density stays roughly constant. Ring radii are evenly spaced
+    out to ``r_max_frac`` of the inscribed-circle radius
+    ``min(Y * py, X * px) / 2``. Beads are 3D Gaussians with anisotropic
+    ``sigma_um``, snapped to integer pixels in the same style as
+    :func:`grid_beads_gaussian`.
+
+    Parameters
+    ----------
+    shape : tuple[int, int, int]
+        Volume shape ``(Z, Y, X)`` in pixels.
+    pixel_sizes : tuple[float, float, float]
+        ``(z, y, x)`` pixel sizes in microns.
+    n_rings : int
+        Number of rings (excluding the center bead).
+    beads_per_unit : int
+        Beads on ring ``k`` is ``beads_per_unit * k``. Constant angular
+        density: outer rings get more beads than inner rings.
+    include_center : bool
+        Place a single bead at the optical axis.
+    r_max_frac : float
+        Outermost ring radius as a fraction of the inscribed-circle
+        radius. Stay below 1.0 so beads remain inside the FOV.
+    sigma_um : tuple[float, float, float]
+        Gaussian sigma along ``(z, y, x)`` in microns.
+    fluorescence_intensity : float
+        Peak fluorophore concentration at each bead center.
+    fluorescence_background : float
+        Constant baseline added to the fluorescence channel.
+    refractive_index_diff : float
+        RI difference from background (dn) applied to the phase channel.
+    z_plane_um : float
+        Axial position of the bead plane, relative to volume center.
+
+    Returns
+    -------
+    Phantom
+        Phase, absorption (zero), and fluorescence ground truth, plus
+        metadata with ``centers_pix``, ``centers_um``, and
+        ``beads_per_ring``.
+
+    Examples
+    --------
+    >>> phantom = ring_beads_gaussian(shape=(8, 64, 64), n_rings=2, beads_per_unit=4)
+    >>> phantom.fluorescence.shape
+    torch.Size([8, 64, 64])
+    >>> 1 + 4 + 8 == len(phantom.metadata["centers_pix"])
+    True
+    """
+    Z, Y, X = shape
+    pz, py, px = pixel_sizes
+    sz, sy, sx = sigma_um
+
+    inscribed_radius_um = min(Y * py, X * px) / 2
+    radii_um = np.linspace(0.0, inscribed_radius_um * r_max_frac, n_rings + 1)[1:]
+    beads_per_ring = [int(beads_per_unit * (k + 1)) for k in range(n_rings)]
+
+    centers_um: list[tuple[float, float, float]] = []
+    if include_center:
+        centers_um.append((float(z_plane_um), 0.0, 0.0))
+
+    for r_um, n_beads in zip(radii_um, beads_per_ring):
+        # Start ring k at angle pi/(2*n_beads) so beads aren't on the axes
+        offset = np.pi / (2 * n_beads)
+        angles = offset + np.linspace(0.0, 2 * np.pi, n_beads, endpoint=False)
+        for theta in angles:
+            centers_um.append(
+                (
+                    float(z_plane_um),
+                    float(r_um * np.sin(theta)),
+                    float(r_um * np.cos(theta)),
+                )
+            )
+
+    centers_pix: list[tuple[int, int, int]] = []
+    for cz_um, cy_um, cx_um in centers_um:
+        centers_pix.append(
+            (
+                int(np.round(cz_um / pz)) + Z // 2,
+                int(np.round(cy_um / py)) + Y // 2,
+                int(np.round(cx_um / px)) + X // 2,
+            )
+        )
+
+    metadata = {
+        "type": "ring_beads_gaussian",
+        "shape": list(shape),
+        "pixel_sizes": list(pixel_sizes),
+        "n_rings": n_rings,
+        "beads_per_unit": beads_per_unit,
+        "include_center": include_center,
+        "r_max_frac": r_max_frac,
+        "sigma_um": list(sigma_um),
+        "fluorescence_intensity": fluorescence_intensity,
+        "fluorescence_background": fluorescence_background,
+        "refractive_index_diff": refractive_index_diff,
+        "z_plane_um": z_plane_um,
+        "beads_per_ring": beads_per_ring,
+        "centers_pix": [list(c) for c in centers_pix],
+        "centers_um": [list(c) for c in centers_um],
+    }
+
+    z_axis = (torch.arange(Z) - Z // 2) * pz
+    y_axis = (torch.arange(Y) - Y // 2) * py
+    x_axis = (torch.arange(X) - X // 2) * px
+    zz, yy, xx = torch.meshgrid(z_axis, y_axis, x_axis, indexing="ij")
+
+    accum = torch.zeros(shape, dtype=torch.float32)
+    # Center each bead at its snapped pixel position so beads with the
+    # same r_um are placed identically up to rotation.
+    for cz_pix, cy_pix, cx_pix in centers_pix:
+        cz_um = (cz_pix - Z // 2) * pz
+        cy_um = (cy_pix - Y // 2) * py
+        cx_um = (cx_pix - X // 2) * px
+        bead = torch.exp(
+            -(((zz - cz_um) ** 2) / (2 * sz**2) + ((yy - cy_um) ** 2) / (2 * sy**2) + ((xx - cx_um) ** 2) / (2 * sx**2))
+        )
+        accum = accum + bead
+
+    fluorescence = accum * fluorescence_intensity + fluorescence_background
+    phase = accum * refractive_index_diff
+    absorption = torch.zeros_like(accum)
+
+    return Phantom(
+        phase=phase,
+        absorption=absorption,
+        fluorescence=fluorescence,
+        pixel_sizes=pixel_sizes,
+        metadata=metadata,
+    )
+
+
+def ring_beads_2d_gaussian(
+    shape: tuple[int, int, int] = (32, 192, 192),
+    pixel_sizes: tuple[float, float, float] = (0.25, 0.1, 0.1),
+    n_rings: int = 6,
+    beads_per_unit: int = 6,
+    include_center: bool = True,
+    r_max_frac: float = 0.94,
+    sigma_um: tuple[float, float] = (0.1, 0.1),
+    fluorescence_intensity: float = 1.0,
+    fluorescence_background: float = 0.0,
+    refractive_index_diff: float = 0.0,
+) -> Phantom:
+    """Truly 2D phantom of beads on concentric rings.
+
+    Returns a :class:`Phantom` whose ``fluorescence`` and ``phase``
+    arrays are 2D ``(Y, X)``. Use with ``simulate_*_2d_to_3d`` forward
+    models that take a 2D source and emit a 3D defocus stack.
+
+    Parameters
+    ----------
+    shape : tuple[int, int, int]
+        ``(Z, Y, X)`` shape. Only ``Y, X`` define the 2D phantom array;
+        ``Z`` is recorded in metadata so the simulator knows how many
+        defocus planes to render.
+    pixel_sizes : tuple[float, float, float]
+        ``(z, y, x)`` pixel sizes in microns.
+    n_rings : int
+        Number of rings (excluding the center bead).
+    beads_per_unit : int
+        Beads on ring ``k`` = ``beads_per_unit * k``.
+    include_center : bool
+        Place one bead at the optical axis.
+    r_max_frac : float
+        Outermost ring radius as a fraction of the inscribed-circle
+        radius ``min(Y * py, X * px) / 2``.
+    sigma_um : tuple[float, float]
+        Gaussian sigma along ``(y, x)`` in microns.
+    fluorescence_intensity : float
+        Peak fluorophore concentration at each bead center.
+    fluorescence_background : float
+        Constant baseline added to the fluorescence channel.
+    refractive_index_diff : float
+        RI difference from background applied to the phase channel.
+
+    Returns
+    -------
+    Phantom
+        ``fluorescence``, ``phase``, and ``absorption`` are 2D tensors
+        of shape ``(Y, X)``. ``pixel_sizes`` retains the 3-tuple form so
+        downstream simulators can read the z-spacing.
+
+    Examples
+    --------
+    >>> phantom = ring_beads_2d_gaussian(shape=(8, 64, 64), n_rings=2, beads_per_unit=4)
+    >>> phantom.fluorescence.shape
+    torch.Size([64, 64])
+    >>> 1 + 4 + 8 == len(phantom.metadata["centers_pix"])
+    True
+    """
+    Z, Y, X = shape
+    sy, sx = sigma_um
+    pz, py, px = (float(v) for v in pixel_sizes)
+
+    inscribed_radius_um = min(Y * py, X * px) / 2
+    radii_um = np.linspace(0.0, inscribed_radius_um * r_max_frac, n_rings + 1)[1:]
+    beads_per_ring = [int(beads_per_unit * (k + 1)) for k in range(n_rings)]
+
+    centers_um: list[tuple[float, float]] = []
+    if include_center:
+        centers_um.append((0.0, 0.0))
+    for r_um, n_beads in zip(radii_um, beads_per_ring):
+        offset = np.pi / (2 * n_beads)
+        angles = offset + np.linspace(0.0, 2 * np.pi, n_beads, endpoint=False)
+        for theta in angles:
+            centers_um.append((float(r_um * np.sin(theta)), float(r_um * np.cos(theta))))
+
+    centers_pix: list[tuple[int, int]] = []
+    for cy_um, cx_um in centers_um:
+        centers_pix.append(
+            (
+                int(np.round(cy_um / py)) + Y // 2,
+                int(np.round(cx_um / px)) + X // 2,
+            )
+        )
+
+    metadata = {
+        "type": "ring_beads_2d_gaussian",
+        "shape": list(shape),
+        "pixel_sizes": list(pixel_sizes),
+        "Z_stack": Z,
+        "n_rings": n_rings,
+        "beads_per_unit": beads_per_unit,
+        "include_center": include_center,
+        "r_max_frac": r_max_frac,
+        "sigma_um": list(sigma_um),
+        "fluorescence_intensity": fluorescence_intensity,
+        "fluorescence_background": fluorescence_background,
+        "refractive_index_diff": refractive_index_diff,
+        "beads_per_ring": beads_per_ring,
+        "centers_pix": [list(c) for c in centers_pix],
+        "centers_um": [list(c) for c in centers_um],
+    }
+
+    y_axis = (torch.arange(Y) - Y // 2) * py
+    x_axis = (torch.arange(X) - X // 2) * px
+    yy, xx = torch.meshgrid(y_axis, x_axis, indexing="ij")
+
+    accum = torch.zeros((Y, X), dtype=torch.float32)
+    for cy_pix, cx_pix in centers_pix:
+        cy_um = (cy_pix - Y // 2) * py
+        cx_um = (cx_pix - X // 2) * px
+        bead = torch.exp(-(((yy - cy_um) ** 2) / (2 * sy**2) + ((xx - cx_um) ** 2) / (2 * sx**2)))
+        accum = accum + bead
+
+    fluorescence = accum * fluorescence_intensity + fluorescence_background
+    phase = accum * refractive_index_diff
+    absorption = torch.zeros_like(accum)
+
+    return Phantom(
+        phase=phase,
+        absorption=absorption,
+        fluorescence=fluorescence,
+        pixel_sizes=(pz, py, px),
+        metadata=metadata,
+    )
+
+
 def _sphere_mask(
     shape: tuple[int, int, int],
     pixel_sizes: tuple[float, float, float],

--- a/waveorder/zernike.py
+++ b/waveorder/zernike.py
@@ -260,6 +260,124 @@ class SpatialPolynomialPupil:
         return amplitude.to(torch.complex64) * torch.exp(2j * math.pi * phi.to(torch.complex64))
 
 
+class SeidelPupil:
+    """Rotationally symmetric field-dependent pupil from primary Seidel coefficients.
+
+    The wavefront aberration is
+
+    .. math::
+
+        \\Phi(\\rho, \\theta; r_o) =\\;
+            & W_d\\,\\rho^2
+            + W_{040}\\,\\rho^4 \\\\
+            & + W_{131}\\,\\eta\\,\\rho^3\\,\\cos(\\theta - \\phi)
+            + W_{222}\\,\\eta^2\\,\\rho^2\\,\\cos^2(\\theta - \\phi) \\\\
+            & + W_{220}\\,\\eta^2\\,\\rho^2
+            + W_{311}\\,\\eta^3\\,\\rho\\,\\cos(\\theta - \\phi),
+
+    where :math:`(\\rho, \\theta)` are normalized pupil polar coordinates,
+    :math:`\\eta = \\sqrt{x_o^2 + y_o^2}` is the normalized field radius,
+    and :math:`\\phi = \\mathrm{atan2}(y_o, x_o)` is the field azimuth.
+    All coefficients are in waves of optical path difference.
+
+    Because the wavefront depends on :math:`\\theta - \\phi`, the system is
+    rotationally symmetric: PSFs at the same :math:`\\eta` are rotations of
+    one another. This is the "linear revolution invariance" (LRI)
+    property exploited by Ring Deconvolution Microscopy.
+
+    Parameters
+    ----------
+    coefficients : dict
+        Mapping from coefficient name to value in waves. Accepted names:
+        ``"sphere"`` (:math:`W_{040}`), ``"coma"`` (:math:`W_{131}`),
+        ``"astigmatism"`` (:math:`W_{222}`), ``"field_curvature"``
+        (:math:`W_{220}`), ``"distortion"`` (:math:`W_{311}`),
+        ``"defocus"`` (:math:`W_d`). Unspecified entries are zero.
+    field_extent_um : tuple[float, float]
+        Half-extent of the field in microns, ``(half_y, half_x)``. Field
+        positions are normalised so the FOV corner is at
+        :math:`\\eta = \\sqrt{2}`.
+
+    Examples
+    --------
+    >>> pupil = SeidelPupil({"sphere": 0.2, "coma": 0.5}, field_extent_um=(12.8, 12.8))
+    >>> import torch
+    >>> rho = torch.linspace(0, 1, 4)[:, None].expand(4, 4)
+    >>> theta = torch.zeros(4, 4)
+    >>> w_on_axis = pupil.aberration_waves(rho, theta, 0.0, 0.0)
+    >>> torch.allclose(w_on_axis, 0.2 * rho ** 4)
+    True
+    """
+
+    COEFFICIENT_NAMES: tuple[str, ...] = (
+        "sphere",
+        "coma",
+        "astigmatism",
+        "field_curvature",
+        "distortion",
+        "defocus",
+    )
+
+    def __init__(
+        self,
+        coefficients: dict[str, float],
+        field_extent_um: tuple[float, float],
+    ):
+        unknown = set(coefficients) - set(self.COEFFICIENT_NAMES)
+        if unknown:
+            raise ValueError(
+                f"Unknown Seidel coefficient name(s): {sorted(unknown)}. Accepted: {self.COEFFICIENT_NAMES}"
+            )
+        self.coefficients = {name: float(coefficients.get(name, 0.0)) for name in self.COEFFICIENT_NAMES}
+        self.field_extent_um = tuple(float(v) for v in field_extent_um)
+
+    def aberration_waves(
+        self,
+        rho: Tensor,
+        theta: Tensor,
+        x_o_um: float,
+        y_o_um: float,
+    ) -> Tensor:
+        """Evaluate the Seidel wavefront aberration (in waves) on a pupil grid.
+
+        Parameters
+        ----------
+        rho : Tensor
+            Normalized pupil radius, shape ``(Ny, Nx)``.
+        theta : Tensor
+            Azimuthal pupil angle in radians, shape ``(Ny, Nx)``.
+        x_o_um, y_o_um : float
+            Field position relative to the FOV center, in microns.
+
+        Returns
+        -------
+        Tensor
+            Wavefront aberration in waves, same shape as ``rho``.
+        """
+        x_norm = x_o_um / self.field_extent_um[1]
+        y_norm = y_o_um / self.field_extent_um[0]
+        eta = math.sqrt(x_norm * x_norm + y_norm * y_norm)
+        phi_field = math.atan2(y_norm, x_norm) if eta > 0 else 0.0
+
+        c = self.coefficients
+        out = torch.zeros_like(rho)
+        if c["defocus"]:
+            out = out + c["defocus"] * rho**2
+        if c["sphere"]:
+            out = out + c["sphere"] * rho**4
+        if eta > 0:
+            cos_dtheta = torch.cos(theta - phi_field)
+            if c["coma"]:
+                out = out + c["coma"] * eta * rho**3 * cos_dtheta
+            if c["astigmatism"]:
+                out = out + c["astigmatism"] * (eta**2) * (rho**2) * (cos_dtheta**2)
+            if c["field_curvature"]:
+                out = out + c["field_curvature"] * (eta**2) * (rho**2)
+            if c["distortion"]:
+                out = out + c["distortion"] * (eta**3) * rho * cos_dtheta
+        return out
+
+
 def make_pupil_grid(
     yx_shape: tuple[int, int],
     yx_pixel_size: float,


### PR DESCRIPTION
Adds two building blocks needed by the NMI benchmark table downstream in mehta-lab/waveorder-design#7. Scope kept tight — the shift-variant 2D-to-3D forward models live in waveorder-design for now until the inverse API is figured out.

**Commits**

1. `feat(zernike,phantoms): SeidelPupil + ring-bead phantoms` — adds `SeidelPupil` to `waveorder.zernike` (a 6-coef primary Seidel wavefront parameterized by field position, mirroring the `SpatialPolynomialPupil` API), plus `ring_beads_gaussian` / `ring_beads_2d_gaussian` in `waveorder.phantoms` (ring-of-beads patterns with bead centers stored in `phantom.metadata` for downstream per-bead metrics).

2. `test(zernike,phantoms): cover SeidelPupil + ring-bead phantoms` — 25 new tests in `tests/test_zernike_seidel.py` and `tests/test_phantoms_ring_beads.py`. Covers constructor validation, on-axis behavior (only `sphere`+`defocus` survive at η=0), field-dependence scaling (`field_curvature ∝ η²`, coma odd parity under field negation), the 2D PSF sign-ambiguity property (foundation of the v2 c_err `abs()` rule downstream), and 3D/2D phantom shapes, metadata, reproducibility, and centers-within-FOV.

3. `test: ruff format + drop unused pytest import` — pre-commit fixups.