### PR TITLE
feat(fluo): FISTA (non-negative) reconstruction for 3D fluorescence

### DIFF
--- a/benchmarks/configs/fluor_3d_beads_fista.yml
+++ b/benchmarks/configs/fluor_3d_beads_fista.yml
@@ -1,0 +1,14 @@
+reconstruction_dimension: 3
+input_channel_names: [GFP]
+fluorescence:
+  transfer_function:
+    yx_pixel_size: 0.1
+    z_pixel_size: 0.25
+    wavelength_emission: 0.532
+    index_of_refraction_media: 1.3
+    numerical_aperture_detection: 1.2
+  apply_inverse:
+    reconstruction_algorithm: FISTA
+    regularization_strength: 5.0e-3
+    FISTA_max_iter: 100
+    FISTA_rel_change_tol: 1.0e-3

--- a/waveorder/api/fluorescence.py
+++ b/waveorder/api/fluorescence.py
@@ -8,7 +8,7 @@ from typing import Literal, Optional
 import numpy as np
 import torch
 import xarray as xr
-from pydantic import Field, PositiveFloat, model_validator
+from pydantic import Field, NonNegativeFloat, PositiveFloat, PositiveInt, model_validator
 
 from waveorder.api._settings import (
     FourierApplyInverseSettings,
@@ -57,7 +57,27 @@ class TransferFunctionSettings(OptimizableFourierTransferFunctionSettings):
         return self
 
 
-ApplyInverseSettings = FourierApplyInverseSettings
+class ApplyInverseSettings(FourierApplyInverseSettings):
+    """Fluorescence-specific apply-inverse settings.
+
+    Extends ``FourierApplyInverseSettings`` with a ``FISTA`` option and
+    FISTA-specific knobs. FISTA solves the non-negativity-constrained
+    Tikhonov objective via accelerated proximal gradient — same Gaussian
+    data term + L2 penalty as Tikhonov, but with a ReLU prox at every iter
+    so the reconstruction is guaranteed non-negative. ``regularization_strength``
+    is shared between Tikhonov and FISTA.
+    """
+
+    reconstruction_algorithm: Literal["Tikhonov", "TV", "FISTA"] = Field(
+        default="Tikhonov",
+        description="'Tikhonov' (closed form), 'TV' (not implemented), or "
+        "'FISTA' (accelerated proximal gradient with non-negativity).",
+    )
+    FISTA_max_iter: PositiveInt = Field(default=100, description="FISTA maximum iteration count")
+    FISTA_rel_change_tol: NonNegativeFloat = Field(
+        default=1e-3,
+        description="FISTA early-stop tolerance on ||x_{k+1}-x_k|| / ||x_k||",
+    )
 
 
 class Settings(MyBaseModel):
@@ -298,13 +318,23 @@ def apply_inverse_transfer_function(
         zyx_tensor = torch.tensor(czyx_data.values[0], dtype=torch.float32, device=device)  # (Z, Y, X)
 
     # Single model call — handles both (Z,Y,X) and (B,Z,Y,X)
+    inverse_kwargs = settings.apply_inverse.model_dump()
     # [fluo, 2]
     if recon_dim == 2:
+        # 2D fluorescence uses a singular-system inverse and does not (yet)
+        # support FISTA. Strip the FISTA-only fields before calling the 2D
+        # entry-point, and reject if the user explicitly asked for FISTA.
+        if inverse_kwargs.get("reconstruction_algorithm") == "FISTA":
+            raise NotImplementedError(
+                "FISTA reconstruction is currently only implemented for 3D fluorescence (recon_dim=3)."
+            )
+        inverse_kwargs.pop("FISTA_max_iter", None)
+        inverse_kwargs.pop("FISTA_rel_change_tol", None)
         U, S, Vh = _to_singular_system(transfer_function)
         output = isotropic_fluorescent_thin_3d.apply_inverse_transfer_function(
             zyx_tensor,
             (U.to(device), S.to(device), Vh.to(device)),
-            **settings.apply_inverse.model_dump(),
+            **inverse_kwargs,
         )
     # [fluo, 3]
     elif recon_dim == 3:
@@ -312,7 +342,7 @@ def apply_inverse_transfer_function(
             zyx_tensor,
             _to_tensor(transfer_function, "optical_transfer_function").to(device),
             settings.transfer_function.z_padding,
-            **settings.apply_inverse.model_dump(),
+            **inverse_kwargs,
         )
 
     # Wrap output tensor(s) back into xr.DataArray(s)

--- a/waveorder/models/isotropic_fluorescent_thick_3d.py
+++ b/waveorder/models/isotropic_fluorescent_thick_3d.py
@@ -235,10 +235,12 @@ def apply_inverse_transfer_function(
     zyx_data: Tensor,
     optical_transfer_function: Tensor,
     z_padding: int,
-    reconstruction_algorithm: Literal["Tikhonov", "TV"] = "Tikhonov",
+    reconstruction_algorithm: Literal["Tikhonov", "TV", "FISTA"] = "Tikhonov",
     regularization_strength: float = 1e-3,
     TV_rho_strength: float = 1e-3,
     TV_iterations: int = 10,
+    FISTA_max_iter: int = 100,
+    FISTA_rel_change_tol: float = 1e-3,
 ) -> Tensor:
     """Reconstructs fluorescence density from defocus data.
 
@@ -251,14 +253,22 @@ def apply_inverse_transfer_function(
     z_padding : int
         Padding for axial dimension. Use zero for defocus stacks that
         extend ~3 PSF widths beyond the sample. Pad by ~3 PSF widths otherwise.
-    reconstruction_algorithm : {"Tikhonov", "TV"}, optional
-        By default "Tikhonov". "TV" is not implemented.
+    reconstruction_algorithm : {"Tikhonov", "TV", "FISTA"}, optional
+        By default "Tikhonov". "TV" is not implemented. "FISTA" solves
+        ``min 0.5||Hx - y||^2 + 0.5 lambda ||x||^2  s.t.  x >= 0`` via
+        FISTA with a non-negativity proximal step.
     regularization_strength : float, optional
-        Regularization parameter, by default 1e-3
+        Regularization parameter (lambda), by default 1e-3. Used by both
+        Tikhonov and FISTA (shared L2 penalty).
     TV_rho_strength : float, optional
         TV-specific regularization parameter, by default 1e-3
     TV_iterations : int, optional
         TV-specific number of iterations, by default 10
+    FISTA_max_iter : int, optional
+        FISTA maximum iteration count, by default 100
+    FISTA_rel_change_tol : float, optional
+        FISTA early-stop tolerance on ``||x_{k+1} - x_k|| / ||x_k||``,
+        by default 1e-3
 
     Returns
     -------
@@ -282,6 +292,40 @@ def apply_inverse_transfer_function(
 
     elif reconstruction_algorithm == "TV":
         raise NotImplementedError
+
+    elif reconstruction_algorithm == "FISTA":
+        # FISTA on  0.5 ||H x - y||^2 + 0.5 lambda ||x||^2  s.t.  x >= 0.
+        # H is the convolution by the PSF whose OTF is `optical_transfer_function`,
+        # so Hx = IFFT(FFT(x) * OTF). The smooth-part Lipschitz constant is
+        # L = max(|OTF|^2) + lambda, giving a constant step 1/L.
+        otf = optical_transfer_function
+        otf_conj = torch.conj(otf)
+        # `otf_sq` is real and shared across the batch.
+        otf_sq = torch.real(otf_conj * otf)
+        L = float(otf_sq.max().item() + regularization_strength)
+        step = 1.0 / L
+
+        y_fft = torch.fft.fftn(zyx_padded, dim=(-3, -2, -1))
+        x = torch.zeros_like(zyx_padded)
+        z = x.clone()
+        t = 1.0
+
+        for k in range(FISTA_max_iter):
+            z_fft = torch.fft.fftn(z, dim=(-3, -2, -1))
+            residual_fft = z_fft * otf - y_fft  # FFT of (H z - y)
+            grad = torch.real(torch.fft.ifftn(residual_fft * otf_conj, dim=(-3, -2, -1))) + regularization_strength * z
+            x_new = torch.clamp(z - step * grad, min=0.0)
+            t_new = 0.5 * (1.0 + (1.0 + 4.0 * t * t) ** 0.5)
+            z = x_new + ((t - 1.0) / t_new) * (x_new - x)
+
+            denom = torch.linalg.norm(x).item() + 1e-12
+            rc = torch.linalg.norm(x_new - x).item() / denom
+            x = x_new
+            t = t_new
+            if k > 0 and rc < FISTA_rel_change_tol:
+                break
+
+        f_real = x
 
     # Unpad
     if z_padding != 0:


### PR DESCRIPTION
**Summary**

Adds `reconstruction_algorithm: FISTA` to 3D fluorescence reconstructions. FISTA solves

\`\`\`
min  0.5 ||Hx - y||^2 + 0.5 lambda ||x||^2    s.t.  x >= 0
\`\`\`

via accelerated proximal gradient with a ReLU prox at every iteration, guaranteeing a non-negative reconstruction. Shares `regularization_strength` with the existing Tikhonov path.

**Config example**

\`\`\`yaml
reconstruction_dimension: 3
input_channel_names: [GFP]
fluorescence:
  transfer_function:
    yx_pixel_size: 0.1
    z_pixel_size: 0.25
    wavelength_emission: 0.532
    index_of_refraction_media: 1.3
    numerical_aperture_detection: 1.2
  apply_inverse:
    reconstruction_algorithm: FISTA       # NEW
    regularization_strength: 5.0e-3       # shared L2 with Tikhonov
    FISTA_max_iter: 100                   # NEW
    FISTA_rel_change_tol: 1.0e-3          # NEW
\`\`\`

Full file at `benchmarks/configs/fluor_3d_beads_fista.yml`.

**Motivation**

Standard TLS / Tikhonov fluorescence reconstructions produce non-physical negative voxels (~50% in dynacell mantis A549 SEC61 ER and hummingbird A549 G3BP1 stress granule data) regardless of regularization choice. FISTA removes the negatives by construction at the cost of ~30-100x more wall time (still well under a minute per 100-iter, 512^2 lateral FOV on CPU).

**Scope**

- Only 3D fluorescence (recon_dim=3). 2D fluorescence (singular-system path) explicitly raises `NotImplementedError` for FISTA for now.
- Phase / birefringence settings untouched. The `FISTA` option lives on a new `ApplyInverseSettings` subclass in `waveorder/api/fluorescence.py` rather than the shared `FourierApplyInverseSettings`, so phase / birefringence schemas stay clean.

**Changes**

- `waveorder/api/fluorescence.py`: new `ApplyInverseSettings(FourierApplyInverseSettings)` widens the algorithm Literal and adds `FISTA_max_iter` / `FISTA_rel_change_tol`. Apply-inverse dispatcher filters FISTA-only kwargs before calling the 2D entry-point and rejects 2D FISTA with a clear message.
- `waveorder/models/isotropic_fluorescent_thick_3d.py`: FISTA branch with constant step size `1 / L`, `L = max(|OTF|^2) + lambda`. Two FFTs per iteration (FFT(z), IFFT(residual_fft * conj(OTF))), early stop on `||x_{k+1} - x_k|| / ||x_k|| < FISTA_rel_change_tol`.
- `benchmarks/configs/fluor_3d_beads_fista.yml`: example config.

**Tested**

Smoke test on `simulate(...)` phantom in 3D: Tikhonov and FISTA both reconstruct the bead within a few counts of the true intensity; FISTA stays strictly non-negative. 2D FISTA correctly raises NotImplementedError.

\`\`\`
phantom range: 0.0 1.0
data    range: 10.07 10.55
Tikhonov out: min=9.57 max=10.90 frac<0=0.000
FISTA    out: min=9.49 max=10.80 frac<0=0.000
OK: FISTA in 2D raised: FISTA reconstruction is currently only implemented for 3D fluorescence
\`\`\`

**Follow-ups (not in this PR)**

- 2D FISTA in `isotropic_fluorescent_thin_3d.apply_inverse_transfer_function` (different forward model — singular-system convolution).
- Per-voxel Poisson-with-offset model for low-SNR data.

## Test plan
- [ ] Tikhonov path produces same results as before (regression).
- [ ] FISTA on a simulated 3D phantom converges and stays non-negative.
- [ ] 2D FISTA raises NotImplementedError.