### PR TITLE
fix(bench): update ops path to /hpc/projects/icd.fast.ops

### DIFF
--- a/benchmarks/experiments/regression.yml
+++ b/benchmarks/experiments/regression.yml
@@ -66,7 +66,7 @@ cases:
 
   ops_pheno_center:
     type: hpc
-    input: /hpc/projects/intracellular_dashboard/ops/ops0105_20260106/0-convert/live_imaging/phenotyping_transform.zarr
+    input: /hpc/projects/icd.fast.ops/ops0105_20260106/0-convert/live_imaging/phenotyping_transform.zarr
     position: A/1/029029
     config: ../configs/ops_pheno_phase_2d.yml
     reference:
@@ -74,7 +74,7 @@ cases:
 
   ops_pheno_center_opt:
     type: hpc
-    input: /hpc/projects/intracellular_dashboard/ops/ops0105_20260106/0-convert/live_imaging/phenotyping_transform.zarr
+    input: /hpc/projects/icd.fast.ops/ops0105_20260106/0-convert/live_imaging/phenotyping_transform.zarr
     position: A/1/029029
     crop:
       y: [768, 1280]


### PR DESCRIPTION
The ops dataset moved from `/hpc/projects/intracellular_dashboard/ops/` to `/hpc/projects/icd.fast.ops/`, which broke the two HPC benchmark cases in `regression.yml` (`ops_pheno_center`, `ops_pheno_center_opt`).

**Verification**

Ran `ops_pheno_center_opt` end-to-end against the new path: passed in 84.6s, reference parameter bounds all satisfied.