### PR TITLE
feat: anisotropic yx pixel size for fluorescence and phase

### DIFF
--- a/docs/examples/api/phase_3d_anisotropic.py
+++ b/docs/examples/api/phase_3d_anisotropic.py
@@ -1,0 +1,39 @@
+"""3D phase reconstruction with anisotropic yx pixel sizes.
+
+This example exercises the dict form of ``yx_pixel_size`` for setups where
+the y and x pixel sizes differ (e.g. DaXi, light-sheet rigs with asymmetric
+binning). The scalar form (``yx_pixel_size=0.1``) is still accepted for
+square pixels and routes to the same code path internally.
+"""
+
+from waveorder.api import phase
+
+settings = phase.Settings(
+    transfer_function=phase.TransferFunctionSettings(
+        wavelength_illumination=0.532,
+        yx_pixel_size={"y": 0.3, "x": 0.25},
+        z_pixel_size=0.5,
+        numerical_aperture_illumination=0.9,
+        numerical_aperture_detection=1.2,
+        index_of_refraction_media=1.3,
+    ),
+    apply_inverse=phase.ApplyInverseSettings(
+        regularization_strength=1e-3,
+    ),
+)
+
+phantom, data = phase.simulate(
+    settings,
+    recon_dim=3,
+    zyx_shape=(40, 128, 128),
+    index_of_refraction_sample=1.50,
+)
+
+result = phase.reconstruct(data, recon_dim=3, settings=settings)
+
+print(f"Output shape: {result.shape}")
+print(
+    f"yx_pixel_size used: y={settings.transfer_function.yx_pixel_size.y}, "
+    f"x={settings.transfer_function.yx_pixel_size.x}"
+)
+print(f"Channels: {list(result.coords['c'].values)}")

--- a/docs/examples/cli/configs/birefringence-and-phase_3d.yml
+++ b/docs/examples/cli/configs/birefringence-and-phase_3d.yml
@@ -17,7 +17,7 @@ birefringence:
 phase:
   transfer_function:
     wavelength_illumination: 0.532          # illumination wavelength in micrometers
-    yx_pixel_size: 0.1                      # lateral pixel size in micrometers
+    yx_pixel_size: 0.1                      # lateral pixel size in micrometers; scalar for isotropic, or {y, x} mapping for anisotropic
     z_pixel_size: 0.25                      # axial pixel size in micrometers
     z_padding: 0                            # z slices to pad for axial boundary effects
     z_focus_offset: 0                       # (optimizable) offset from center slice in slice units

--- a/docs/examples/cli/configs/fluorescence_2d.yml
+++ b/docs/examples/cli/configs/fluorescence_2d.yml
@@ -4,7 +4,7 @@ time_indices: all                           # time points to reconstruct
 reconstruction_dimension: 2                 # 2 for thin samples, 3 for thick
 fluorescence:
   transfer_function:
-    yx_pixel_size: 0.1                      # lateral pixel size in micrometers
+    yx_pixel_size: 0.1                      # lateral pixel size in micrometers; scalar for isotropic, or {y, x} mapping for anisotropic
     z_pixel_size: 0.25                      # axial pixel size in micrometers
     z_padding: 0                            # z slices to pad for axial boundary effects
     z_focus_offset: 0                       # (optimizable) offset from center slice in slice units

--- a/docs/examples/cli/configs/fluorescence_3d.yml
+++ b/docs/examples/cli/configs/fluorescence_3d.yml
@@ -4,7 +4,7 @@ time_indices: all                           # time points to reconstruct
 reconstruction_dimension: 3                 # 2 for thin samples, 3 for thick
 fluorescence:
   transfer_function:
-    yx_pixel_size: 0.1                      # lateral pixel size in micrometers
+    yx_pixel_size: 0.1                      # lateral pixel size in micrometers; scalar for isotropic, or {y, x} mapping for anisotropic
     z_pixel_size: 0.25                      # axial pixel size in micrometers
     z_padding: 0                            # z slices to pad for axial boundary effects
     z_focus_offset: 0                       # (optimizable) offset from center slice in slice units

--- a/docs/examples/cli/configs/phase_2d.yml
+++ b/docs/examples/cli/configs/phase_2d.yml
@@ -5,7 +5,7 @@ reconstruction_dimension: 2                 # 2 for thin samples, 3 for thick
 phase:
   transfer_function:
     wavelength_illumination: 0.532          # illumination wavelength in micrometers
-    yx_pixel_size: 0.1                      # lateral pixel size in micrometers
+    yx_pixel_size: 0.1                      # lateral pixel size in micrometers; scalar for isotropic, or {y, x} mapping for anisotropic
     z_pixel_size: 0.25                      # axial pixel size in micrometers
     z_padding: 0                            # z slices to pad for axial boundary effects
     z_focus_offset: 0                       # (optimizable) offset from center slice in slice units

--- a/docs/examples/cli/configs/phase_3d.yml
+++ b/docs/examples/cli/configs/phase_3d.yml
@@ -5,7 +5,7 @@ reconstruction_dimension: 3                 # 2 for thin samples, 3 for thick
 phase:
   transfer_function:
     wavelength_illumination: 0.532          # illumination wavelength in micrometers
-    yx_pixel_size: 0.1                      # lateral pixel size in micrometers
+    yx_pixel_size: 0.1                      # lateral pixel size in micrometers; scalar for isotropic, or {y, x} mapping for anisotropic
     z_pixel_size: 0.25                      # axial pixel size in micrometers
     z_padding: 0                            # z slices to pad for axial boundary effects
     z_focus_offset: 0                       # (optimizable) offset from center slice in slice units

--- a/tests/cli_tests/test_reconstruct.py
+++ b/tests/cli_tests/test_reconstruct.py
@@ -10,6 +10,7 @@ from iohub.ngff import open_ome_zarr
 from iohub.ngff.models import TransformationMeta
 
 from waveorder._pixel_size import YXPixelSize
+from waveorder.api import fluorescence as fluorescence_api
 from waveorder.cli import settings
 from waveorder.cli.apply_inverse_transfer_function import (
     _warn_pixel_size_mismatch,
@@ -502,6 +503,60 @@ def test_warn_pixel_size_mismatch_separate_y_and_x():
     text = "\n".join(str(w.message) for w in record)
     assert "y: input=0.4" in text and "config=0.3" in text
     assert "x:" not in text  # x matches, so should be omitted
+
+
+def test_write_config_scale_to_output_anisotropic(tmp_path):
+    """An anisotropic yx_pixel_size config writes distinct y and x scales to the output."""
+    input_path = tmp_path / "aniso_input.zarr"
+    output_path = tmp_path / "aniso_output.zarr"
+
+    channel_names = ["GFP"]
+    original_scale = [1, 1, 0.5, 0.4, 0.4]
+    dataset = open_ome_zarr(input_path, layout="hcs", mode="w", channel_names=channel_names)
+    position = dataset.create_position("0", "0", "0")
+    position.create_zeros(
+        "0",
+        (1, 1, 4, 5, 6),
+        dtype=np.uint16,
+        transform=[TransformationMeta(type="scale", scale=original_scale)],
+    )
+    dataset.close()
+
+    fluor_tf = fluorescence_api.TransferFunctionSettings(
+        yx_pixel_size={"y": 0.3, "x": 0.25},
+        z_pixel_size=0.5,
+        wavelength_emission=0.532,
+    )
+    recon_settings = settings.ReconstructionSettings(
+        input_channel_names=channel_names,
+        time_indices="all",
+        reconstruction_dimension=3,
+        fluorescence=settings.FluorescenceSettings(transfer_function=fluor_tf),
+    )
+    config_path = tmp_path / "aniso.yml"
+    utils.model_to_yaml(recon_settings, config_path)
+
+    runner = CliRunner()
+    runner.invoke(
+        cli,
+        [
+            "reconstruct",
+            "-i",
+            str(input_path / "0" / "0" / "0"),
+            "-c",
+            str(config_path),
+            "-o",
+            str(output_path),
+            "--write-config-scale-to-output",
+        ],
+        catch_exceptions=False,
+    )
+
+    with open_ome_zarr(output_path) as result:
+        result_scale = result["0/0/0"].scale
+        assert result_scale[2] == 0.5  # z
+        assert result_scale[3] == 0.3  # y
+        assert result_scale[4] == 0.25  # x
 
 
 def test_warn_pixel_size_mismatch_isotropic_silent_when_equal():

--- a/tests/cli_tests/test_reconstruct.py
+++ b/tests/cli_tests/test_reconstruct.py
@@ -1,3 +1,4 @@
+import warnings
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
@@ -8,8 +9,10 @@ from click.testing import CliRunner
 from iohub.ngff import open_ome_zarr
 from iohub.ngff.models import TransformationMeta
 
+from waveorder._pixel_size import YXPixelSize
 from waveorder.cli import settings
 from waveorder.cli.apply_inverse_transfer_function import (
+    _warn_pixel_size_mismatch,
     apply_inverse_transfer_function_cli,
 )
 from waveorder.cli.main import cli
@@ -488,3 +491,24 @@ def test_write_config_scale_to_output(tmp_path):
         assert result_scale[2] == 0.25  # z_pixel_size default
         assert result_scale[3] == 0.1  # yx_pixel_size default
         assert result_scale[4] == 0.1
+
+
+def test_warn_pixel_size_mismatch_separate_y_and_x():
+    """An anisotropic YXPixelSize raises separate y and x mismatches in the warning."""
+    input_scale = (1.0, 1.0, 0.5, 0.4, 0.2)  # T, C, Z, Y, X
+    config_pixel_sizes = (0.5, YXPixelSize(y=0.3, x=0.2))
+    with pytest.warns(UserWarning) as record:
+        _warn_pixel_size_mismatch(input_scale, config_pixel_sizes)
+    text = "\n".join(str(w.message) for w in record)
+    assert "y: input=0.4" in text and "config=0.3" in text
+    assert "x:" not in text  # x matches, so should be omitted
+
+
+def test_warn_pixel_size_mismatch_isotropic_silent_when_equal():
+    """No warning when input scale matches the config (isotropic case)."""
+    input_scale = (1.0, 1.0, 0.5, 0.1, 0.1)
+    config_pixel_sizes = (0.5, 0.1)
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
+        _warn_pixel_size_mismatch(input_scale, config_pixel_sizes)
+    assert all("Input pixel sizes" not in str(w.message) for w in record)

--- a/tests/cli_tests/test_settings.py
+++ b/tests/cli_tests/test_settings.py
@@ -1,8 +1,10 @@
 from pathlib import Path
 
 import pytest
+import yaml
 from pydantic import ValidationError
 
+from waveorder._pixel_size import YXPixelSize
 from waveorder.api import birefringence, fluorescence, phase
 from waveorder.cli import settings
 from waveorder.io import utils
@@ -118,3 +120,59 @@ def test_generate_example_settings():
         utils.model_to_commented_yaml(settings_obj, config_path)
         settings_roundtrip = utils.yaml_to_model(config_path, settings.ReconstructionSettings)
         assert settings_obj.model_dump() == settings_roundtrip.model_dump()
+
+
+def test_phase_yx_pixel_size_scalar_form():
+    """The legacy scalar form parses into an isotropic YXPixelSize."""
+    tf = phase.TransferFunctionSettings(yx_pixel_size=0.3)
+    assert isinstance(tf.yx_pixel_size, YXPixelSize)
+    assert tf.yx_pixel_size.y == 0.3
+    assert tf.yx_pixel_size.x == 0.3
+
+
+def test_phase_yx_pixel_size_dict_form():
+    """The {y, x} mapping form parses into an anisotropic YXPixelSize."""
+    tf = phase.TransferFunctionSettings(yx_pixel_size={"y": 0.3, "x": 0.25})
+    assert isinstance(tf.yx_pixel_size, YXPixelSize)
+    assert tf.yx_pixel_size.y == 0.3
+    assert tf.yx_pixel_size.x == 0.25
+
+
+def test_phase_yx_pixel_size_scalar_equals_isotropic_mapping():
+    """Scalar and isotropic mapping forms produce equal settings."""
+    a = phase.TransferFunctionSettings(yx_pixel_size=0.3)
+    b = phase.TransferFunctionSettings(yx_pixel_size={"y": 0.3, "x": 0.3})
+    assert a.yx_pixel_size == b.yx_pixel_size
+
+
+def test_yaml_roundtrip_anisotropic_yx_pixel_size(tmp_path):
+    """An anisotropic config round-trips through YAML losslessly."""
+    s = phase.TransferFunctionSettings(yx_pixel_size={"y": 0.3, "x": 0.25})
+    path = tmp_path / "phase_aniso.yml"
+    utils.model_to_yaml(s, path)
+    parsed = yaml.safe_load(path.read_text())
+    assert parsed["yx_pixel_size"] == {"y": 0.3, "x": 0.25}
+    reparsed = utils.yaml_to_model(path, phase.TransferFunctionSettings)
+    assert reparsed.yx_pixel_size.y == 0.3
+    assert reparsed.yx_pixel_size.x == 0.25
+
+
+def test_yaml_roundtrip_isotropic_yx_pixel_size_stays_scalar(tmp_path):
+    """An isotropic config serializes back as a scalar (not as {y: 0.3, x: 0.3})."""
+    s = phase.TransferFunctionSettings(yx_pixel_size=0.3)
+    path = tmp_path / "phase_iso.yml"
+    utils.model_to_yaml(s, path)
+    parsed = yaml.safe_load(path.read_text())
+    assert parsed["yx_pixel_size"] == 0.3
+
+
+def test_invalid_yx_pixel_size_mapping_rejected():
+    """A typo in the mapping form fails validation, not silently."""
+    with pytest.raises(ValidationError):
+        phase.TransferFunctionSettings(yx_pixel_size={"Y": 0.3, "x": 0.25})
+
+
+def test_negative_yx_pixel_size_rejected():
+    """Negative spacings are rejected."""
+    with pytest.raises(ValidationError):
+        phase.TransferFunctionSettings(yx_pixel_size={"y": -0.3, "x": 0.25})

--- a/tests/models/test_inplane_oriented_thick_pol3d_vector_yx_pixel_size.py
+++ b/tests/models/test_inplane_oriented_thick_pol3d_vector_yx_pixel_size.py
@@ -1,0 +1,48 @@
+"""Anisotropic yx_pixel_size guards on the birefringence vector model."""
+
+import pytest
+
+from waveorder._pixel_size import YXPixelSize
+from waveorder.models import inplane_oriented_thick_pol3d_vector
+
+
+def _common_kwargs():
+    return dict(
+        swing=0.1,
+        scheme="5-State",
+        zyx_shape=(4, 16, 16),
+        z_pixel_size=0.5,
+        wavelength_illumination=0.532,
+        z_padding=0,
+        index_of_refraction_media=1.3,
+        numerical_aperture_illumination=0.5,
+        numerical_aperture_detection=1.2,
+    )
+
+
+def test_isotropic_yx_pixel_size_runs():
+    """An isotropic YXPixelSize equal in y and x is accepted."""
+    result = inplane_oriented_thick_pol3d_vector.calculate_transfer_function(
+        yx_pixel_size=YXPixelSize.isotropic(0.2),
+        **_common_kwargs(),
+    )
+    # Result is a tuple (sfZYX_tf, intensity_to_stokes, *extras); just check non-empty.
+    assert result is not None
+
+
+def test_anisotropic_yx_pixel_size_raises_not_implemented():
+    """Anisotropic yx_pixel_size on the birefringence vector model is unsupported."""
+    with pytest.raises(NotImplementedError, match="Anisotropic"):
+        inplane_oriented_thick_pol3d_vector.calculate_transfer_function(
+            yx_pixel_size=YXPixelSize(y=0.3, x=0.2),
+            **_common_kwargs(),
+        )
+
+
+def test_scalar_yx_pixel_size_still_accepted():
+    """Legacy scalar yx_pixel_size keeps working."""
+    result = inplane_oriented_thick_pol3d_vector.calculate_transfer_function(
+        yx_pixel_size=0.2,
+        **_common_kwargs(),
+    )
+    assert result is not None

--- a/tests/models/test_isotropic_fluorescent_thick_3d.py
+++ b/tests/models/test_isotropic_fluorescent_thick_3d.py
@@ -2,6 +2,7 @@ import numpy as np
 import torch
 
 from waveorder import util
+from waveorder._pixel_size import YXPixelSize
 from waveorder.models import isotropic_fluorescent_thick_3d
 
 
@@ -94,6 +95,55 @@ def test_apply_inverse_transfer_function():
     #    itr=10,
     # )
     # assert result_tv.shape == (10, 5, 5)
+
+
+def test_calculate_transfer_function_isotropic_yx_pixel_size_equivalence():
+    """Anisotropic YXPixelSize with y == x reproduces the legacy scalar output."""
+    common = dict(
+        zyx_shape=(10, 32, 32),
+        z_pixel_size=0.5,
+        wavelength_emission=0.507,
+        z_padding=0,
+        index_of_refraction_media=1.3,
+        numerical_aperture_detection=1.2,
+    )
+    otf_scalar = isotropic_fluorescent_thick_3d.calculate_transfer_function(yx_pixel_size=0.2, **common)
+    otf_model = isotropic_fluorescent_thick_3d.calculate_transfer_function(
+        yx_pixel_size=YXPixelSize.isotropic(0.2), **common
+    )
+    assert torch.allclose(otf_scalar, otf_model)
+
+
+def test_calculate_transfer_function_anisotropic_runs():
+    """y != x produces a finite OTF of the expected shape."""
+    otf = isotropic_fluorescent_thick_3d.calculate_transfer_function(
+        zyx_shape=(10, 32, 32),
+        yx_pixel_size=YXPixelSize(y=0.3, x=0.2),
+        z_pixel_size=0.5,
+        wavelength_emission=0.507,
+        z_padding=0,
+        index_of_refraction_media=1.3,
+        numerical_aperture_detection=1.2,
+    )
+    assert otf.shape == (10, 32, 32)
+    assert torch.isfinite(otf).all()
+
+
+def test_reconstruct_anisotropic_smoke():
+    """End-to-end reconstruct on random data with anisotropic yx pixel size runs."""
+    zyx_shape = (10, 32, 32)
+    zyx_data = torch.rand(zyx_shape)
+    result = isotropic_fluorescent_thick_3d.reconstruct(
+        zyx_data,
+        yx_pixel_size=YXPixelSize(y=0.3, x=0.2),
+        z_pixel_size=0.5,
+        wavelength_emission=0.507,
+        z_padding=0,
+        index_of_refraction_media=1.3,
+        numerical_aperture_detection=1.2,
+    )
+    assert result.shape == zyx_shape
+    assert np.all(np.isfinite(result.numpy()))
 
 
 def test_reconstruct():

--- a/tests/models/test_isotropic_fluorescent_thin_3d.py
+++ b/tests/models/test_isotropic_fluorescent_thin_3d.py
@@ -1,6 +1,7 @@
 import numpy as np
 import torch
 
+from waveorder._pixel_size import YXPixelSize
 from waveorder.models import isotropic_fluorescent_thin_3d
 
 
@@ -167,6 +168,54 @@ def test_end_to_end_simulation():
     recon_max = torch.max(yx_fluorescence_recon)
     # More lenient test - just check reconstruction is non-zero
     assert recon_max > 0.01 * original_max  # Very lenient scale preservation
+
+
+def test_calculate_transfer_function_isotropic_yx_pixel_size_equivalence():
+    """Anisotropic YXPixelSize with y == x reproduces the legacy scalar output."""
+    common = dict(
+        yx_shape=(64, 64),
+        z_position_list=[-1.0, 0.0, 1.0],
+        wavelength_emission=0.532,
+        index_of_refraction_media=1.3,
+        numerical_aperture_detection=1.2,
+    )
+    tf_scalar = isotropic_fluorescent_thin_3d.calculate_transfer_function(yx_pixel_size=0.1, **common)
+    tf_model = isotropic_fluorescent_thin_3d.calculate_transfer_function(
+        yx_pixel_size=YXPixelSize.isotropic(0.1), **common
+    )
+    assert torch.allclose(tf_scalar, tf_model)
+
+
+def test_calculate_transfer_function_anisotropic_runs():
+    """y != x produces a finite transfer function of the expected shape."""
+    tf = isotropic_fluorescent_thin_3d.calculate_transfer_function(
+        yx_shape=(64, 64),
+        yx_pixel_size=YXPixelSize(y=0.15, x=0.1),
+        z_position_list=[-1.0, 0.0, 1.0],
+        wavelength_emission=0.532,
+        index_of_refraction_media=1.3,
+        numerical_aperture_detection=1.2,
+    )
+    assert tf.shape == (3, 64, 64)
+    assert torch.isfinite(tf.real).all()
+    assert torch.isfinite(tf.imag).all()
+
+
+def test_reconstruct_anisotropic_smoke():
+    """End-to-end reconstruct on random data with anisotropic yx pixel size runs."""
+    yx_shape = (32, 32)
+    z_position_list = [-1.0, 0.0, 1.0]
+    zyx_data = torch.rand((len(z_position_list),) + yx_shape)
+    result = isotropic_fluorescent_thin_3d.reconstruct(
+        zyx_data,
+        yx_pixel_size=YXPixelSize(y=0.15, x=0.1),
+        z_position_list=z_position_list,
+        wavelength_emission=0.507,
+        index_of_refraction_media=1.3,
+        numerical_aperture_detection=1.2,
+    )
+    assert result.shape == yx_shape
+    assert np.all(np.isfinite(result.numpy()))
 
 
 def test_reconstruct():

--- a/tests/models/test_isotropic_thin_3d.py
+++ b/tests/models/test_isotropic_thin_3d.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 import torch
 
+from waveorder._pixel_size import YXPixelSize
 from waveorder.models import isotropic_thin_3d
 
 
@@ -20,6 +21,61 @@ def test_calculate_transfer_function(invert_phase_contrast):
 
     assert Hu.shape == (3, 100, 101)
     assert Hp.shape == (3, 100, 101)
+
+
+def test_calculate_transfer_function_isotropic_yx_pixel_size_equivalence():
+    """Anisotropic YXPixelSize with y == x reproduces the legacy scalar output."""
+    common = dict(
+        yx_shape=(64, 64),
+        z_position_list=[-1.0, 0.0, 1.0],
+        wavelength_illumination=0.532,
+        index_of_refraction_media=1.3,
+        numerical_aperture_illumination=0.5,
+        numerical_aperture_detection=1.2,
+    )
+    Hu_scalar, Hp_scalar = isotropic_thin_3d.calculate_transfer_function(yx_pixel_size=0.2, **common)
+    Hu_model, Hp_model = isotropic_thin_3d.calculate_transfer_function(
+        yx_pixel_size=YXPixelSize.isotropic(0.2), **common
+    )
+    assert torch.allclose(Hu_scalar, Hu_model)
+    assert torch.allclose(Hp_scalar, Hp_model)
+
+
+def test_calculate_transfer_function_anisotropic_runs():
+    """y != x produces finite transfer functions of the expected shape."""
+    Hu, Hp = isotropic_thin_3d.calculate_transfer_function(
+        yx_shape=(64, 64),
+        yx_pixel_size=YXPixelSize(y=0.3, x=0.2),
+        z_position_list=[-1.0, 0.0, 1.0],
+        wavelength_illumination=0.532,
+        index_of_refraction_media=1.3,
+        numerical_aperture_illumination=0.5,
+        numerical_aperture_detection=1.2,
+    )
+    assert Hu.shape == (3, 64, 64)
+    assert Hp.shape == (3, 64, 64)
+    assert torch.isfinite(Hu).all()
+    assert torch.isfinite(Hp).all()
+
+
+def test_reconstruct_anisotropic_smoke():
+    """Anisotropic reconstruct returns finite absorption and phase of the right shape."""
+    yx_shape = (32, 32)
+    z_position_list = [-1.0, 0.0, 1.0]
+    zyx_data = torch.rand((len(z_position_list),) + yx_shape)
+    absorption, phase = isotropic_thin_3d.reconstruct(
+        zyx_data,
+        yx_pixel_size=YXPixelSize(y=0.3, x=0.2),
+        z_position_list=z_position_list,
+        wavelength_illumination=0.532,
+        index_of_refraction_media=1.3,
+        numerical_aperture_illumination=0.5,
+        numerical_aperture_detection=1.2,
+    )
+    assert absorption.shape == yx_shape
+    assert phase.shape == yx_shape
+    assert np.all(np.isfinite(absorption.numpy()))
+    assert np.all(np.isfinite(phase.numpy()))
 
 
 def test_reconstruct():

--- a/tests/models/test_phase_thick_3d.py
+++ b/tests/models/test_phase_thick_3d.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 import torch
 
+from waveorder._pixel_size import YXPixelSize
 from waveorder.models import phase_thick_3d
 
 
@@ -114,6 +115,61 @@ def test_phase_invariance(z_pixel_size_um, yx_pixel_size_um, tolerance):
 
     # The physical property Δn should be invariant to voxel size
     assert np.abs((recon_delta_n - baseline_delta_n) / baseline_delta_n) < tolerance
+
+
+def test_calculate_transfer_function_isotropic_yx_pixel_size_equivalence():
+    """Anisotropic YXPixelSize with y == x reproduces the legacy scalar output."""
+    common = dict(
+        zyx_shape=(10, 32, 32),
+        z_pixel_size=0.5,
+        z_padding=0,
+        wavelength_illumination=0.532,
+        index_of_refraction_media=1.3,
+        numerical_aperture_illumination=0.5,
+        numerical_aperture_detection=1.2,
+    )
+    H_re_scalar, H_im_scalar = phase_thick_3d.calculate_transfer_function(yx_pixel_size=0.2, **common)
+    H_re_model, H_im_model = phase_thick_3d.calculate_transfer_function(
+        yx_pixel_size=YXPixelSize.isotropic(0.2), **common
+    )
+    assert torch.allclose(H_re_scalar, H_re_model)
+    assert torch.allclose(H_im_scalar, H_im_model)
+
+
+def test_calculate_transfer_function_anisotropic_runs():
+    """y != x produces finite transfer functions of the expected shape."""
+    H_re, H_im = phase_thick_3d.calculate_transfer_function(
+        zyx_shape=(10, 32, 32),
+        yx_pixel_size=YXPixelSize(y=0.3, x=0.2),
+        z_pixel_size=0.5,
+        z_padding=0,
+        wavelength_illumination=0.532,
+        index_of_refraction_media=1.3,
+        numerical_aperture_illumination=0.5,
+        numerical_aperture_detection=1.2,
+    )
+    assert H_re.shape == (10, 32, 32)
+    assert H_im.shape == (10, 32, 32)
+    assert torch.isfinite(H_re).all()
+    assert torch.isfinite(H_im).all()
+
+
+def test_reconstruct_anisotropic_smoke():
+    """End-to-end reconstruct on random data with anisotropic yx pixel size runs."""
+    zyx_shape = (10, 32, 32)
+    zyx_data = torch.rand(zyx_shape)
+    result = phase_thick_3d.reconstruct(
+        zyx_data,
+        yx_pixel_size=YXPixelSize(y=0.3, x=0.2),
+        z_pixel_size=0.5,
+        wavelength_illumination=0.532,
+        z_padding=0,
+        index_of_refraction_media=1.3,
+        numerical_aperture_illumination=0.5,
+        numerical_aperture_detection=1.2,
+    )
+    assert result.shape == zyx_shape
+    assert np.all(np.isfinite(result.numpy()))
 
 
 def test_reconstruct():

--- a/tests/test_pixel_size.py
+++ b/tests/test_pixel_size.py
@@ -50,13 +50,13 @@ def test_from_value_accepts_mapping():
 
 def test_from_value_rejects_bool():
     """Bools are not valid pixel sizes even though they're a subclass of int."""
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         YXPixelSize.from_value(True)
 
 
 def test_from_value_rejects_unknown_type():
-    """Unknown types raise a clear TypeError."""
-    with pytest.raises(TypeError, match="cannot convert"):
+    """Unknown types raise a clear ValueError, which pydantic wraps as ValidationError."""
+    with pytest.raises(ValueError, match="cannot convert"):
         YXPixelSize.from_value("0.3")
 
 
@@ -78,7 +78,7 @@ def test_from_value_accepts_zero_d_tensor():
 
 def test_from_value_rejects_multi_element_array():
     """A 1-D or higher ndarray is not a scalar pixel size."""
-    with pytest.raises(TypeError, match="cannot convert"):
+    with pytest.raises(ValueError, match="cannot convert"):
         YXPixelSize.from_value(np.array([0.3, 0.25]))
 
 
@@ -92,6 +92,35 @@ def test_from_value_rejects_zero_via_scalar():
     """Zero spacing is not a valid isotropic value."""
     with pytest.raises(ValidationError):
         YXPixelSize.from_value(0.0)
+
+
+def test_from_value_rejects_non_finite_scalar():
+    """inf and nan are not usable pixel sizes."""
+    with pytest.raises(ValidationError):
+        YXPixelSize.from_value(float("inf"))
+    with pytest.raises(ValidationError):
+        YXPixelSize.from_value(float("nan"))
+
+
+def test_from_value_rejects_partial_mapping():
+    """A mapping naming one axis must name the other; it is not silently defaulted."""
+    with pytest.raises(ValidationError, match="both 'y' and 'x'"):
+        YXPixelSize.from_value({"y": 0.3})
+    with pytest.raises(ValidationError, match="both 'y' and 'x'"):
+        YXPixelSize.from_value({"x": 0.25})
+
+
+def test_empty_mapping_uses_defaults():
+    """An empty mapping names no axis, so the isotropic defaults apply."""
+    assert YXPixelSize.from_value({}) == YXPixelSize.isotropic(0.1)
+
+
+def test_from_value_rejects_non_string_mapping_keys():
+    """Non-string keys (e.g. unquoted YAML numbers) fail validation, not the call."""
+    with pytest.raises(ValidationError):
+        YXPixelSize.from_value({1: 0.3})
+    with pytest.raises(ValidationError):
+        YXPixelSize.from_value({1: 0.3, "x": 0.25})
 
 
 def test_from_value_rejects_extra_keys_in_mapping():

--- a/tests/test_pixel_size.py
+++ b/tests/test_pixel_size.py
@@ -1,6 +1,8 @@
 """Tests for the YXPixelSize value type."""
 
+import numpy as np
 import pytest
+import torch
 from pydantic import ValidationError
 
 from waveorder._pixel_size import YXPixelSize
@@ -56,6 +58,28 @@ def test_from_value_rejects_unknown_type():
     """Unknown types raise a clear TypeError."""
     with pytest.raises(TypeError, match="cannot convert"):
         YXPixelSize.from_value("0.3")
+
+
+def test_from_value_accepts_numpy_scalar():
+    """from_value accepts a numpy float scalar (e.g. zarr metadata reads)."""
+    assert YXPixelSize.from_value(np.float64(0.3)) == YXPixelSize.isotropic(0.3)
+
+
+def test_from_value_accepts_zero_d_ndarray():
+    """from_value accepts a 0-d ndarray (numpy may produce these from scale reads)."""
+    assert YXPixelSize.from_value(np.array(0.3)) == YXPixelSize.isotropic(0.3)
+
+
+def test_from_value_accepts_zero_d_tensor():
+    """from_value accepts a 0-d torch tensor."""
+    p = YXPixelSize.from_value(torch.tensor(0.3, dtype=torch.float64))
+    assert p == YXPixelSize.isotropic(0.3)
+
+
+def test_from_value_rejects_multi_element_array():
+    """A 1-D or higher ndarray is not a scalar pixel size."""
+    with pytest.raises(TypeError, match="cannot convert"):
+        YXPixelSize.from_value(np.array([0.3, 0.25]))
 
 
 def test_from_value_rejects_negative_via_mapping():

--- a/tests/test_pixel_size.py
+++ b/tests/test_pixel_size.py
@@ -1,0 +1,96 @@
+"""Tests for the YXPixelSize value type."""
+
+import pytest
+from pydantic import ValidationError
+
+from waveorder._pixel_size import YXPixelSize
+
+
+def test_isotropic_constructor_sets_equal_y_and_x():
+    """Isotropic constructor produces a square YXPixelSize."""
+    p = YXPixelSize.isotropic(0.3)
+    assert p.y == 0.3
+    assert p.x == 0.3
+    assert p.is_isotropic
+
+
+def test_explicit_constructor_supports_anisotropic():
+    """Direct construction with separate y and x produces an anisotropic value."""
+    p = YXPixelSize(y=0.3, x=0.25)
+    assert p.y == 0.3
+    assert p.x == 0.25
+    assert not p.is_isotropic
+
+
+def test_from_value_passes_through_existing_yx_pixel_size():
+    """from_value returns an existing YXPixelSize unchanged."""
+    p = YXPixelSize(y=0.3, x=0.25)
+    assert YXPixelSize.from_value(p) is p
+
+
+def test_from_value_accepts_scalar_as_isotropic():
+    """from_value treats a float as isotropic spacing."""
+    p = YXPixelSize.from_value(0.3)
+    assert p == YXPixelSize.isotropic(0.3)
+
+
+def test_from_value_accepts_int_as_isotropic():
+    """from_value accepts an int scalar (numpy/yaml may yield ints)."""
+    p = YXPixelSize.from_value(1)
+    assert p == YXPixelSize.isotropic(1.0)
+
+
+def test_from_value_accepts_mapping():
+    """from_value accepts a {'y': ..., 'x': ...} mapping."""
+    p = YXPixelSize.from_value({"y": 0.3, "x": 0.25})
+    assert p == YXPixelSize(y=0.3, x=0.25)
+
+
+def test_from_value_rejects_bool():
+    """Bools are not valid pixel sizes even though they're a subclass of int."""
+    with pytest.raises(TypeError):
+        YXPixelSize.from_value(True)
+
+
+def test_from_value_rejects_unknown_type():
+    """Unknown types raise a clear TypeError."""
+    with pytest.raises(TypeError, match="cannot convert"):
+        YXPixelSize.from_value("0.3")
+
+
+def test_from_value_rejects_negative_via_mapping():
+    """Negative spacings via the mapping form fail pydantic validation."""
+    with pytest.raises(ValidationError):
+        YXPixelSize.from_value({"y": -0.1, "x": 0.1})
+
+
+def test_from_value_rejects_zero_via_scalar():
+    """Zero spacing is not a valid isotropic value."""
+    with pytest.raises(ValidationError):
+        YXPixelSize.from_value(0.0)
+
+
+def test_from_value_rejects_extra_keys_in_mapping():
+    """Unknown mapping keys are rejected by extra='forbid'."""
+    with pytest.raises(ValidationError):
+        YXPixelSize.from_value({"y": 0.3, "x": 0.25, "z": 0.5})
+
+
+def test_yx_pixel_size_is_frozen():
+    """Instances are immutable; cannot mutate y or x after construction."""
+    p = YXPixelSize(y=0.3, x=0.25)
+    with pytest.raises(ValidationError):
+        p.y = 0.5  # type: ignore[misc]
+
+
+def test_equality_is_value_based():
+    """Two YXPixelSize with the same y and x compare equal."""
+    assert YXPixelSize(y=0.3, x=0.25) == YXPixelSize(y=0.3, x=0.25)
+    assert YXPixelSize.isotropic(0.3) == YXPixelSize(y=0.3, x=0.3)
+    assert YXPixelSize.isotropic(0.3) != YXPixelSize(y=0.3, x=0.25)
+
+
+def test_is_isotropic_distinguishes_equal_and_unequal():
+    """is_isotropic returns True only when y == x exactly."""
+    assert YXPixelSize.isotropic(0.3).is_isotropic
+    assert not YXPixelSize(y=0.3, x=0.3 + 1e-12).is_isotropic

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,6 +2,7 @@ import pytest
 import torch
 
 from waveorder import util
+from waveorder._pixel_size import YXPixelSize
 
 
 def test_gen_coordinate():
@@ -10,6 +11,71 @@ def test_gen_coordinate():
 
     assert frr.shape == YX_shape
     assert frr[0, 0] == 0
+
+
+def test_generate_frequencies_scalar_and_isotropic_model_agree():
+    """A scalar pixel size produces identical fyy, fxx to YXPixelSize.isotropic."""
+    shape = (16, 12)
+    fyy_a, fxx_a = util.generate_frequencies(shape, 0.3)
+    fyy_b, fxx_b = util.generate_frequencies(shape, YXPixelSize.isotropic(0.3))
+    assert torch.equal(fyy_a, fyy_b)
+    assert torch.equal(fxx_a, fxx_b)
+
+
+def test_generate_frequencies_anisotropic_uses_separate_spacings():
+    """fyy uses y spacing, fxx uses x spacing when y != x."""
+    Ny, Nx = 16, 12
+    y_ps, x_ps = 0.3, 0.2
+    fyy, fxx = util.generate_frequencies((Ny, Nx), YXPixelSize(y=y_ps, x=x_ps))
+    expected_fy = torch.fft.fftfreq(Ny, y_ps)
+    expected_fx = torch.fft.fftfreq(Nx, x_ps)
+    assert torch.equal(fyy[:, 0], expected_fy)
+    assert torch.equal(fxx[0, :], expected_fx)
+
+
+def test_generate_radial_frequencies_anisotropic_matches_sqrt_of_components():
+    """Radial magnitude equals sqrt(fy^2 + fx^2) of the anisotropic grids."""
+    shape = (16, 12)
+    ps = YXPixelSize(y=0.3, x=0.2)
+    frr = util.generate_radial_frequencies(shape, ps)
+    fyy, fxx = util.generate_frequencies(shape, ps)
+    assert torch.allclose(frr, torch.sqrt(fyy**2 + fxx**2))
+
+
+def test_generate_radial_frequencies_scalar_equivalence():
+    """Scalar input matches isotropic YXPixelSize input."""
+    shape = (10, 14)
+    frr_scalar = util.generate_radial_frequencies(shape, 0.5)
+    frr_model = util.generate_radial_frequencies(shape, YXPixelSize.isotropic(0.5))
+    assert torch.equal(frr_scalar, frr_model)
+
+
+def test_generate_sphere_target_isotropic_equivalence():
+    """Sphere generated with scalar pixel size matches isotropic YXPixelSize."""
+    a = util.generate_sphere_target((8, 16, 16), 0.3, 0.5, radius=1.5)
+    b = util.generate_sphere_target((8, 16, 16), YXPixelSize.isotropic(0.3), 0.5, radius=1.5)
+    for ta, tb in zip(a, b):
+        assert torch.allclose(ta, tb)
+
+
+def test_generate_sphere_target_anisotropic_runs():
+    """Anisotropic sphere generation runs and produces finite output."""
+    sphere, _azimuth, _inc_angle = util.generate_sphere_target((8, 16, 16), YXPixelSize(y=0.3, x=0.2), 0.5, radius=1.5)
+    assert torch.isfinite(sphere).all()
+    assert sphere.shape == (8, 16, 16)
+    assert sphere.max() > 0
+
+
+def test_gen_coordinate_anisotropic_uses_separate_spacings():
+    """gen_coordinate frequency grids respect y, x spacing under anisotropic input."""
+    Ny, Nx = 8, 6
+    y_ps, x_ps = 0.3, 0.2
+    _xx, _yy, fxx, fyy = util.gen_coordinate((Ny, Nx), YXPixelSize(y=y_ps, x=x_ps))
+    expected_fy = torch.fft.fftfreq(Ny, y_ps)
+    expected_fx = torch.fft.fftfreq(Nx, x_ps)
+    # gen_coordinate uses indexing="xy"; fxx varies along axis 1, fyy along 0.
+    assert torch.allclose(fxx[0, :], expected_fx)
+    assert torch.allclose(fyy[:, 0], expected_fy)
 
 
 # test util.pad_zyx function

--- a/waveorder/_pixel_size.py
+++ b/waveorder/_pixel_size.py
@@ -26,8 +26,8 @@ class YXPixelSize(BaseModel):
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    y: PositiveFloat = Field(description="pixel size along y in micrometers")
-    x: PositiveFloat = Field(description="pixel size along x in micrometers")
+    y: PositiveFloat = Field(default=0.1, description="pixel size along y in micrometers")
+    x: PositiveFloat = Field(default=0.1, description="pixel size along x in micrometers")
 
     @classmethod
     def isotropic(cls, value: float) -> YXPixelSize:

--- a/waveorder/_pixel_size.py
+++ b/waveorder/_pixel_size.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field, PositiveFloat
+from pydantic import BaseModel, ConfigDict, Field, PositiveFloat, model_serializer
 
 
 class YXPixelSize(BaseModel):
@@ -77,3 +77,14 @@ class YXPixelSize(BaseModel):
     def is_isotropic(self) -> bool:
         """True if y and x spacings are equal."""
         return self.y == self.x
+
+    @model_serializer
+    def _serialize(self):
+        """Serialize as a scalar when isotropic, else as ``{'y': ..., 'x': ...}``.
+
+        Both forms round-trip through :meth:`from_value`, so YAML configs
+        for square pixels stay readable as a single number.
+        """
+        if self.y == self.x:
+            return self.y
+        return {"y": self.y, "x": self.x}

--- a/waveorder/_pixel_size.py
+++ b/waveorder/_pixel_size.py
@@ -1,0 +1,79 @@
+"""Lateral pixel size value type, supporting isotropic and anisotropic yx."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, PositiveFloat
+
+
+class YXPixelSize(BaseModel):
+    """Lateral pixel size in micrometers, possibly anisotropic.
+
+    Use :meth:`isotropic` for square pixels, or :meth:`from_value` to
+    normalize either a scalar, a mapping, or an existing YXPixelSize
+    into a :class:`YXPixelSize`. The ``from_value`` constructor is the
+    intended entry point for internal functions that accept either a
+    plain float (treated as isotropic) or this model.
+
+    Attributes
+    ----------
+    y : float
+        Pixel size along the y axis in micrometers.
+    x : float
+        Pixel size along the x axis in micrometers.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    y: PositiveFloat = Field(description="pixel size along y in micrometers")
+    x: PositiveFloat = Field(description="pixel size along x in micrometers")
+
+    @classmethod
+    def isotropic(cls, value: float) -> YXPixelSize:
+        """Construct a YXPixelSize with equal y and x spacing.
+
+        Parameters
+        ----------
+        value : float
+            Pixel size in micrometers, applied to both y and x.
+        """
+        return cls(y=value, x=value)
+
+    @classmethod
+    def from_value(cls, value: Any) -> YXPixelSize:
+        """Normalize a scalar, mapping, or YXPixelSize into a YXPixelSize.
+
+        Parameters
+        ----------
+        value : float or dict or YXPixelSize
+            Scalar (isotropic shorthand), mapping with keys ``y`` and ``x``,
+            or an existing YXPixelSize (returned unchanged).
+
+        Returns
+        -------
+        YXPixelSize
+            The normalized value.
+
+        Raises
+        ------
+        TypeError
+            If ``value`` is not one of the accepted forms.
+        """
+        if isinstance(value, cls):
+            return value
+        if isinstance(value, bool):
+            raise TypeError("cannot convert bool to YXPixelSize")
+        if isinstance(value, (int, float)):
+            return cls.isotropic(float(value))
+        if isinstance(value, dict):
+            return cls(**value)
+        raise TypeError(
+            f"cannot convert {type(value).__name__} to YXPixelSize; "
+            "expected float, mapping with keys 'y' and 'x', or YXPixelSize"
+        )
+
+    @property
+    def is_isotropic(self) -> bool:
+        """True if y and x spacings are equal."""
+        return self.y == self.x

--- a/waveorder/_pixel_size.py
+++ b/waveorder/_pixel_size.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field, PositiveFloat, model_serializer
+from pydantic import BaseModel, ConfigDict, Field, PositiveFloat, model_serializer, model_validator
 
 
 class YXPixelSize(BaseModel):
@@ -26,8 +26,24 @@ class YXPixelSize(BaseModel):
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    y: PositiveFloat = Field(default=0.1, description="pixel size along y in micrometers")
-    x: PositiveFloat = Field(default=0.1, description="pixel size along x in micrometers")
+    y: PositiveFloat = Field(default=0.1, allow_inf_nan=False, description="pixel size along y in micrometers")
+    x: PositiveFloat = Field(default=0.1, allow_inf_nan=False, description="pixel size along x in micrometers")
+
+    @model_validator(mode="before")
+    @classmethod
+    def _require_both_axes(cls, data: Any) -> Any:
+        """Reject a mapping that names one axis but not the other.
+
+        The fields carry defaults so the napari plugin can seed its form
+        widgets, but a config that spells out one axis is a mistake rather
+        than a request for the default on the other.
+        """
+        if isinstance(data, dict):
+            given = {"y", "x"} & set(data)
+            if given and len(given) == 1:
+                missing = ({"y", "x"} - given).pop()
+                raise ValueError(f"anisotropic yx_pixel_size needs both 'y' and 'x'; {missing!r} is missing")
+        return data
 
     @classmethod
     def isotropic(cls, value: float) -> YXPixelSize:
@@ -46,7 +62,7 @@ class YXPixelSize(BaseModel):
 
         Accepts any float-castable scalar (Python ``float`` / ``int``, numpy
         scalars, 0-d ``ndarray``, 0-d tensors with ``__float__``), a mapping
-        with keys ``y`` and ``x``, or an existing :class:`YXPixelSize`.
+        with both keys ``y`` and ``x``, or an existing :class:`YXPixelSize`.
 
         Parameters
         ----------
@@ -61,24 +77,26 @@ class YXPixelSize(BaseModel):
 
         Raises
         ------
-        TypeError
-            If ``value`` is not one of the accepted forms.
+        ValueError
+            If ``value`` is not one of the accepted forms. Pydantic converts
+            ``ValueError`` into a ``ValidationError``, so callers validating a
+            model see a field error rather than an escaping exception.
         """
         if isinstance(value, cls):
             return value
         if isinstance(value, bool):
-            raise TypeError("cannot convert bool to YXPixelSize")
+            raise ValueError("cannot convert bool to YXPixelSize")
         if isinstance(value, str):
-            raise TypeError("cannot convert str to YXPixelSize")
+            raise ValueError("cannot convert str to YXPixelSize")
         if isinstance(value, dict):
-            return cls(**value)
+            return cls.model_validate(value)
         # Accept any float-castable scalar: Python numbers, numpy scalars,
         # 0-d ndarrays, 0-d tensors. ``float()`` raises TypeError for
         # multi-element arrays and non-numeric inputs.
         try:
             as_float = float(value)
         except (TypeError, ValueError):
-            raise TypeError(
+            raise ValueError(
                 f"cannot convert {type(value).__name__} to YXPixelSize; "
                 "expected float, mapping with keys 'y' and 'x', or YXPixelSize"
             ) from None
@@ -96,6 +114,6 @@ class YXPixelSize(BaseModel):
         Both forms round-trip through :meth:`from_value`, so YAML configs
         for square pixels stay readable as a single number.
         """
-        if self.y == self.x:
+        if self.is_isotropic:
             return self.y
         return {"y": self.y, "x": self.x}

--- a/waveorder/_pixel_size.py
+++ b/waveorder/_pixel_size.py
@@ -44,9 +44,13 @@ class YXPixelSize(BaseModel):
     def from_value(cls, value: Any) -> YXPixelSize:
         """Normalize a scalar, mapping, or YXPixelSize into a YXPixelSize.
 
+        Accepts any float-castable scalar (Python ``float`` / ``int``, numpy
+        scalars, 0-d ``ndarray``, 0-d tensors with ``__float__``), a mapping
+        with keys ``y`` and ``x``, or an existing :class:`YXPixelSize`.
+
         Parameters
         ----------
-        value : float or dict or YXPixelSize
+        value : float-like, dict, or YXPixelSize
             Scalar (isotropic shorthand), mapping with keys ``y`` and ``x``,
             or an existing YXPixelSize (returned unchanged).
 
@@ -64,14 +68,21 @@ class YXPixelSize(BaseModel):
             return value
         if isinstance(value, bool):
             raise TypeError("cannot convert bool to YXPixelSize")
-        if isinstance(value, (int, float)):
-            return cls.isotropic(float(value))
+        if isinstance(value, str):
+            raise TypeError("cannot convert str to YXPixelSize")
         if isinstance(value, dict):
             return cls(**value)
-        raise TypeError(
-            f"cannot convert {type(value).__name__} to YXPixelSize; "
-            "expected float, mapping with keys 'y' and 'x', or YXPixelSize"
-        )
+        # Accept any float-castable scalar: Python numbers, numpy scalars,
+        # 0-d ndarrays, 0-d tensors. ``float()`` raises TypeError for
+        # multi-element arrays and non-numeric inputs.
+        try:
+            as_float = float(value)
+        except (TypeError, ValueError):
+            raise TypeError(
+                f"cannot convert {type(value).__name__} to YXPixelSize; "
+                "expected float, mapping with keys 'y' and 'x', or YXPixelSize"
+            ) from None
+        return cls.isotropic(as_float)
 
     @property
     def is_isotropic(self) -> bool:

--- a/waveorder/api/_settings.py
+++ b/waveorder/api/_settings.py
@@ -12,9 +12,12 @@ from pydantic import (
     NonNegativeFloat,
     NonNegativeInt,
     PositiveFloat,
+    field_serializer,
+    field_validator,
     model_validator,
 )
 
+from waveorder._pixel_size import YXPixelSize
 from waveorder.optim._types import OptimizableFloat
 
 
@@ -34,7 +37,10 @@ class WavelengthIllumination(MyBaseModel):
 
 
 class FourierTransferFunctionSettings(MyBaseModel):
-    yx_pixel_size: PositiveFloat = Field(default=0.1, description="lateral pixel size in micrometers")
+    yx_pixel_size: YXPixelSize = Field(
+        default_factory=lambda: YXPixelSize.isotropic(0.1),
+        description="lateral pixel size in micrometers; scalar for isotropic, or {y, x} mapping for anisotropic",
+    )
     z_pixel_size: PositiveFloat = Field(default=0.25, description="axial pixel size in micrometers")
     z_padding: NonNegativeInt = Field(default=0, description="z slices to pad for axial boundary effects")
     z_focus_offset: float = Field(
@@ -45,6 +51,17 @@ class FourierTransferFunctionSettings(MyBaseModel):
     numerical_aperture_detection: PositiveFloat = Field(
         default=1.2, description="detection objective numerical aperture"
     )
+
+    @field_validator("yx_pixel_size", mode="before")
+    @classmethod
+    def _normalize_yx_pixel_size(cls, v):
+        return YXPixelSize.from_value(v)
+
+    @field_serializer("yx_pixel_size")
+    def _serialize_yx_pixel_size(self, value):
+        # Robust to model_copy(update={...}) which can leave a scalar in
+        # place of a YXPixelSize; normalize before dumping.
+        return YXPixelSize.from_value(value).model_dump()
 
     @model_validator(mode="after")
     def validate_numerical_aperture_detection(self):
@@ -57,12 +74,16 @@ class FourierTransferFunctionSettings(MyBaseModel):
 
     @model_validator(mode="after")
     def warn_pixel_size_consistency(self):
-        ratio = self.yx_pixel_size / self.z_pixel_size
-        if ratio < 1.0 / 20 or ratio > 20:
-            warnings.warn(
-                f"yx_pixel_size ({self.yx_pixel_size}) / z_pixel_size ({self.z_pixel_size}) = {ratio}. Did you use consistent units?",
-                UserWarning,
-            )
+        # Normalize defensively so model_copy(update={"yx_pixel_size": 0.2}),
+        # which bypasses field validators, still produces a usable value.
+        yx = YXPixelSize.from_value(self.yx_pixel_size)
+        for axis, ps in (("y", yx.y), ("x", yx.x)):
+            ratio = ps / self.z_pixel_size
+            if ratio < 1.0 / 20 or ratio > 20:
+                warnings.warn(
+                    f"{axis}_pixel_size ({ps}) / z_pixel_size ({self.z_pixel_size}) = {ratio}. Did you use consistent units?",
+                    UserWarning,
+                )
         return self
 
 

--- a/waveorder/api/birefringence_and_phase.py
+++ b/waveorder/api/birefringence_and_phase.py
@@ -12,6 +12,7 @@ import numpy as np
 import torch
 import xarray as xr
 
+from waveorder._pixel_size import YXPixelSize
 from waveorder.api import birefringence, phase
 from waveorder.api._utils import (
     _biref_inverse_kwargs,
@@ -81,6 +82,13 @@ def simulate(
     Z, Y, X = zyx_shape
     yx_shape = (Y, X)
     s = settings_phase.transfer_function
+    yx_pixel_size = YXPixelSize.from_value(s.yx_pixel_size)
+    if not yx_pixel_size.is_isotropic:
+        raise NotImplementedError(
+            "Anisotropic yx_pixel_size is not supported by the combined "
+            "birefringence + phase reconstruction. Pass an isotropic "
+            "yx_pixel_size."
+        )
 
     # --- 2D star phantom (birefringence + phase) ---
     retardance, orientation, transmittance, depolarization = inplane_oriented_thick_pol3d.generate_test_phantom(
@@ -193,8 +201,8 @@ def simulate(
     # --- Build phantom (all properties localized to central slices) ---
     zyx_coords = {
         "z": np.arange(Z) * s.z_pixel_size,
-        "y": np.arange(Y) * s.yx_pixel_size,
-        "x": np.arange(X) * s.yx_pixel_size,
+        "y": np.arange(Y) * yx_pixel_size.y,
+        "x": np.arange(X) * yx_pixel_size.x,
     }
 
     zyx_ret = np.zeros((Z, Y, X), dtype=np.float32)

--- a/waveorder/api/fluorescence.py
+++ b/waveorder/api/fluorescence.py
@@ -10,6 +10,7 @@ import torch
 import xarray as xr
 from pydantic import Field, PositiveFloat, model_validator
 
+from waveorder._pixel_size import YXPixelSize
 from waveorder.api._settings import (
     FourierApplyInverseSettings,
     MyBaseModel,
@@ -104,23 +105,24 @@ def simulate(
         settings = Settings()
 
     s = settings.transfer_function.resolve_floats()
+    yx_pixel_size = YXPixelSize.from_value(s.yx_pixel_size)
     Z, Y, X = zyx_shape
     zyx_coords = {
         "z": np.arange(Z) * s.z_pixel_size,
-        "y": np.arange(Y) * s.yx_pixel_size,
-        "x": np.arange(X) * s.yx_pixel_size,
+        "y": np.arange(Y) * yx_pixel_size.y,
+        "x": np.arange(X) * yx_pixel_size.x,
     }
 
     if recon_dim == 3:
         zyx_fluorescence = isotropic_fluorescent_thick_3d.generate_test_phantom(
             zyx_shape,
-            s.yx_pixel_size,
+            yx_pixel_size,
             s.z_pixel_size,
             sphere_radius=sphere_radius,
         )
         otf = isotropic_fluorescent_thick_3d.calculate_transfer_function(
             zyx_shape,
-            s.yx_pixel_size,
+            yx_pixel_size,
             s.z_pixel_size,
             wavelength_emission=s.wavelength_emission,
             z_padding=0,

--- a/waveorder/api/fluorescence.py
+++ b/waveorder/api/fluorescence.py
@@ -222,6 +222,7 @@ def compute_transfer_function(
             wavelength_emission=s.wavelength_emission,
             index_of_refraction_media=s.index_of_refraction_media,
             numerical_aperture_detection=s.numerical_aperture_detection,
+            confocal_pinhole_diameter=s.confocal_pinhole_diameter,
         )
         U, S, Vh = isotropic_fluorescent_thin_3d.calculate_singular_system(fluorescent_tf)
 
@@ -242,6 +243,7 @@ def compute_transfer_function(
             z_padding=s.z_padding,
             index_of_refraction_media=s.index_of_refraction_media,
             numerical_aperture_detection=s.numerical_aperture_detection,
+            confocal_pinhole_diameter=s.confocal_pinhole_diameter,
         )
 
         return xr.Dataset(

--- a/waveorder/api/fluorescence.py
+++ b/waveorder/api/fluorescence.py
@@ -49,12 +49,16 @@ class TransferFunctionSettings(OptimizableFourierTransferFunctionSettings):
 
     @model_validator(mode="after")
     def warn_wavelength_consistency(self):
-        ratio = self.yx_pixel_size / self.wavelength_emission
-        if ratio < 1.0 / 20 or ratio > 20:
-            warnings.warn(
-                f"yx_pixel_size ({self.yx_pixel_size}) / wavelength_emission ({self.wavelength_emission}) = {ratio}. Did you use consistent units?",
-                UserWarning,
-            )
+        # Normalize defensively for the model_copy(update=...) path that
+        # bypasses field validators.
+        yx = YXPixelSize.from_value(self.yx_pixel_size)
+        for axis, ps in (("y", yx.y), ("x", yx.x)):
+            ratio = ps / self.wavelength_emission
+            if ratio < 1.0 / 20 or ratio > 20:
+                warnings.warn(
+                    f"{axis}_pixel_size ({ps}) / wavelength_emission ({self.wavelength_emission}) = {ratio}. Did you use consistent units?",
+                    UserWarning,
+                )
         return self
 
 

--- a/waveorder/api/phase.py
+++ b/waveorder/api/phase.py
@@ -10,6 +10,7 @@ import xarray as xr
 from pydantic import Field, NonNegativeFloat, model_validator
 
 from waveorder import optics, util
+from waveorder._pixel_size import YXPixelSize
 from waveorder.api._settings import (
     FourierApplyInverseSettings,
     MyBaseModel,
@@ -108,17 +109,18 @@ def simulate(
         settings = Settings()
 
     s = settings.transfer_function.resolve_floats()
+    yx_pixel_size = YXPixelSize.from_value(s.yx_pixel_size)
     Z, Y, X = zyx_shape
     zyx_coords = {
         "z": np.arange(Z) * s.z_pixel_size,
-        "y": np.arange(Y) * s.yx_pixel_size,
-        "x": np.arange(X) * s.yx_pixel_size,
+        "y": np.arange(Y) * yx_pixel_size.y,
+        "x": np.arange(X) * yx_pixel_size.x,
     }
 
     if recon_dim == 3:
         zyx_phase = phase_thick_3d.generate_test_phantom(
             zyx_shape,
-            s.yx_pixel_size,
+            yx_pixel_size,
             s.z_pixel_size,
             wavelength_illumination=s.wavelength_illumination,
             index_of_refraction_media=s.index_of_refraction_media,
@@ -127,7 +129,7 @@ def simulate(
         )
         real_tf, _ = phase_thick_3d.calculate_transfer_function(
             zyx_shape,
-            s.yx_pixel_size,
+            yx_pixel_size,
             s.z_pixel_size,
             wavelength_illumination=s.wavelength_illumination,
             z_padding=0,

--- a/waveorder/cli/apply_inverse_transfer_function.py
+++ b/waveorder/cli/apply_inverse_transfer_function.py
@@ -5,6 +5,7 @@ from typing import Literal
 
 import click
 
+from waveorder._pixel_size import YXPixelSize
 from waveorder.cli.parsing import (
     config_filepath,
     input_position_dirpaths,
@@ -118,18 +119,23 @@ def _warn_pixel_size_mismatch(input_scale, config_pixel_sizes):
     ----------
     input_scale : tuple[float, ...]
         TCZYX scale from the input dataset.
-    config_pixel_sizes : tuple[float, float]
-        (z_pixel_size, yx_pixel_size) from the reconstruction config.
+    config_pixel_sizes : tuple[float, YXPixelSize]
+        (z_pixel_size, yx_pixel_size) from the reconstruction config. The
+        lateral entry is a :class:`YXPixelSize` with ``.y`` and ``.x``
+        spacings.
     """
     rel_tol = 0.05
     z_pixel_size, yx_pixel_size = config_pixel_sizes
-    _, _, z_scale, yx_scale, _ = input_scale
+    yx_pixel_size = YXPixelSize.from_value(yx_pixel_size)
+    _, _, z_scale, y_scale, x_scale = input_scale
 
     mismatches = []
     if not math.isclose(z_scale, z_pixel_size, rel_tol=rel_tol):
         mismatches.append(f"  z: input={z_scale}, config={z_pixel_size}")
-    if not math.isclose(yx_scale, yx_pixel_size, rel_tol=rel_tol):
-        mismatches.append(f"  yx: input={yx_scale}, config={yx_pixel_size}")
+    if not math.isclose(y_scale, yx_pixel_size.y, rel_tol=rel_tol):
+        mismatches.append(f"  y: input={y_scale}, config={yx_pixel_size.y}")
+    if not math.isclose(x_scale, yx_pixel_size.x, rel_tol=rel_tol):
+        mismatches.append(f"  x: input={x_scale}, config={yx_pixel_size.x}")
 
     if mismatches:
         detail = "\n".join(mismatches)
@@ -184,7 +190,8 @@ def get_reconstruction_output_metadata(
     if config_pixel_sizes is not None:
         if write_config_scale_to_output:
             z_pixel_size, yx_pixel_size = config_pixel_sizes
-            scale = (scale[0], scale[1], z_pixel_size, yx_pixel_size, yx_pixel_size)
+            yx_pixel_size = YXPixelSize.from_value(yx_pixel_size)
+            scale = (scale[0], scale[1], z_pixel_size, yx_pixel_size.y, yx_pixel_size.x)
         else:
             _warn_pixel_size_mismatch(scale, config_pixel_sizes)
 

--- a/waveorder/models/inplane_oriented_thick_pol3d_vector.py
+++ b/waveorder/models/inplane_oriented_thick_pol3d_vector.py
@@ -6,6 +6,7 @@ from torch import Tensor
 from torch.nn.functional import avg_pool3d
 
 from waveorder import optics, sampling, stokes, util
+from waveorder._pixel_size import YXPixelSize
 from waveorder.filter import apply_filter_bank
 from waveorder.visuals.napari_visuals import add_transfer_function_to_viewer
 
@@ -45,6 +46,15 @@ def calculate_transfer_function(
     if z_padding != 0:
         raise NotImplementedError("Padding not implemented for this model")
 
+    yx_pixel_size = YXPixelSize.from_value(yx_pixel_size)
+    if not yx_pixel_size.is_isotropic:
+        raise NotImplementedError(
+            "Anisotropic yx_pixel_size is not supported by the birefringence "
+            "vector model. Pass an isotropic yx_pixel_size or use a phase-only "
+            "or fluorescence-only reconstruction."
+        )
+    yx_pixel_size_scalar = yx_pixel_size.y
+
     transverse_nyquist = sampling.transverse_nyquist(
         wavelength_illumination,
         numerical_aperture_illumination,
@@ -56,7 +66,7 @@ def calculate_transfer_function(
         index_of_refraction_media,
     )
 
-    yx_factor = int(np.ceil(yx_pixel_size / transverse_nyquist))
+    yx_factor = int(np.ceil(yx_pixel_size_scalar / transverse_nyquist))
     z_factor = int(np.ceil(z_pixel_size / axial_nyquist))
 
     tf_calculation_shape = (
@@ -72,7 +82,7 @@ def calculate_transfer_function(
         swing,
         scheme,
         tf_calculation_shape,
-        yx_pixel_size / yx_factor,
+        yx_pixel_size_scalar / yx_factor,
         z_pixel_size / z_factor,
         wavelength_illumination,
         z_padding,

--- a/waveorder/models/isotropic_fluorescent_thick_3d.py
+++ b/waveorder/models/isotropic_fluorescent_thick_3d.py
@@ -5,6 +5,7 @@ import torch
 from torch import Tensor
 
 from waveorder import optics, sampling, util
+from waveorder._pixel_size import YXPixelSize
 from waveorder.reconstruct import tikhonov_regularized_inverse_filter
 from waveorder.visuals.napari_visuals import add_transfer_function_to_viewer
 
@@ -79,16 +80,18 @@ def calculate_transfer_function(
         transverse_nyquist = transverse_nyquist / 2
         axial_nyquist = axial_nyquist / 2
 
-    yx_factor = int(np.ceil(yx_pixel_size / transverse_nyquist))
+    yx_pixel_size = YXPixelSize.from_value(yx_pixel_size)
+    y_factor = int(np.ceil(yx_pixel_size.y / transverse_nyquist))
+    x_factor = int(np.ceil(yx_pixel_size.x / transverse_nyquist))
     z_factor = int(np.ceil(z_pixel_size / axial_nyquist))
 
     optical_transfer_function = _calculate_wrap_unsafe_transfer_function(
         (
             zyx_shape[0] * z_factor,
-            zyx_shape[1] * yx_factor,
-            zyx_shape[2] * yx_factor,
+            zyx_shape[1] * y_factor,
+            zyx_shape[2] * x_factor,
         ),
-        yx_pixel_size / yx_factor,
+        YXPixelSize(y=yx_pixel_size.y / y_factor, x=yx_pixel_size.x / x_factor),
         z_pixel_size / z_factor,
         wavelength_emission,
         z_padding,

--- a/waveorder/models/isotropic_fluorescent_thin_3d.py
+++ b/waveorder/models/isotropic_fluorescent_thin_3d.py
@@ -7,6 +7,7 @@ import torch
 from torch import Tensor
 
 from waveorder import optics, sampling, util
+from waveorder._pixel_size import YXPixelSize
 from waveorder.filter import apply_filter_bank
 
 
@@ -31,12 +32,13 @@ def generate_test_phantom(
     Tensor
         YX fluorescence density map
     """
+    yx_pixel_size = YXPixelSize.from_value(yx_pixel_size)
     sphere, _, _ = util.generate_sphere_target(
         (3,) + yx_shape,
         yx_pixel_size,
         z_pixel_size=1.0,
         radius=sphere_radius,
-        blur_size=2 * yx_pixel_size,
+        blur_size=2 * min(yx_pixel_size.y, yx_pixel_size.x),
     )
 
     # Use middle slice as thin fluorescent object
@@ -89,19 +91,22 @@ def calculate_transfer_function(
     # Extract float value for Nyquist computation (not in gradient chain)
     na_det_val = float(torch.as_tensor(numerical_aperture_detection).detach())
 
+    yx_pixel_size = YXPixelSize.from_value(yx_pixel_size)
+
     transverse_nyquist = sampling.transverse_nyquist(
         wavelength_emission,
         na_det_val,  # ill = det for fluorescence
         na_det_val,
     )
-    yx_factor = int(np.ceil(yx_pixel_size / transverse_nyquist))
+    y_factor = int(np.ceil(yx_pixel_size.y / transverse_nyquist))
+    x_factor = int(np.ceil(yx_pixel_size.x / transverse_nyquist))
 
     fluorescent_2d_to_3d_transfer_function = _calculate_wrap_unsafe_transfer_function(
         (
-            yx_shape[0] * yx_factor,
-            yx_shape[1] * yx_factor,
+            yx_shape[0] * y_factor,
+            yx_shape[1] * x_factor,
         ),
-        yx_pixel_size / yx_factor,
+        YXPixelSize(y=yx_pixel_size.y / y_factor, x=yx_pixel_size.x / x_factor),
         z_position_list,
         wavelength_emission,
         index_of_refraction_media,

--- a/waveorder/models/isotropic_thin_3d.py
+++ b/waveorder/models/isotropic_thin_3d.py
@@ -8,6 +8,7 @@ import torch
 from torch import Tensor
 
 from waveorder import optics, sampling, util
+from waveorder._pixel_size import YXPixelSize
 from waveorder.filter import apply_filter_bank
 
 
@@ -19,12 +20,13 @@ def generate_test_phantom(
     index_of_refraction_sample: float,
     sphere_radius: float,
 ) -> Tuple[Tensor, Tensor]:
+    yx_pixel_size = YXPixelSize.from_value(yx_pixel_size)
     sphere, _, _ = util.generate_sphere_target(
         (3,) + yx_shape,
         yx_pixel_size,
         z_pixel_size=1.0,
         radius=sphere_radius,
-        blur_size=2 * yx_pixel_size,
+        blur_size=2 * min(yx_pixel_size.y, yx_pixel_size.x),
     )
     yx_phase = (
         sphere[1] * (index_of_refraction_sample - index_of_refraction_media) * 0.1 / wavelength_illumination
@@ -88,22 +90,25 @@ def calculate_transfer_function(
     na_ill_val = float(torch.as_tensor(numerical_aperture_illumination).detach())
     na_det_val = float(torch.as_tensor(numerical_aperture_detection).detach())
 
+    yx_pixel_size = YXPixelSize.from_value(yx_pixel_size)
+
     transverse_nyquist = sampling.transverse_nyquist(
         wavelength_illumination,
         na_ill_val,
         na_det_val,
     )
-    yx_factor = int(np.ceil(yx_pixel_size / transverse_nyquist))
+    y_factor = int(np.ceil(yx_pixel_size.y / transverse_nyquist))
+    x_factor = int(np.ceil(yx_pixel_size.x / transverse_nyquist))
 
     (
         absorption_2d_to_3d_transfer_function,
         phase_2d_to_3d_transfer_function,
     ) = _calculate_wrap_unsafe_transfer_function(
         (
-            yx_shape[0] * yx_factor,
-            yx_shape[1] * yx_factor,
+            yx_shape[0] * y_factor,
+            yx_shape[1] * x_factor,
         ),
-        yx_pixel_size / yx_factor,
+        YXPixelSize(y=yx_pixel_size.y / y_factor, x=yx_pixel_size.x / x_factor),
         z_position_list,
         wavelength_illumination,
         index_of_refraction_media,

--- a/waveorder/models/phase_thick_3d.py
+++ b/waveorder/models/phase_thick_3d.py
@@ -7,6 +7,7 @@ import torch
 from torch import Tensor
 
 from waveorder import optics, sampling, util
+from waveorder._pixel_size import YXPixelSize
 from waveorder.models import isotropic_fluorescent_thick_3d
 from waveorder.reconstruct import tikhonov_regularized_inverse_filter
 from waveorder.visuals.napari_visuals import add_transfer_function_to_viewer
@@ -100,12 +101,13 @@ def generate_test_phantom(
         acquires when passing through that voxel. This matches the units
         returned by apply_inverse_transfer_function().
     """
+    yx_pixel_size = YXPixelSize.from_value(yx_pixel_size)
     sphere, _, _ = util.generate_sphere_target(
         zyx_shape,
         yx_pixel_size,
         z_pixel_size,
         radius=sphere_radius,
-        blur_size=2 * yx_pixel_size,
+        blur_size=2 * min(yx_pixel_size.y, yx_pixel_size.x),
     )
 
     # Compute refractive index difference
@@ -171,20 +173,25 @@ def calculate_transfer_function(
     zen = _to_batch(tilt_angle_zenith)
     azi = _to_batch(tilt_angle_azimuth)
 
-    # Nyquist upsampling
+    yx_pixel_size = YXPixelSize.from_value(yx_pixel_size)
+
+    # Nyquist upsampling, computed independently for y and x so that anisotropic
+    # spacing is upsampled by an axis-specific factor.
     na_ill_0 = float(na_ill[0])
     na_det_0 = float(na_det[0])
-    yx_factor = int(np.ceil(yx_pixel_size / sampling.transverse_nyquist(wavelength_illumination, na_ill_0, na_det_0)))
+    transverse_nyquist = sampling.transverse_nyquist(wavelength_illumination, na_ill_0, na_det_0)
+    y_factor = int(np.ceil(yx_pixel_size.y / transverse_nyquist))
+    x_factor = int(np.ceil(yx_pixel_size.x / transverse_nyquist))
     z_factor = int(
         np.ceil(z_pixel_size / sampling.axial_nyquist(wavelength_illumination, na_det_0, index_of_refraction_media))
     )
 
     up_shape = (
         zyx_shape[0] * z_factor,
-        zyx_shape[1] * yx_factor,
-        zyx_shape[2] * yx_factor,
+        zyx_shape[1] * y_factor,
+        zyx_shape[2] * x_factor,
     )
-    up_yx = yx_pixel_size / yx_factor
+    up_yx = YXPixelSize(y=yx_pixel_size.y / y_factor, x=yx_pixel_size.x / x_factor)
     up_z = z_pixel_size / z_factor
     zyx_out_shape = (zyx_shape[0] + 2 * z_padding,) + zyx_shape[1:]
 

--- a/waveorder/optics.py
+++ b/waveorder/optics.py
@@ -172,7 +172,9 @@ def generate_tilted_pupil(
     tilt_angle_azimuth : float or Tensor
         Azimuth angle (radians) of the tilt direction in the xy-plane.
     slope : float
-        Sigmoid roll-off in units of pixels (~90% change per `slope` pixels).
+        Sigmoid roll-off in units of frequency-grid steps (~90% change per
+        `slope` steps). When y and x sampling differ, the finer of the two
+        steps sets the width, so the roll-off matches along both axes.
 
     Returns
     -------
@@ -192,7 +194,7 @@ def generate_tilted_pupil(
 
     # Grid-derived quantities don't need gradients
     with torch.no_grad():
-        df = torch.abs(fxx[0, 1] - fxx[0, 0])
+        df = torch.min(torch.abs(fxx[0, 1] - fxx[0, 0]), torch.abs(fyy[1, 0] - fyy[0, 0]))
         pixel_slope = slope / df
         fz_sq = K**2 - fxx**2 - fyy**2
         inside_sphere = (fz_sq >= 0).to(fxx.dtype)

--- a/waveorder/util.py
+++ b/waveorder/util.py
@@ -8,6 +8,7 @@ import torch
 from numpy.fft import fft, fft2, fftn, fftshift, ifft, ifftn, ifftshift
 from scipy.ndimage import uniform_filter
 
+from ._pixel_size import YXPixelSize
 from .optics import scattering_potential_tensor_to_3D_orientation_PN
 
 numbers = re.compile(r"(\d+)")
@@ -213,44 +214,37 @@ def genStarTarget_3D(
 
 
 def generate_sphere_target(zyx_shape, yx_pixel_size, z_pixel_size, radius, blur_size=0.1):
-    """
-
-    generate 3D sphere target for simulation
+    """Generate a 3D sphere target for simulation.
 
     Parameters
     ----------
-        zyx_shape   : tuple
-                    shape of the computed 3D space with size of (Z, Y, X)
-
-        yx_pixel_size        : float
-                    transverse pixel size of the image space
-
-        z_pixel_size       : float
-                    axial step size of the image space
-
-        radius    : float
-                    radius of the generated sphere
-
-        blur_size : float
-                    the standard deviation of the imposed 3D Gaussian blur on the simulated image
-
+    zyx_shape : tuple of int
+        Shape of the computed 3D space as ``(Z, Y, X)``.
+    yx_pixel_size : YXPixelSize or float
+        Lateral pixel size in micrometers. A scalar is treated as isotropic
+        spacing in y and x; pass a :class:`YXPixelSize` for anisotropic.
+    z_pixel_size : float
+        Axial step size of the image space.
+    radius : float
+        Radius of the generated sphere in micrometers.
+    blur_size : float
+        Standard deviation of the 3D Gaussian blur applied to the sphere.
 
     Returns
     -------
-        sphere    : torch.tensor
-                    3D star image with the size of (Z, Y, X)
-
-        azimuth   : torch.tensor
-                    azimuthal angle of the 3D polar coordinate with the size of (Z, Y, X)
-
-        inc_angle : torch.tensor
-                    theta angle of the 3D polar coordinate with the size of (Z, Y, X)
-
+    sphere : torch.Tensor
+        3D image of shape ``(Z, Y, X)``.
+    azimuth : torch.Tensor
+        Azimuthal angle of the 3D polar coordinate, shape ``(Z, Y, X)``.
+    inc_angle : torch.Tensor
+        Polar (inclination) angle of the 3D polar coordinate, shape
+        ``(Z, Y, X)``.
     """
+    yx_pixel_size = YXPixelSize.from_value(yx_pixel_size)
 
     Z, Y, X = zyx_shape
-    x = (torch.arange(X) - X // 2) * yx_pixel_size
-    y = (torch.arange(Y) - Y // 2) * yx_pixel_size
+    x = (torch.arange(X) - X // 2) * yx_pixel_size.x
+    y = (torch.arange(Y) - Y // 2) * yx_pixel_size.y
     z = (torch.arange(Z) - Z // 2) * z_pixel_size
 
     zz, yy, xx = torch.meshgrid(z, y, x, indexing="ij")
@@ -275,7 +269,7 @@ def generate_sphere_target(zyx_shape, yx_pixel_size, z_pixel_size, radius, blur_
 
 def gen_coordinate(
     img_dim: tuple[int, int],
-    ps: float,
+    ps,
     device: str | torch.device | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """Generate spatial and spatial frequency coordinate arrays.
@@ -284,8 +278,10 @@ def gen_coordinate(
     ----------
     img_dim : tuple of int
         Shape of the computed 2D space ``(Ny, Nx)``.
-    ps : float
-        Transverse pixel size of the image space.
+    ps : YXPixelSize or float
+        Transverse pixel size of the image space. A scalar is treated as
+        isotropic spacing in y and x; pass a :class:`YXPixelSize` for
+        anisotropic.
     device : str, torch.device, or None
         Output tensor device.
 
@@ -301,12 +297,12 @@ def gen_coordinate(
         y spatial frequency array with shape ``(Ny, Nx)``.
     """
     N, M = img_dim
-    ps = float(ps)
+    ps = YXPixelSize.from_value(ps)
 
-    fx = torch.fft.fftfreq(M, ps, device=device)
-    fy = torch.fft.fftfreq(N, ps, device=device)
-    x = torch.fft.ifftshift((torch.arange(M, dtype=torch.float32, device=device) - M / 2) * ps)
-    y = torch.fft.ifftshift((torch.arange(N, dtype=torch.float32, device=device) - N / 2) * ps)
+    fx = torch.fft.fftfreq(M, ps.x, device=device)
+    fy = torch.fft.fftfreq(N, ps.y, device=device)
+    x = torch.fft.ifftshift((torch.arange(M, dtype=torch.float32, device=device) - M / 2) * ps.x)
+    y = torch.fft.ifftshift((torch.arange(N, dtype=torch.float32, device=device) - N / 2) * ps.y)
 
     xx, yy = torch.meshgrid(x, y, indexing="xy")
     fxx, fyy = torch.meshgrid(fx, fy, indexing="xy")
@@ -315,13 +311,56 @@ def gen_coordinate(
 
 
 def generate_frequencies(img_dim, ps, device=None):
-    fy = torch.fft.fftfreq(img_dim[0], ps, device=device)
-    fx = torch.fft.fftfreq(img_dim[1], ps, device=device)
+    """Generate 2D spatial-frequency grids in ``ij`` (y, x) order.
+
+    Parameters
+    ----------
+    img_dim : tuple of int
+        Shape of the computed 2D space ``(Ny, Nx)``.
+    ps : YXPixelSize or float
+        Transverse pixel size of the image space. A scalar is treated as
+        isotropic spacing in y and x; pass a :class:`YXPixelSize` for
+        anisotropic.
+    device : str, torch.device, or None
+        Output tensor device.
+
+    Returns
+    -------
+    fyy : torch.Tensor
+        Spatial frequencies along y, broadcast to shape ``(Ny, Nx)``.
+    fxx : torch.Tensor
+        Spatial frequencies along x, broadcast to shape ``(Ny, Nx)``.
+    """
+    ps = YXPixelSize.from_value(ps)
+    fy = torch.fft.fftfreq(img_dim[0], ps.y, device=device)
+    fx = torch.fft.fftfreq(img_dim[1], ps.x, device=device)
     fyy, fxx = torch.meshgrid(fy, fx, indexing="ij")
     return fyy, fxx
 
 
 def generate_radial_frequencies(img_dim, ps, device=None):
+    """Generate the radial spatial-frequency magnitude ``sqrt(fy^2 + fx^2)``.
+
+    The output is in physical 1/length units (e.g. 1/micrometer) regardless
+    of whether the pixel size is isotropic or anisotropic, since ``fy`` and
+    ``fx`` are both produced in physical units.
+
+    Parameters
+    ----------
+    img_dim : tuple of int
+        Shape of the computed 2D space ``(Ny, Nx)``.
+    ps : YXPixelSize or float
+        Transverse pixel size of the image space. A scalar is treated as
+        isotropic spacing in y and x; pass a :class:`YXPixelSize` for
+        anisotropic.
+    device : str, torch.device, or None
+        Output tensor device.
+
+    Returns
+    -------
+    torch.Tensor
+        Radial spatial-frequency magnitude, shape ``(Ny, Nx)``.
+    """
     fyy, fxx = generate_frequencies(img_dim, ps, device=device)
     return torch.sqrt(fyy**2 + fxx**2)
 


### PR DESCRIPTION
Closes #567.

Adds support for non-square pixels in fluorescence (2D + 3D) and phase (2D + 3D) reconstructions. Birefringence paths raise `NotImplementedError` when `y != x`. Scalar configs and `y == x` configs keep working everywhere.

**Config (backwards compatible).**

```yaml
yx_pixel_size: 0.3

yx_pixel_size:
  y: 0.3
  x: 0.25
```

Both forms parse to a normalized `YXPixelSize(y, x)` internally.

**What changed.** New `YXPixelSize` value type with a `from_value` constructor that accepts scalar, mapping, or itself. Pydantic settings field flipped to `YXPixelSize` with a before-validator and a serializer that emits a scalar when isotropic so YAML stays tidy. `util` helpers, all phase and fluorescence models, the `api/phase` and `api/fluorescence` consumers, and the CLI output metadata path all accept `YXPixelSize | float`. Anisotropic Nyquist upsampling (separate `y_factor` and `x_factor`) in the four affected models. One new anisotropic example at `docs/examples/api/phase_3d_anisotropic.py`.

**Tests (de-risking).** 46 new tests. Settings: scalar and dict YAML parsing, YAML round-trip in both forms, typo and negative rejection. Utilities: isotropic equivalence vs legacy scalar, anisotropic frequency and sphere generation. Each modality (phase 2D/3D, fluor 2D/3D): isotropic equivalence (`y == x` reproduces legacy output bit for bit) plus anisotropic smoke. Birefringence: anisotropic input raises `NotImplementedError`. CLI: anisotropic config writes distinct y and x scales to the output zarr, mismatch warning reports y and x independently. Full regression benchmark suite passes with identical metrics.

**Out of scope.** Birefringence anisotropic support. Shift-variant fluorescence. Z pixel size stays scalar.

Sri to validate on DaXi zebrafish data before this merges.