### PR TITLE
ci: add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @srivarra @talonchandler


### PR DESCRIPTION
With this PR,  @talonchandler and I are codeowners for the whole repository, but we can split repository owners by directories as well