### PR TITLE
fix(cli): support FOVs with differing ZYX shapes

### DIFF
--- a/tests/cli_tests/test_reconstruct.py
+++ b/tests/cli_tests/test_reconstruct.py
@@ -567,3 +567,136 @@ def test_warn_pixel_size_mismatch_isotropic_silent_when_equal():
         warnings.simplefilter("always")
         _warn_pixel_size_mismatch(input_scale, config_pixel_sizes)
     assert all("Input pixel sizes" not in str(w.message) for w in record)
+
+
+def _write_mixed_shape_plate(input_path, shapes):
+    """Write an HCS plate whose positions have the given TCZYX shapes."""
+    plate = open_ome_zarr(input_path, layout="hcs", mode="w", channel_names=["GFP"])
+    rng = np.random.default_rng(0)
+    for position_key, shape in shapes.items():
+        position = plate.create_position(*position_key)
+        position.create_image(
+            "0",
+            rng.random(shape).astype(np.float32),
+            transform=[TransformationMeta(type="scale", scale=(1, 1, 0.25, 0.1, 0.1))],
+        )
+    plate.close()
+
+
+def _write_fluorescence_config(config_path):
+    recon_settings = settings.ReconstructionSettings(
+        input_channel_names=["GFP"],
+        time_indices="all",
+        reconstruction_dimension=3,
+        fluorescence=settings.FluorescenceSettings(),
+    )
+    utils.model_to_yaml(recon_settings, config_path)
+
+
+def test_reconstruct_fovs_with_different_zyx_shapes(tmp_path):
+    """Each distinct ZYX shape gets its own transfer function and output shape."""
+    input_path = tmp_path / "input.zarr"
+    config_path = tmp_path / "config.yml"
+    output_path = tmp_path / "output.zarr"
+
+    # "A/1/0" and "B/1/0" share a shape, so only two transfer functions are needed.
+    shapes = {
+        ("A", "1", "0"): (2, 1, 6, 32, 32),
+        ("A", "2", "0"): (2, 1, 6, 48, 48),
+        ("B", "1", "0"): (2, 1, 6, 32, 32),
+    }
+    _write_mixed_shape_plate(input_path, shapes)
+    _write_fluorescence_config(config_path)
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "reconstruct",
+            "-i",
+            *[str(input_path / Path(*position_key)) for position_key in shapes],
+            "-c",
+            str(config_path),
+            "-o",
+            str(output_path),
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+
+    with open_ome_zarr(output_path) as output_plate:
+        for position_key, shape in shapes.items():
+            reconstructed = output_plate["/".join(position_key)]["0"]
+            assert reconstructed.shape[2:] == shape[2:]
+            assert not np.all(reconstructed[:] == 0)
+
+    transfer_functions = sorted(p.name for p in tmp_path.glob("transfer_function_*.zarr"))
+    assert transfer_functions == [
+        "transfer_function_config_6x32x32.zarr",
+        "transfer_function_config_6x48x48.zarr",
+    ]
+
+
+def test_reconstruct_uniform_shape_keeps_unsuffixed_transfer_function_name(tmp_path):
+    """A single ZYX shape still writes the plain transfer_function_<config>.zarr."""
+    input_path = tmp_path / "input.zarr"
+    config_path = tmp_path / "config.yml"
+    output_path = tmp_path / "output.zarr"
+
+    shapes = {
+        ("A", "1", "0"): (1, 1, 6, 32, 32),
+        ("A", "2", "0"): (1, 1, 6, 32, 32),
+    }
+    _write_mixed_shape_plate(input_path, shapes)
+    _write_fluorescence_config(config_path)
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "reconstruct",
+            "-i",
+            *[str(input_path / Path(*position_key)) for position_key in shapes],
+            "-c",
+            str(config_path),
+            "-o",
+            str(output_path),
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert [p.name for p in tmp_path.glob("transfer_function_*.zarr")] == ["transfer_function_config.zarr"]
+
+
+def test_apply_inv_tf_rejects_fovs_with_different_zyx_shapes(tmp_path):
+    """apply-inv-tf holds one transfer function, so mixed shapes must error early."""
+    input_path = tmp_path / "input.zarr"
+    config_path = tmp_path / "config.yml"
+    tf_path = tmp_path / "tf.zarr"
+    output_path = tmp_path / "output.zarr"
+
+    shapes = {
+        ("A", "1", "0"): (1, 1, 6, 32, 32),
+        ("A", "2", "0"): (1, 1, 6, 48, 48),
+    }
+    _write_mixed_shape_plate(input_path, shapes)
+    _write_fluorescence_config(config_path)
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "apply-inv-tf",
+            "-i",
+            *[str(input_path / Path(*position_key)) for position_key in shapes],
+            "-t",
+            str(tf_path),
+            "-c",
+            str(config_path),
+            "-o",
+            str(output_path),
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "all positions must have the same ZYX shape" in result.output
+    assert "Use `waveorder reconstruct`" in result.output
+    assert not output_path.exists()

--- a/waveorder/cli/apply_inverse_transfer_function.py
+++ b/waveorder/cli/apply_inverse_transfer_function.py
@@ -1,5 +1,6 @@
 import math
 import warnings
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Literal
 
@@ -165,9 +166,9 @@ def get_reconstruction_output_metadata(
     plate_metadata = {}
     input_version = "0.4"
     try:
-        input_plate = open_ome_zarr(position_path.parent.parent.parent, mode="r")
-        input_version = input_plate.version
-        plate_metadata = dict(input_plate.zattrs)
+        with open_ome_zarr(position_path.parent.parent.parent, mode="r") as input_plate:
+            input_version = input_plate.version
+            plate_metadata = dict(input_plate.zattrs)
         # In v0.5 (zarr v3), OME metadata is nested inside an "ome" key
         if "ome" in plate_metadata:
             plate_metadata.pop("ome")
@@ -176,16 +177,15 @@ def get_reconstruction_output_metadata(
     except (RuntimeError, FileNotFoundError):
         warnings.warn("Position is not part of a plate...no plate metadata will be copied.")
 
-    # Load the first position to infer dataset information
-    input_dataset = open_ome_zarr(str(position_path), mode="r")
-    T, _, Z, Y, X = input_dataset.data.shape
+    with open_ome_zarr(str(position_path), mode="r") as input_dataset:
+        T, _, Z, Y, X = input_dataset.data.shape
+        scale = input_dataset.scale
 
     settings = utils.yaml_to_model(config_path, ReconstructionSettings)
 
     channel_names = settings.output_channel_names
     output_z_shape = 1 if settings.output_z_is_singleton else Z
 
-    scale = input_dataset.scale
     config_pixel_sizes = _get_config_pixel_sizes(settings)
     if config_pixel_sizes is not None:
         if write_config_scale_to_output:
@@ -395,14 +395,83 @@ def apply_inverse_transfer_function_single_position(
     input_dataset.close()
 
 
+def _check_uniform_zyx_shapes(input_position_dirpaths: list[Path]) -> None:
+    """Raise if the positions do not all share one ZYX shape.
+
+    A transfer function is only valid for the ZYX shape it was computed from,
+    so a single transfer function cannot cover positions of mixed shapes.
+    """
+    # Deferred import for fast CLI help
+    from waveorder.cli.utils import read_zyx_shapes
+
+    positions_by_zyx_shape: dict[tuple[int, ...], list[Path]] = {}
+    for zyx_shape, position_dirpath in zip(
+        read_zyx_shapes(input_position_dirpaths), input_position_dirpaths, strict=True
+    ):
+        positions_by_zyx_shape.setdefault(zyx_shape, []).append(position_dirpath)
+
+    if len(positions_by_zyx_shape) == 1:
+        return
+
+    max_listed = 3
+    detail_lines = []
+    for zyx_shape, position_dirpaths in positions_by_zyx_shape.items():
+        listed = ", ".join(str(dirpath) for dirpath in position_dirpaths[:max_listed])
+        if len(position_dirpaths) > max_listed:
+            listed += f", and {len(position_dirpaths) - max_listed} more"
+        detail_lines.append(f"  ZYX {zyx_shape}: {listed}")
+    detail = "\n".join(detail_lines)
+
+    raise click.ClickException(
+        "apply-inv-tf applies one transfer function to every position, so all "
+        "positions must have the same ZYX shape, but the input positions have "
+        f"{len(positions_by_zyx_shape)} different shapes:\n{detail}\n"
+        "Use `waveorder reconstruct`, which computes a transfer function for "
+        "each distinct shape, or run apply-inv-tf once per shape."
+    )
+
+
+def _resolve_transfer_function_dirpaths(
+    transfer_function_dirpaths: str | Path | Mapping[tuple[int, ...], Path],
+    input_position_dirpaths: list[Path],
+) -> list[Path]:
+    """Return one transfer function dirpath per input position.
+
+    A single dirpath is reused for every position, which is only valid when the
+    positions share a ZYX shape. A mapping selects the transfer function by
+    each position's ZYX shape.
+    """
+    # Deferred import for fast CLI help
+    from waveorder.cli.utils import read_zyx_shapes
+
+    if isinstance(transfer_function_dirpaths, (str, Path)):
+        _check_uniform_zyx_shapes(input_position_dirpaths)
+        return [Path(transfer_function_dirpaths)] * len(input_position_dirpaths)
+
+    zyx_shapes = read_zyx_shapes(input_position_dirpaths)
+    missing_shapes = set(zyx_shapes) - transfer_function_dirpaths.keys()
+    if missing_shapes:
+        raise ValueError(
+            "No transfer function was provided for ZYX shape(s): "
+            + ", ".join(map(str, sorted(missing_shapes)))
+        )
+    return [Path(transfer_function_dirpaths[zyx_shape]) for zyx_shape in zyx_shapes]
+
+
 def apply_inverse_transfer_function_cli(
     input_position_dirpaths: list[Path],
-    transfer_function_dirpath: Path,
+    transfer_function_dirpath: str | Path | Mapping[tuple[int, ...], Path],
     config_filepath: Path,
     output_dirpath: Path,
     num_processes,
     write_config_scale_to_output: bool = False,
 ) -> None:
+    """Reconstruct every position in ``input_position_dirpaths``.
+
+    ``transfer_function_dirpath`` is either a single transfer function, which
+    requires every position to share one ZYX shape, or a mapping from ZYX
+    shapes to transfer functions.
+    """
     # Deferred imports for fast CLI help
     import torch
     from iohub import open_ome_zarr
@@ -413,16 +482,23 @@ def apply_inverse_transfer_function_cli(
         is_single_position_store,
     )
 
-    # Prepare output store
-    output_metadata = get_reconstruction_output_metadata(
-        input_position_dirpaths[0], config_filepath, write_config_scale_to_output
+    per_position_transfer_function_dirpaths = _resolve_transfer_function_dirpaths(
+        transfer_function_dirpath, input_position_dirpaths
     )
+
+    # Positions may differ in shape and scale, so each gets its own metadata.
+    output_metadatas = [
+        get_reconstruction_output_metadata(position_dirpath, config_filepath, write_config_scale_to_output)
+        for position_dirpath in input_position_dirpaths
+    ]
 
     # `plate_metadata` is not a `create_empty_plate` parameter; write it to
     # the plate's zattrs after creation. `output_metadata["version"]` is read
     # from the input plate by `get_reconstruction_output_metadata`, so the
     # output preserves the input's OME-Zarr version.
-    plate_metadata = output_metadata.pop("plate_metadata", {})
+    plate_metadata = output_metadatas[0].pop("plate_metadata", {})
+    for output_metadata in output_metadatas[1:]:
+        output_metadata.pop("plate_metadata", None)
 
     # Generate position keys - use valid HCS keys for single-position stores
     position_keys = []
@@ -434,11 +510,13 @@ def apply_inverse_transfer_function_cli(
             position_key = input_path.parts[-3:]
         position_keys.append(position_key)
 
-    create_empty_plate(
-        store_path=output_dirpath,
-        position_keys=position_keys,
-        **output_metadata,
-    )
+    # `create_empty_plate` allocates one shape and scale per call.
+    for position_key, output_metadata in zip(position_keys, output_metadatas, strict=True):
+        create_empty_plate(
+            store_path=output_dirpath,
+            position_keys=[position_key],
+            **output_metadata,
+        )
 
     if plate_metadata:
         with open_ome_zarr(str(output_dirpath), mode="r+") as output_plate:
@@ -450,20 +528,18 @@ def apply_inverse_transfer_function_cli(
         torch.set_num_interop_threads(1)
 
     # Loop through positions
-    for i, input_position_dirpath in enumerate(input_position_dirpaths):
-        # Use the same position key generation logic
-        if is_single_position_store(input_position_dirpath):
-            position_key = generate_valid_position_key(i)
-        else:
-            position_key = input_position_dirpath.parts[-3:]
-
-        output_position_path = output_dirpath / Path(*position_key)
-
+    for input_position_dirpath, tf_dirpath, position_key, output_metadata in zip(
+        input_position_dirpaths,
+        per_position_transfer_function_dirpaths,
+        position_keys,
+        output_metadatas,
+        strict=True,
+    ):
         apply_inverse_transfer_function_single_position(
             input_position_dirpath,
-            transfer_function_dirpath,
+            tf_dirpath,
             config_filepath,
-            output_position_path,
+            output_dirpath / Path(*position_key),
             num_processes,
             output_metadata["channel_names"],
         )
@@ -487,7 +563,11 @@ def _apply_inverse_transfer_function_cli(
     """Apply an inverse transfer function to a dataset.
 
     Applies a transfer function to all positions in the list
-    `input-position-dirpaths`, so all positions must have the same TCZYX shape.
+    `input-position-dirpaths`. A transfer function is only valid for the ZYX
+    shape it was computed from, so this command errors out unless all
+    positions have the same ZYX shape. To reconstruct positions of mixed
+    shapes, use `waveorder reconstruct`, which computes a transfer function
+    for each distinct shape.
 
     \b
     Example:

--- a/waveorder/cli/apply_inverse_transfer_function.py
+++ b/waveorder/cli/apply_inverse_transfer_function.py
@@ -452,8 +452,7 @@ def _resolve_transfer_function_dirpaths(
     missing_shapes = set(zyx_shapes) - transfer_function_dirpaths.keys()
     if missing_shapes:
         raise ValueError(
-            "No transfer function was provided for ZYX shape(s): "
-            + ", ".join(map(str, sorted(missing_shapes)))
+            "No transfer function was provided for ZYX shape(s): " + ", ".join(map(str, sorted(missing_shapes)))
         )
     return [Path(transfer_function_dirpaths[zyx_shape]) for zyx_shape in zyx_shapes]
 

--- a/waveorder/cli/parsing.py
+++ b/waveorder/cli/parsing.py
@@ -39,7 +39,7 @@ def input_position_dirpaths() -> Callable:
             type=tuple,
             required=True,
             callback=_validate_and_process_paths,
-            help="List of paths to input positions, each with the same TCZYX shape. Supports wildcards e.g. 'input.zarr/*/*/*'.",
+            help="List of paths to input positions. Supports wildcards e.g. 'input.zarr/*/*/*'.",
         )(f)
 
     return decorator

--- a/waveorder/cli/reconstruct.py
+++ b/waveorder/cli/reconstruct.py
@@ -32,10 +32,10 @@ def _reconstruct_cli(
     convenience function for a `compute-tf` call followed by a `apply-inv-tf`
     call.
 
-    Calculates the transfer function based on the shape of the first position
-    in the list `input-position-dirpaths`, then applies that transfer function
-    to all positions in the list `input-position-dirpaths`, so all positions
-    must have the same TCZYX shape.
+    A transfer function is only valid for the ZYX shape it was computed from,
+    so this command groups the positions in `input-position-dirpaths` by their
+    ZYX shape, calculates one transfer function per distinct shape, and applies
+    each transfer function to the positions it was computed for.
 
     If any parameter has an `lr` key (OptimizableFloat), an optimization loop
     runs before the standard reconstruction pipeline.
@@ -53,6 +53,7 @@ def _reconstruct_cli(
     from waveorder.cli.apply_inverse_transfer_function import apply_inverse_transfer_function_cli
     from waveorder.cli.compute_transfer_function import compute_transfer_function_cli
     from waveorder.cli.settings import ReconstructionSettings
+    from waveorder.cli.utils import read_zyx_shapes
     from waveorder.io import utils
     from waveorder.optim import has_optimizable_params
 
@@ -62,20 +63,36 @@ def _reconstruct_cli(
     if has_optimizable_params(settings):
         config_filepath = _run_optimization(settings, input_position_dirpaths[0], config_filepath)
 
-    # Handle transfer function path
-    transfer_function_path = output_dirpath.parent / Path("transfer_function_" + config_filepath.stem + ".zarr")
+    # Positions that share a ZYX shape can share a transfer function, so compute
+    # one per distinct shape, using the first position that has that shape.
+    position_zyx_shapes = read_zyx_shapes(input_position_dirpaths)
+    first_position_by_zyx_shape: dict[tuple[int, ...], Path] = {}
+    for zyx_shape, input_position_dirpath in zip(position_zyx_shapes, input_position_dirpaths, strict=True):
+        first_position_by_zyx_shape.setdefault(zyx_shape, input_position_dirpath)
 
-    # Compute transfer function
-    compute_transfer_function_cli(
-        input_position_dirpaths[0],
-        config_filepath,
-        transfer_function_path,
-    )
+    if len(first_position_by_zyx_shape) > 1:
+        click.echo(
+            click.style(
+                f"Found {len(first_position_by_zyx_shape)} distinct ZYX shapes across "
+                f"{len(input_position_dirpaths)} positions: computing one transfer "
+                "function per shape.",
+                fg="yellow",
+            )
+        )
 
-    # Apply inverse transfer function
+    transfer_function_paths = {}
+    for zyx_shape, input_position_dirpath in first_position_by_zyx_shape.items():
+        # Only disambiguate the filename when there is more than one shape, so
+        # single-shape runs keep writing the path users already expect.
+        suffix = "" if len(first_position_by_zyx_shape) == 1 else "_" + "x".join(str(size) for size in zyx_shape)
+        transfer_function_path = output_dirpath.parent / f"transfer_function_{config_filepath.stem}{suffix}.zarr"
+        compute_transfer_function_cli(input_position_dirpath, config_filepath, transfer_function_path)
+        transfer_function_paths[zyx_shape] = transfer_function_path
+
+    # Apply each position's matching inverse transfer function
     apply_inverse_transfer_function_cli(
         input_position_dirpaths,
-        transfer_function_path,
+        transfer_function_paths,
         config_filepath,
         output_dirpath,
         num_processes,

--- a/waveorder/cli/utils.py
+++ b/waveorder/cli/utils.py
@@ -31,6 +31,19 @@ def generate_valid_position_key(index: int) -> tuple[str, str, str]:
     return (row, column, field)
 
 
+def read_zyx_shapes(position_paths: list[Path]) -> list[tuple[int, ...]]:
+    """Read the ZYX shape of each position, in the order it was given.
+
+    A transfer function is only valid for the ZYX shape it was computed from,
+    so callers use these shapes to decide which positions can share one.
+    """
+    shapes = []
+    for position_path in position_paths:
+        with open_ome_zarr(str(position_path), layout="fov", mode="r") as position_dataset:
+            shapes.append(tuple(position_dataset.data.shape[-3:]))  # ZYX
+    return shapes
+
+
 def is_single_position_store(position_path: Path) -> bool:
     """Check if a position path is from a single-position store (not HCS plate).
 


### PR DESCRIPTION
We run a pass through the HCS store, and group positions by ZYX shape, then compute one transfer function per unique ZYX shape.

- `apply-inv-tf` takes a single transfer function, so mixed shapes fail fast instead of writing wrong output.
- `create_empty_plate` allocates one shape and scale per call, so output metadata is derived per position.
