### PR TITLE
feat: choose regularization_strength from the data (otsu_cnr, l_curve)

### DIFF
--- a/docs/examples/cli/configs/birefringence-and-phase_3d.yml
+++ b/docs/examples/cli/configs/birefringence-and-phase_3d.yml
@@ -33,3 +33,4 @@ phase:
     TV_rho_strength: 0.001                  # ADMM rho parameter for TV regularization
     TV_iterations: 1                        # ADMM iterations for TV regularization
     apodization_rolloff: 0.0                # raised-cosine roll-off fraction applied to the inverse filter at the transverse Nyquist edge; suppresses checkerboard artifacts when the optical band limit exceeds the sampling Nyquist frequency. Must be between 0 and 1 (0 = off); if you see checkerboarding artifacts, start with 0.25
+    auto_regularization: null               # choose regularization_strength from the data; 3D Tikhonov only

--- a/docs/examples/cli/configs/fluorescence_2d.yml
+++ b/docs/examples/cli/configs/fluorescence_2d.yml
@@ -20,4 +20,5 @@ fluorescence:
     TV_rho_strength: 0.001                  # ADMM rho parameter for TV regularization
     TV_iterations: 1                        # ADMM iterations for TV regularization
     apodization_rolloff: 0.0                # raised-cosine roll-off fraction applied to the inverse filter at the transverse Nyquist edge; suppresses checkerboard artifacts when the optical band limit exceeds the sampling Nyquist frequency. Must be between 0 and 1 (0 = off); if you see checkerboarding artifacts, start with 0.25
+    auto_regularization: null               # choose regularization_strength from the data; 3D Tikhonov only
     rl: null                                # Richardson-Lucy knobs; only valid with reconstruction_algorithm 'RL'/'RLGC', and filled with defaults if omitted there

--- a/docs/examples/cli/configs/fluorescence_3d.yml
+++ b/docs/examples/cli/configs/fluorescence_3d.yml
@@ -20,4 +20,5 @@ fluorescence:
     TV_rho_strength: 0.001                  # ADMM rho parameter for TV regularization
     TV_iterations: 1                        # ADMM iterations for TV regularization
     apodization_rolloff: 0.0                # raised-cosine roll-off fraction applied to the inverse filter at the transverse Nyquist edge; suppresses checkerboard artifacts when the optical band limit exceeds the sampling Nyquist frequency. Must be between 0 and 1 (0 = off); if you see checkerboarding artifacts, start with 0.25
+    auto_regularization: null               # choose regularization_strength from the data; 3D Tikhonov only
     rl: null                                # Richardson-Lucy knobs; only valid with reconstruction_algorithm 'RL'/'RLGC', and filled with defaults if omitted there

--- a/docs/examples/cli/configs/phase_2d.yml
+++ b/docs/examples/cli/configs/phase_2d.yml
@@ -21,3 +21,4 @@ phase:
     TV_rho_strength: 0.001                  # ADMM rho parameter for TV regularization
     TV_iterations: 1                        # ADMM iterations for TV regularization
     apodization_rolloff: 0.0                # raised-cosine roll-off fraction applied to the inverse filter at the transverse Nyquist edge; suppresses checkerboard artifacts when the optical band limit exceeds the sampling Nyquist frequency. Must be between 0 and 1 (0 = off); if you see checkerboarding artifacts, start with 0.25
+    auto_regularization: null               # choose regularization_strength from the data; 3D Tikhonov only

--- a/docs/examples/cli/configs/phase_3d_autoreg.yml
+++ b/docs/examples/cli/configs/phase_3d_autoreg.yml
@@ -21,4 +21,10 @@ phase:
     TV_rho_strength: 0.001                  # ADMM rho parameter for TV regularization
     TV_iterations: 1                        # ADMM iterations for TV regularization
     apodization_rolloff: 0.0                # raised-cosine roll-off fraction applied to the inverse filter at the transverse Nyquist edge; suppresses checkerboard artifacts when the optical band limit exceeds the sampling Nyquist frequency. Must be between 0 and 1 (0 = off); if you see checkerboarding artifacts, start with 0.25
-    auto_regularization: null               # choose regularization_strength from the data; 3D Tikhonov only
+    auto_regularization:                    # choose regularization_strength from the data; 3D Tikhonov only
+      rule: otsu_cnr                        # 'otsu_cnr' maximizes local-variance contrast; 'l_curve' finds the trade-off corner
+      search_min: -6.0                      # lower log10 bound of the sweep, interpreted per search_scale
+      search_max: 2.0                       # upper log10 bound of the sweep, interpreted per search_scale
+      num_samples: 9                        # regularization strengths to try
+      search_scale: relative                # 'relative' reads the search bounds as log10(lambda / |H|^2max); 'absolute' as log10(lambda)
+      report_path: ./autoreg_report.json    # write the full sweep (scores, norms, chosen index) to this JSON path; null = no report

--- a/docs/examples/cli/phase_3d_autoreg.sh
+++ b/docs/examples/cli/phase_3d_autoreg.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Reconstruct 3D phase with `regularization_strength` chosen from the data.
+#
+# `wo rec` sweeps the strength after computing the transfer function, writes the
+# value it picked into `phase_3d_autoreg_autoreg.yml`, and dumps the whole sweep
+# to `autoreg_report.json`. Read the report before trusting the pick: neither
+# rule is an oracle, and `wo rec` warns when the pick lands on a sweep endpoint.
+wo sim \
+  -c ./configs/phase_3d_autoreg.yml \
+  -o ./phase_autoreg_data.zarr
+
+wo rec \
+  -i ./phase_autoreg_data.zarr \
+  -c ./configs/phase_3d_autoreg.yml \
+  -o ./phase_3d_autoreg_recon.zarr
+
+wo view ./phase_autoreg_data.zarr ./phase_3d_autoreg_recon.zarr

--- a/tests/cli_tests/test_reconstruct.py
+++ b/tests/cli_tests/test_reconstruct.py
@@ -1,3 +1,4 @@
+import json
 import warnings
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -18,6 +19,7 @@ from waveorder.cli.apply_inverse_transfer_function import (
 )
 from waveorder.cli.main import cli
 from waveorder.io import utils
+from waveorder.optim.autoreg import AutoRegularizationSettings
 
 input_scale = [1, 2, 3, 4, 5]
 # Setup options
@@ -567,3 +569,67 @@ def test_warn_pixel_size_mismatch_isotropic_silent_when_equal():
         warnings.simplefilter("always")
         _warn_pixel_size_mismatch(input_scale, config_pixel_sizes)
     assert all("Input pixel sizes" not in str(w.message) for w in record)
+
+
+def test_auto_regularization_cli(tmp_path):
+    """Smoke test: reconstruct with auto_regularization sweeps then reconstructs."""
+    input_path = tmp_path / "autoreg_input.zarr"
+    output_path = tmp_path / "autoreg_output.zarr"
+    report_path = tmp_path / "autoreg_report.json"
+
+    # Create input dataset with a single channel, structured so the metrics have
+    # something to score: on featureless noise every rule pins to a sweep edge.
+    channel_names = ["Brightfield"]
+    dataset = open_ome_zarr(input_path, layout="hcs", mode="w", channel_names=channel_names)
+    position = dataset.create_position("0", "0", "0")
+    data = np.random.default_rng(0).normal(1000, 20, size=(1, 1, 6, 32, 32)).astype(np.float32)
+    data[..., 10:22, 10:22] += 300
+    position.create_image("0", data, transform=[TransformationMeta(type="scale", scale=input_scale)])
+    dataset.close()
+
+    recon_settings = settings.ReconstructionSettings(
+        input_channel_names=channel_names,
+        time_indices=0,
+        reconstruction_dimension=3,
+        phase=settings.PhaseSettings(),
+    )
+    recon_settings.phase.apply_inverse.auto_regularization = AutoRegularizationSettings(
+        num_samples=5,
+        search_min=-4.0,
+        search_max=2.0,
+        report_path=str(report_path),
+    )
+    config_path = tmp_path / "autoreg.yml"
+    utils.model_to_yaml(recon_settings, config_path)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "reconstruct",
+            "-i",
+            str(input_path / "0" / "0" / "0"),
+            "-c",
+            str(config_path),
+            "-o",
+            str(output_path),
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert output_path.exists()
+
+    # The pick is frozen into regularization_strength and the block is spent, so
+    # rerunning the resolved config reproduces the run without sweeping again.
+    resolved_config = config_path.with_name("autoreg_autoreg.yml")
+    assert resolved_config.exists()
+    resolved = utils.yaml_to_model(resolved_config, settings.ReconstructionSettings)
+    assert resolved.phase.apply_inverse.auto_regularization is None
+    assert resolved.phase.apply_inverse.regularization_strength != (
+        settings.PhaseSettings().apply_inverse.regularization_strength
+    )
+
+    # A report that disagreed with the config would be worse than no report.
+    report = json.loads(report_path.read_text())
+    assert report["regularization_strength"] == pytest.approx(resolved.phase.apply_inverse.regularization_strength)
+    assert report["regularization_strengths"][report["index"]] == pytest.approx(report["regularization_strength"])

--- a/tests/cli_tests/test_settings.py
+++ b/tests/cli_tests/test_settings.py
@@ -6,6 +6,10 @@ from waveorder._pixel_size import YXPixelSize
 from waveorder.api import birefringence, fluorescence, phase
 from waveorder.cli import settings
 from waveorder.io import utils
+from waveorder.optim.autoreg import (
+    AutoRegularizationIgnoredWarning,
+    AutoRegularizationSettings,
+)
 
 
 def test_reconstruction_settings():
@@ -110,6 +114,17 @@ def test_generate_example_settings(pytestconfig):
             birefringence=settings.BirefringenceSettings(),
             phase=settings.PhaseSettings(),
         ),
+        "phase_3d_autoreg.yml": settings.ReconstructionSettings(
+            input_channel_names=["Brightfield"],
+            phase=phase.Settings(
+                apply_inverse=phase.ApplyInverseSettings(
+                    auto_regularization=AutoRegularizationSettings(
+                        num_samples=9,
+                        report_path="./autoreg_report.json",
+                    )
+                )
+            ),
+        ),
     }
 
     for file_name, settings_obj in configs.items():
@@ -173,3 +188,104 @@ def test_negative_yx_pixel_size_rejected():
     """Negative spacings are rejected."""
     with pytest.raises(ValidationError):
         phase.TransferFunctionSettings(yx_pixel_size={"y": -0.3, "x": 0.25})
+
+
+# --- auto_regularization ---
+
+
+def _auto_reg_config(**overrides):
+    config = {
+        "input_channel_names": ["Brightfield"],
+        "reconstruction_dimension": 3,
+        "phase": {
+            "apply_inverse": {
+                "reconstruction_algorithm": "Tikhonov",
+                "auto_regularization": {"rule": "otsu_cnr"},
+            }
+        },
+    }
+    config.update(overrides)
+    return config
+
+
+def test_auto_regularization_defaults_to_absent():
+    """A config that does not ask for a sweep does not get one."""
+    s = settings.PhaseSettings()
+    assert s.apply_inverse.auto_regularization is None
+    assert settings.FluorescenceSettings().apply_inverse.auto_regularization is None
+
+
+def test_auto_regularization_parses():
+    s = settings.ReconstructionSettings(**_auto_reg_config())
+    auto = s.phase.apply_inverse.auto_regularization
+    assert auto.rule == "otsu_cnr"
+    assert auto.search_scale == "relative"
+    assert auto.num_samples == 25
+
+
+def test_auto_regularization_is_not_a_model_kwarg():
+    """It is resolved into regularization_strength before the model is called."""
+    s = settings.ReconstructionSettings(**_auto_reg_config())
+    assert "auto_regularization" not in s.phase.apply_inverse.to_model_kwargs()
+
+    fluo = fluorescence.ApplyInverseSettings(auto_regularization={"rule": "l_curve"})
+    assert "auto_regularization" not in fluo.to_model_kwargs()
+
+
+def test_auto_regularization_requires_tikhonov():
+    """Dropped with a warning, like the 'rl' block, because the plugin always submits one."""
+    with pytest.warns(AutoRegularizationIgnoredWarning, match="not 'Tikhonov'"):
+        s = phase.ApplyInverseSettings(
+            reconstruction_algorithm="TV",
+            auto_regularization={"rule": "otsu_cnr"},
+        )
+    assert s.auto_regularization is None
+
+
+def test_auto_regularization_dropped_for_2d():
+    """The thin models regularize a singular system, which the sweep cannot drive."""
+    with pytest.warns(AutoRegularizationIgnoredWarning, match="reconstruction_dimension is 2"):
+        s = settings.ReconstructionSettings(**_auto_reg_config(reconstruction_dimension=2))
+    assert s.phase.apply_inverse.auto_regularization is None
+
+
+def test_auto_regularization_dropped_alongside_birefringence():
+    """A joint reconstruction shares regularization_strength with the vector system."""
+    config = _auto_reg_config(input_channel_names=[f"State{i}" for i in range(4)])
+    config["birefringence"] = settings.BirefringenceSettings().model_dump()
+    with pytest.warns(AutoRegularizationIgnoredWarning, match="birefringence reconstruction"):
+        s = settings.ReconstructionSettings(**config)
+    assert s.phase.apply_inverse.auto_regularization is None
+
+
+def test_auto_regularization_survives_a_plugin_shaped_submission():
+    """The napari plugin always submits a populated Optional[Model] block.
+
+    plugin/tab_recon.py::get_pydantic_kwargs unwraps Optional and recurses, so it
+    emits a full auto_regularization dict even when the user never touched it.
+    Rejecting a block on its presence alone would break every 2D reconstruction
+    started from the GUI, so these must warn rather than raise.
+    """
+    plugin_submission = _auto_reg_config(reconstruction_dimension=2)
+    plugin_submission["phase"]["apply_inverse"]["auto_regularization"] = AutoRegularizationSettings().model_dump()
+
+    with pytest.warns(AutoRegularizationIgnoredWarning):
+        s = settings.ReconstructionSettings(**plugin_submission)
+
+    assert s.phase.apply_inverse.auto_regularization is None
+    assert s.reconstruction_dimension == 2
+
+
+def test_auto_regularization_yaml_roundtrip(tmp_path):
+    s = settings.ReconstructionSettings(**_auto_reg_config())
+    s.phase.apply_inverse.auto_regularization.rule = "l_curve"
+    s.phase.apply_inverse.auto_regularization.num_samples = 11
+
+    path = tmp_path / "autoreg.yml"
+    utils.model_to_yaml(s, path)
+    parsed = yaml.safe_load(path.read_text())["phase"]["apply_inverse"]["auto_regularization"]
+    assert parsed["rule"] == "l_curve"
+    assert parsed["num_samples"] == 11
+
+    reparsed = utils.yaml_to_model(path, settings.ReconstructionSettings)
+    assert reparsed.phase.apply_inverse.auto_regularization.rule == "l_curve"

--- a/tests/optim/test_autoreg.py
+++ b/tests/optim/test_autoreg.py
@@ -1,0 +1,408 @@
+"""Tests for automatic regularization-strength selection.
+
+The reference numbers in this file were produced by the CZ Biohub weight-search
+scripts that :mod:`waveorder.optim.autoreg` ports (``compMicro/utils.py`` and
+``compMicro/weight_search.py``), so a change in behaviour shows up as a failure
+here rather than as a quietly different pick.
+"""
+
+import json
+
+import numpy as np
+import pytest
+import torch
+from pydantic import ValidationError
+
+from waveorder.models import isotropic_fluorescent_thick_3d, phase_thick_3d
+from waveorder.optim import autoreg
+from waveorder.optim.autoreg import AutoRegularizationSettings
+
+PHASE_TF_KWARGS = dict(
+    yx_pixel_size=0.15,
+    z_pixel_size=1.0,
+    wavelength_illumination=0.441,
+    index_of_refraction_media=1.3,
+    numerical_aperture_illumination=1.15,
+    numerical_aperture_detection=0.52,
+)
+FLUOR_TF_KWARGS = dict(
+    yx_pixel_size=0.325,
+    z_pixel_size=1.0,
+    wavelength_emission=0.525,
+    index_of_refraction_media=1.0,
+    numerical_aperture_detection=0.55,
+)
+
+
+def _measurement(zyx_shape=(12, 64, 64), seed=0):
+    rng = np.random.default_rng(seed)
+    return torch.from_numpy((rng.random(zyx_shape) * 100 + 500).astype(np.float32))
+
+
+def _phase_tfs(zyx_shape, z_padding):
+    return phase_thick_3d.calculate_transfer_function(zyx_shape=zyx_shape, z_padding=z_padding, **PHASE_TF_KWARGS)
+
+
+def _fluor_tf(zyx_shape, z_padding):
+    return isotropic_fluorescent_thick_3d.calculate_transfer_function(
+        zyx_shape=zyx_shape, z_padding=z_padding, **FLUOR_TF_KWARGS
+    )
+
+
+def _sweep_one(data, tf, contrast, z_padding, strength, apodization_rolloff=0.0):
+    """Reproduce a single point of the sweep, the way select_regularization does."""
+    measurement = autoreg.preprocess_measurement(data, contrast, z_padding)
+    spectrum = torch.fft.fftn(measurement, dim=(-3, -2, -1))
+    recon = torch.real(
+        torch.fft.ifftn(
+            spectrum * autoreg._inverse_filter(tf, strength, apodization_rolloff),
+            dim=(-3, -2, -1),
+        )
+    )
+    return recon[z_padding : recon.shape[0] - z_padding] if z_padding else recon
+
+
+# --- the load-bearing test: the sweep scores the production reconstruction ---
+
+
+@pytest.mark.parametrize("z_padding", [0, 3])
+@pytest.mark.parametrize("strength", [1e-8, 1e-3])
+def test_sweep_reconstruction_matches_phase_model(z_padding, strength):
+    """A swept reconstruction is what phase_thick_3d would have produced."""
+    zyx_shape = (12, 64, 64)
+    data = _measurement(zyx_shape)
+    real_tf, imag_tf = _phase_tfs(zyx_shape, z_padding)
+
+    expected = phase_thick_3d.apply_inverse_transfer_function(
+        data,
+        real_tf,
+        imag_tf,
+        z_padding=z_padding,
+        regularization_strength=strength,
+    )
+    actual = _sweep_one(data, real_tf, "phase", z_padding, strength)
+
+    assert torch.allclose(expected, actual, atol=1e-6)
+
+
+@pytest.mark.parametrize("z_padding", [0, 3])
+@pytest.mark.parametrize("strength", [1e-8, 1e-3])
+def test_sweep_reconstruction_matches_fluorescence_model(z_padding, strength):
+    """A swept reconstruction is what isotropic_fluorescent_thick_3d would have produced."""
+    zyx_shape = (12, 64, 64)
+    data = _measurement(zyx_shape)
+    otf = _fluor_tf(zyx_shape, z_padding)
+
+    expected = isotropic_fluorescent_thick_3d.apply_inverse_transfer_function(
+        data,
+        otf,
+        z_padding=z_padding,
+        regularization_strength=strength,
+    )
+    actual = _sweep_one(data, otf, "fluorescence", z_padding, strength)
+
+    assert torch.allclose(expected, actual, atol=1e-6)
+
+
+def test_sweep_applies_apodization_like_the_model():
+    """apodization_rolloff reshapes the inverse filter, so the sweep must apply it too.
+
+    Uses a pixel size that undersamples the optical band, which is the case the
+    knob exists for. At a well-sampled pixel size the window is ~1 wherever the
+    filter carries energy and this test would pass with or without the fix.
+    """
+    zyx_shape, rolloff = (12, 64, 64), 0.25
+    data = _measurement(zyx_shape)
+    undersampled = {**PHASE_TF_KWARGS, "yx_pixel_size": 0.5}
+    real_tf, imag_tf = phase_thick_3d.calculate_transfer_function(zyx_shape=zyx_shape, z_padding=0, **undersampled)
+
+    expected = phase_thick_3d.apply_inverse_transfer_function(
+        data, real_tf, imag_tf, z_padding=0, regularization_strength=1e-3, apodization_rolloff=rolloff
+    )
+    unapodized = _sweep_one(data, real_tf, "phase", 0, 1e-3)
+    apodized = _sweep_one(data, real_tf, "phase", 0, 1e-3, rolloff)
+
+    # The window has to make a real difference here, or the assertion below is empty.
+    assert (expected - unapodized).abs().max() > 0.05 * (expected.max() - expected.min())
+    assert torch.allclose(expected, apodized, atol=1e-6)
+
+
+def test_preprocess_measurement_normalizes_phase_only():
+    """Phase intensity-normalizes before its inverse filter; fluorescence does not."""
+    data = _measurement((6, 16, 16))
+
+    phase = autoreg.preprocess_measurement(data, "phase", z_padding=0)
+    fluorescence = autoreg.preprocess_measurement(data, "fluorescence", z_padding=0)
+
+    assert torch.allclose(phase, data / data.mean() - 1)
+    assert torch.allclose(fluorescence, data)
+
+    padded = autoreg.preprocess_measurement(data, "fluorescence", z_padding=2)
+    assert padded.shape == (10, 16, 16)
+
+    with pytest.raises(ValueError, match="contrast"):
+        autoreg.preprocess_measurement(data, "birefringence", z_padding=0)
+
+
+# --- rules, against reference values from the scripts they port ---
+
+#: ``compMicro/utils.py::batched_otsu_cnr`` on the fixture built below.
+OTSU_REFERENCE = [
+    3.579247,
+    3.343898,
+    3.276220,
+    3.673673,
+    3.484225,
+    4.079302,
+    4.594685,
+    6.974761,
+    7.500283,
+]
+
+
+def _otsu_fixture():
+    rng = np.random.default_rng(20240101)
+    arr = rng.standard_normal((9, 8, 48, 48)).astype(np.float32)
+    # A block whose contrast grows along the sweep, so the scores are ordered.
+    arr[:, :, 10:30, 10:30] += np.linspace(0.5, 4.0, 9, dtype=np.float32).reshape(9, 1, 1, 1)
+    return torch.from_numpy(arr)
+
+
+def test_otsu_cnr_scores_match_reference():
+    scores = autoreg.otsu_cnr_scores(_otsu_fixture()).cpu().numpy()
+    np.testing.assert_allclose(scores, OTSU_REFERENCE, rtol=1e-5)
+
+
+def test_otsu_cnr_scores_use_one_shared_slice():
+    """Every reconstruction is scored on the same z, so scores stay comparable."""
+    recons = _otsu_fixture()
+    # Zeroing a slice that is not the most structured must not change the scores.
+    perturbed = recons.clone()
+    flat_z = int(torch.argmin(autoreg._local_variance(recons).var(dim=(2, 3)).mean(dim=0)))
+    perturbed[0, flat_z] = 0.0
+
+    assert autoreg.otsu_cnr_scores(recons)[1:].allclose(autoreg.otsu_cnr_scores(perturbed)[1:])
+
+
+def _noisy_l_curve():
+    """A gently bent, noisy trace, of the kind real sweeps produce."""
+    rng = np.random.default_rng(7)
+    residual = np.logspace(0, 1.2, 25) * (1 + 0.02 * rng.standard_normal(25))
+    solution = np.logspace(2.6, 1.1, 25) * (1 + 0.02 * rng.standard_normal(25))
+    return residual, solution
+
+
+_NOISY_L_CURVE = _noisy_l_curve()
+
+
+@pytest.mark.parametrize(
+    "residual, solution, expected",
+    [
+        # A real L: two turning points, corner between them.
+        (
+            np.concatenate([np.linspace(1, 1.05, 12), np.linspace(1.05, 40, 13)]),
+            np.concatenate([np.linspace(500, 60, 12), np.linspace(60, 55, 13)]),
+            11,
+        ),
+        # Nearly a straight line in log-log: no corner, so the search runs to an end.
+        (np.logspace(0, 1.5, 25), np.logspace(2.4, 1.0, 25), 24),
+        # Noisy and only gently bent, which is what real data tends to look like.
+        (*_NOISY_L_CURVE, 13),
+    ],
+)
+def test_find_l_curve_corner_matches_reference(residual, solution, expected):
+    assert autoreg.find_l_curve_corner(residual, solution) == expected
+
+
+def test_find_l_curve_corner_degenerate_inputs():
+    assert autoreg.find_l_curve_corner(np.array([1.0, 2.0]), np.array([3.0, 4.0])) == 0
+    # Constant norms carry no curvature at all.
+    flat = np.ones(9)
+    assert 0 <= autoreg.find_l_curve_corner(flat, flat) < 9
+
+
+def test_compute_l_curve_norms():
+    rng = np.random.default_rng(3)
+    tf = torch.from_numpy(rng.standard_normal((6, 16, 16)).astype(np.float32)).to(torch.complex64)
+    data = torch.from_numpy(rng.standard_normal((6, 16, 16)).astype(np.float32))
+    recons = torch.from_numpy(rng.standard_normal((4, 6, 16, 16)).astype(np.float32))
+
+    residual_norms, solution_norms = autoreg.compute_l_curve_norms(data, tf, recons)
+
+    assert residual_norms.shape == solution_norms.shape == (4,)
+    np.testing.assert_allclose(
+        solution_norms,
+        torch.linalg.vector_norm(recons, dim=(-3, -2, -1)).numpy(),
+        rtol=1e-6,
+    )
+
+
+# --- crop selection ---
+
+
+def test_select_crop_finds_the_structured_region():
+    data = torch.zeros(4, 512, 512)
+    data[:, 300:400, 100:200] = torch.from_numpy(
+        np.random.default_rng(0).standard_normal((4, 100, 100)).astype(np.float32)
+    )
+
+    y0, x0, size = autoreg.select_crop(data, crop_size=128)
+
+    assert size == 128
+    # The crop must overlap the structure it was supposed to find.
+    assert y0 < 400 and y0 + size > 300
+    assert x0 < 200 and x0 + size > 100
+
+
+def test_select_crop_returns_full_frame_when_small():
+    assert autoreg.select_crop(torch.zeros(3, 64, 64), crop_size=256) == (0, 0, 64)
+
+
+def test_select_crop_reaches_the_far_edge():
+    """The candidate stride must not leave a strip of the frame unreachable."""
+    data = torch.zeros(2, 300, 300)
+    data[:, 270:300, 270:300] = 100.0
+
+    y0, x0, size = autoreg.select_crop(data, crop_size=128)
+
+    assert y0 + size == 300
+    assert x0 + size == 300
+
+
+@pytest.mark.parametrize("shape, crop_size", [((4, 512, 512), 128), ((6, 301, 457), 128), ((4, 400, 400), 256)])
+def test_select_crop_matches_an_exhaustive_search(shape, crop_size):
+    """The integral-image shortcut picks what re-reducing every window would."""
+    rng = np.random.default_rng(1)
+    array = rng.normal(1000, 5, size=shape).astype(np.float32)
+    array[:, 40:90, 60:110] += 400
+    data = torch.from_numpy(array)
+
+    size = min(crop_size, shape[1], shape[2])
+    step = max(size // 2, 1)
+
+    def starts(extent):
+        last = extent - size
+        return sorted({*range(0, last + 1, step), last})
+
+    expected = max(
+        ((y0, x0) for y0 in starts(shape[1]) for x0 in starts(shape[2])),
+        key=lambda c: float(data[:, c[0] : c[0] + size, c[1] : c[1] + size].double().var(unbiased=False)),
+    )
+
+    assert autoreg.select_crop(data, crop_size)[:2] == expected
+
+
+# --- settings ---
+
+
+def test_settings_defaults_and_validation():
+    settings = AutoRegularizationSettings()
+    assert settings.rule == "otsu_cnr"
+    assert settings.search_scale == "relative"
+    assert settings.report_path is None
+
+    with pytest.raises(ValidationError, match="search_min must be less than search_max"):
+        AutoRegularizationSettings(search_min=2.0, search_max=-6.0)
+    with pytest.raises(ValidationError, match="num_samples must be at least 3"):
+        AutoRegularizationSettings(num_samples=2)
+    with pytest.raises(ValidationError):
+        AutoRegularizationSettings(rule="not_a_rule")
+    with pytest.raises(ValidationError):
+        AutoRegularizationSettings(typo=1)
+
+
+# --- select_regularization ---
+
+
+def _select(rule="otsu_cnr", zyx_shape=(12, 64, 64), z_padding=0, **kwargs):
+    data = _measurement(zyx_shape)
+    real_tf, _ = _phase_tfs(zyx_shape, z_padding)
+    settings = AutoRegularizationSettings(rule=rule, num_samples=7, **kwargs)
+    return data, real_tf, autoreg.select_regularization(data, real_tf, settings, contrast="phase", z_padding=z_padding)
+
+
+@pytest.mark.parametrize("rule", ["otsu_cnr", "l_curve"])
+def test_select_regularization_returns_a_swept_value(rule):
+    _, _, result = _select(rule)
+
+    assert result.rule == rule
+    assert len(result.regularization_strengths) == 7
+    assert result.regularization_strength == pytest.approx(result.regularization_strengths[result.index])
+    assert result.regularization_strength > 0
+    # Ascending sweep, so the pick is inside the swept span.
+    assert result.regularization_strengths[0] <= result.regularization_strength
+    assert result.regularization_strength <= result.regularization_strengths[-1]
+
+    if rule == "otsu_cnr":
+        assert len(result.scores) == 7 and len(result.residual_norms) == 0
+    else:
+        assert len(result.residual_norms) == 7 and len(result.scores) == 0
+
+
+def test_relative_scale_anchors_to_the_transfer_function_peak():
+    """`relative` reads the search bounds as log10(lambda / |H|^2max)."""
+    zyx_shape = (12, 64, 64)
+    data = _measurement(zyx_shape)
+    real_tf, _ = _phase_tfs(zyx_shape, 0)
+    h2max = float((real_tf.abs() ** 2).max())
+
+    relative = autoreg.select_regularization(
+        data,
+        real_tf,
+        AutoRegularizationSettings(num_samples=5, search_min=-2.0, search_max=2.0, search_scale="relative"),
+        contrast="phase",
+    )
+    absolute = autoreg.select_regularization(
+        data,
+        real_tf,
+        AutoRegularizationSettings(num_samples=5, search_min=-2.0, search_max=2.0, search_scale="absolute"),
+        contrast="phase",
+    )
+
+    np.testing.assert_allclose(relative.regularization_strengths, absolute.regularization_strengths * h2max, rtol=1e-6)
+    assert relative.transfer_function_peak_squared == pytest.approx(h2max)
+    assert relative.lambda_over_h2max == pytest.approx(relative.regularization_strength / h2max)
+
+
+def test_pick_on_the_sweep_edge_warns():
+    """A pick at either end means the optimum may be outside the search bounds."""
+    zyx_shape = (12, 64, 64)
+    data = _measurement(zyx_shape)
+    real_tf, _ = _phase_tfs(zyx_shape, 0)
+
+    # The measurement is structureless noise and the whole range is heavily
+    # over-regularized, so Otsu CNR climbs monotonically with smoothing and the
+    # argmax has nowhere to sit but the top of the sweep.
+    result = autoreg.select_regularization(
+        data,
+        real_tf,
+        AutoRegularizationSettings(rule="otsu_cnr", num_samples=5, search_min=3.0, search_max=4.0),
+        contrast="phase",
+    )
+
+    assert result.index == len(result.regularization_strengths) - 1
+    assert any("end of the sweep" in message for message in result.warnings)
+
+    with pytest.warns(UserWarning, match="end of the sweep"):
+        autoreg.warn_all(result)
+
+
+def test_shape_mismatch_is_rejected():
+    data = _measurement((12, 64, 64))
+    real_tf, _ = _phase_tfs((12, 32, 32), 0)
+
+    with pytest.raises(ValueError, match="does not match"):
+        autoreg.select_regularization(data, real_tf, AutoRegularizationSettings(), contrast="phase")
+
+
+def test_result_serializes_for_the_report(tmp_path):
+    _, _, result = _select("l_curve")
+
+    report_path = tmp_path / "report.json"
+    report_path.write_text(json.dumps(result.to_dict(), indent=2))
+    loaded = json.loads(report_path.read_text())
+
+    assert loaded["rule"] == "l_curve"
+    assert loaded["regularization_strength"] == pytest.approx(result.regularization_strength)
+    assert loaded["crop"] == {"y0": 0, "x0": 0, "size": 0}
+    assert len(loaded["residual_norms"]) == 7

--- a/waveorder/api/_settings.py
+++ b/waveorder/api/_settings.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import Literal, Union
+from typing import Literal, Optional, Union
 
 from pydantic import (
     BaseModel,
@@ -19,6 +19,10 @@ from pydantic import (
 
 from waveorder._pixel_size import YXPixelSize
 from waveorder.optim._types import OptimizableFloat
+from waveorder.optim.autoreg import (
+    AutoRegularizationIgnoredWarning,
+    AutoRegularizationSettings,
+)
 
 
 def _float_val(v) -> float:
@@ -143,6 +147,27 @@ class FourierApplyInverseSettings(MyBaseModel):
         "limit exceeds the sampling Nyquist frequency. Must be between 0 and 1 (0 = off); "
         "if you see checkerboarding artifacts, start with 0.25",
     )
+    auto_regularization: Optional[AutoRegularizationSettings] = Field(
+        default=None,
+        description="choose regularization_strength from the data; 3D Tikhonov only",
+    )
+
+    @model_validator(mode="after")
+    def _auto_regularization_matches_algorithm(self):
+        """Auto-regularization only means anything for the Tikhonov filter.
+
+        Dropped rather than rejected, for the same reason as fluorescence's 'rl'
+        block: the napari plugin builds its widgets from every field and so always
+        submits one, whatever the algorithm.
+        """
+        if self.auto_regularization is not None and self.reconstruction_algorithm != "Tikhonov":
+            warnings.warn(
+                f"ignoring 'auto_regularization' settings: reconstruction_algorithm is "
+                f"{self.reconstruction_algorithm!r}, not 'Tikhonov'",
+                AutoRegularizationIgnoredWarning,
+            )
+            self.auto_regularization = None
+        return self
 
     def to_model_kwargs(self) -> dict:
         """Flatten to the keyword arguments of ``apply_inverse_transfer_function``.
@@ -151,4 +176,8 @@ class FourierApplyInverseSettings(MyBaseModel):
         ones its algorithm reads; the model functions take one flat signature.
         This is the seam between the two.
         """
-        return self.model_dump()
+        kwargs = self.model_dump()
+        # Consumed before the reconstruction, by the caller that resolves it into
+        # regularization_strength; not a parameter of the model functions.
+        kwargs.pop("auto_regularization", None)
+        return kwargs

--- a/waveorder/api/fluorescence.py
+++ b/waveorder/api/fluorescence.py
@@ -142,7 +142,7 @@ class ApplyInverseSettings(FourierApplyInverseSettings):
         return self
 
     def to_model_kwargs(self) -> dict:
-        kwargs = self.model_dump(exclude={"rl"})
+        kwargs = self.model_dump(exclude={"rl", "auto_regularization"})
         if self.rl is not None:
             kwargs.update({f"rl_{name}": value for name, value in self.rl.model_dump().items()})
         return kwargs

--- a/waveorder/cli/reconstruct.py
+++ b/waveorder/cli/reconstruct.py
@@ -40,6 +40,10 @@ def _reconstruct_cli(
     If any parameter has an `lr` key (OptimizableFloat), an optimization loop
     runs before the standard reconstruction pipeline.
 
+    If `apply_inverse` has an `auto_regularization` block, `regularization_strength`
+    is chosen from the data after the transfer function is computed, and the
+    resolved settings are written alongside the config.
+
     See /examples for example configuration files.
 
     \b
@@ -71,6 +75,17 @@ def _reconstruct_cli(
         config_filepath,
         transfer_function_path,
     )
+
+    # Choose regularization_strength from the data, if asked to. This runs after
+    # the transfer function (which it needs, and which does not depend on
+    # `apply_inverse`) and before the reconstruction, so the sweep happens once
+    # rather than per timepoint inside the process pool.
+    if _has_auto_regularization(settings):
+        config_filepath = _run_auto_regularization(
+            settings,
+            input_position_dirpaths[0],
+            config_filepath,
+        )
 
     # Apply inverse transfer function
     apply_inverse_transfer_function_cli(
@@ -127,3 +142,104 @@ def _run_optimization(settings, input_position_dirpath, config_filepath):
 
     input_dataset.close()
     return optimized_path
+
+
+def _has_auto_regularization(settings) -> bool:
+    """Whether any reconstruction block asks for an auto-regularization sweep."""
+    return any(
+        block is not None and block.apply_inverse.auto_regularization is not None
+        for block in (settings.phase, settings.fluorescence)
+    )
+
+
+def _run_auto_regularization(settings, input_position_dirpath, config_filepath):
+    """Sweep regularization_strength, then write the resolved settings to a new config.
+
+    Returns the path of the resolved config, which the reconstruction then uses.
+    """
+    # Deferred imports for the same reason as above
+    import json
+
+    import torch
+    from iohub.ngff import open_ome_zarr
+
+    from waveorder.api import fluorescence, phase
+    from waveorder.cli.printing import echo_headline
+    from waveorder.cli.utils import resolve_time_indices
+    from waveorder.device import resolve_device
+    from waveorder.io import utils
+    from waveorder.optim import autoreg
+
+    if settings.phase is not None and settings.phase.apply_inverse.auto_regularization is not None:
+        contrast, block, api_module = "phase", settings.phase, phase
+        tf_key = "real_potential_transfer_function"
+    else:
+        contrast, block, api_module = "fluorescence", settings.fluorescence, fluorescence
+        tf_key = "optical_transfer_function"
+
+    auto_settings = block.apply_inverse.auto_regularization
+    device = resolve_device(settings.device)
+
+    echo_headline(f"\nChoosing {contrast} regularization_strength with the '{auto_settings.rule}' rule...")
+
+    input_dataset = open_ome_zarr(input_position_dirpath, layout="fov", mode="r")
+    try:
+        # Score the first timepoint the config asks for, so `time_indices: [5, 6]`
+        # is scored on 5 without a setting of its own.
+        t_idx = resolve_time_indices(settings.time_indices, input_dataset.data.shape[0])[0]
+        czyx = input_dataset.to_xarray().isel(t=t_idx).sel(c=settings.input_channel_names)
+
+        y0, x0, size = autoreg.select_crop(torch.as_tensor(czyx.values[0]))
+        czyx_crop = czyx.isel(y=slice(y0, y0 + size), x=slice(x0, x0 + size))
+    finally:
+        input_dataset.close()
+
+    # The transfer function cannot be cropped, only recomputed at the crop's shape.
+    tf_crop = api_module.compute_transfer_function(
+        czyx_crop,
+        recon_dim=settings.reconstruction_dimension,
+        settings=block,
+        device=device,
+    )
+
+    result = autoreg.select_regularization(
+        torch.tensor(czyx_crop.values[0], dtype=torch.float32, device=device),
+        torch.as_tensor(tf_crop[tf_key].values).to(device),
+        auto_settings,
+        contrast=contrast,
+        z_padding=block.transfer_function.z_padding,
+        crop=(y0, x0, size),
+        apodization_rolloff=block.apply_inverse.apodization_rolloff,
+        # No full-frame peak is passed: |H|^2max is set by the optics and the pixel
+        # size, not by the frame size, so the crop's own peak is the same number.
+        # Reading it back off the full transfer function measured 0.000000 decades
+        # of difference on a 2048x2048 frame and cost 10 s against a 0.4 s sweep.
+    )
+    autoreg.warn_all(result)
+
+    click.echo(
+        click.style(
+            f"    regularization_strength = {result.regularization_strength:.4g}\n"
+            f"    lambda / |H|^2max       = {result.lambda_over_h2max:.4g}\n"
+            f"    sweep index             = {result.index} of {len(result.regularization_strengths)}\n"
+            f"    scored crop             = {size}x{size} at (y={y0}, x={x0}), t={t_idx}",
+            fg="green",
+        )
+    )
+
+    if auto_settings.report_path is not None:
+        report_path = Path(auto_settings.report_path)
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(json.dumps(result.to_dict(), indent=2))
+        print(f"Auto-regularization report saved to {report_path}")
+
+    # Freeze the pick into a sibling config, so the reconstruction that follows is
+    # reproducible without re-running the sweep.
+    block.apply_inverse.regularization_strength = result.regularization_strength
+    block.apply_inverse.auto_regularization = None
+
+    resolved_path = config_filepath.parent / (config_filepath.stem + "_autoreg.yml")
+    utils.model_to_yaml(settings, resolved_path)
+    print(f"Auto-regularized settings saved to {resolved_path}")
+
+    return resolved_path

--- a/waveorder/cli/settings.py
+++ b/waveorder/cli/settings.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Any, List, Literal, Optional, Union
 
 from pydantic import Field, NonNegativeInt, PositiveInt, model_validator
@@ -15,6 +16,7 @@ from waveorder.api.fluorescence import (  # noqa: F401
     Settings as FluorescenceSettings,
 )
 from waveorder.api.phase import Settings as PhaseSettings  # noqa: F401
+from waveorder.optim.autoreg import AutoRegularizationIgnoredWarning
 from waveorder.optim.losses import MidbandPowerLossSettings, _LossBaseModel
 
 _LOSS_TYPE_MAP = {
@@ -103,6 +105,49 @@ class ReconstructionSettings(MyBaseModel):
                 f"{self.fluorescence.apply_inverse.reconstruction_algorithm!r} requires "
                 f"reconstruction_dimension 3; it is not implemented for thin (2D) fluorescence."
             )
+
+        # Auto-regularization sweeps a single Tikhonov filter H*/(|H|^2 + lambda),
+        # so it is only defined where the reconstruction is that filter. Both
+        # limits are settled here, while parsing, rather than after the transfer
+        # function has been computed.
+        #
+        # Dropped rather than rejected, like the 'rl' block and unlike the
+        # reconstruction_algorithm checks above. The difference is what the guard
+        # keys on: the napari plugin unwraps Optional[Model] fields and always
+        # submits a populated block for them (see plugin/tab_recon.py
+        # get_pydantic_kwargs), so raising on a block's mere presence would break
+        # every 2D reconstruction started from the GUI. A leaf field like
+        # reconstruction_algorithm carries the user's actual choice and can raise.
+        for name in ("phase", "fluorescence"):
+            block = getattr(self, name)
+            if block is None or block.apply_inverse.auto_regularization is None:
+                continue
+
+            reason = None
+            if self.reconstruction_dimension == 2:
+                reason = (
+                    "reconstruction_dimension is 2; thin reconstructions regularize a "
+                    "singular system rather than a single transfer function"
+                )
+            elif self.birefringence is not None:
+                # A joint birefringence + phase reconstruction feeds one
+                # regularization_strength to both the phase filter and the vector
+                # singular system, so a value chosen from the phase filter alone
+                # would silently retune the birefringence too.
+                reason = (
+                    "a birefringence reconstruction is also configured, and it shares "
+                    "regularization_strength between the phase filter and the vector "
+                    "singular system"
+                )
+
+            if reason is not None:
+                warnings.warn(
+                    f"ignoring {name}.apply_inverse.auto_regularization: {reason}. "
+                    f"regularization_strength = "
+                    f"{block.apply_inverse.regularization_strength} will be used as given.",
+                    AutoRegularizationIgnoredWarning,
+                )
+                block.apply_inverse.auto_regularization = None
 
         return self
 

--- a/waveorder/optim/__init__.py
+++ b/waveorder/optim/__init__.py
@@ -6,11 +6,21 @@ from waveorder.optim._types import (
     extract_optimizable_params,
     has_optimizable_params,
 )
+from waveorder.optim.autoreg import (
+    AutoRegResult,
+    AutoRegularizationIgnoredWarning,
+    AutoRegularizationSettings,
+    select_crop,
+    select_regularization,
+)
 from waveorder.optim.logging import NullLogger, OptimLogger, PrintLogger, TensorBoardLogger
 from waveorder.optim.losses import LossSettings, build_loss_fn
 from waveorder.optim.optimize import OptimizationResult, optimize_reconstruction
 
 __all__ = [
+    "AutoRegResult",
+    "AutoRegularizationIgnoredWarning",
+    "AutoRegularizationSettings",
     "build_loss_fn",
     "LossSettings",
     "OptimizableFloat",
@@ -23,4 +33,6 @@ __all__ = [
     "extract_optimizable_params",
     "has_optimizable_params",
     "optimize_reconstruction",
+    "select_crop",
+    "select_regularization",
 ]

--- a/waveorder/optim/autoreg.py
+++ b/waveorder/optim/autoreg.py
@@ -1,0 +1,656 @@
+"""Automatic selection of ``regularization_strength`` from the data.
+
+A Tikhonov reconstruction ``H*/(|H|^2 + lambda)`` needs a regularization strength,
+and the usual way to find one is to reconstruct at many values and look. This
+module automates the looking: it sweeps lambda, scores each reconstruction, and
+returns a pick plus everything needed to second-guess it.
+
+Two rules are available, both ported from the CZ Biohub weight-search scripts:
+
+``otsu_cnr``
+    Contrast-to-noise ratio of an Otsu split of the local-variance map. Highest
+    score wins. This is a per-reconstruction image-quality metric, in the same
+    family as those in :mod:`waveorder.optim.losses`.
+
+``l_curve``
+    Corner of the trade-off curve between residual norm ``||Hx - y||`` and
+    solution norm ``||x||``. This one is *not* a per-reconstruction score: its
+    criterion is a property of the whole sweep, which is why this module sweeps
+    rather than reusing the gradient-based machinery in
+    :mod:`waveorder.optim.optimize`.
+
+Caveats worth knowing before trusting a pick
+--------------------------------------------
+Neither rule is an oracle, and on real brightfield phase data both have been
+observed to move a lot:
+
+- The L-curves are often not L-shaped. A band-limited operator cannot fit
+  out-of-band data, so the residual floors well above zero and the curve never
+  flattens; the corner finder then locates a corner on what is nearly a line.
+- The ``otsu_cnr`` pick shifts with the scoring crop and, less strongly, with
+  the sweep endpoints.
+
+Treat the result as a starting point, read the report, and check the warnings.
+"""
+
+from __future__ import annotations
+
+import warnings
+from dataclasses import dataclass, field
+from typing import Literal, Optional
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from pydantic import BaseModel, ConfigDict, Field, PositiveInt, model_validator
+from scipy.ndimage import uniform_filter1d
+from scipy.signal import find_peaks
+from torch import Tensor
+
+from waveorder import sampling, util
+from waveorder.reconstruct import tikhonov_regularized_inverse_filter
+
+# Fixed rather than exposed as settings: these are implementation choices of the
+# ported rules, not knobs a config is expected to turn. The crop that gets scored
+# is reported so the choice stays visible.
+
+# Side length of the square yx crop that is scored. Full frames are slow to sweep
+# and their empty regions dilute the metrics; the whole Z range is always kept
+# because the 3D transfer function needs it.
+CROP_SIZE = 256
+
+# Box-filter window for the local-variance map that otsu_cnr thresholds.
+OTSU_WINDOW_SIZE = 3
+
+_OTSU_NUM_BINS = 256
+_LOCAL_VAR_CLIP_QUANTILE = 0.99
+# torch.quantile rejects inputs beyond ~16M elements, which a full-frame volume
+# exceeds; sample down to this many values instead.
+_QUANTILE_MAX_ELEMENTS = 2**24
+_L_CURVE_PROMINENCE_FRACTION = 0.10
+_L_CURVE_PLATEAU_FRACTION = 0.90
+
+
+class AutoRegularizationIgnoredWarning(UserWarning):
+    """An ``auto_regularization`` block was dropped instead of being honoured."""
+
+
+# The CLI suppresses UserWarning at startup to silence torch/CUDA noise; carve out
+# this subclass, as PixelSizeMismatchWarning does, so a dropped sweep is not silent.
+# "default" rather than "always" because a config is parsed at several points in the
+# pipeline, and one copy of the message is the useful number.
+warnings.filterwarnings("default", category=AutoRegularizationIgnoredWarning)
+
+
+class AutoRegularizationSettings(BaseModel):
+    """Sweep ``regularization_strength`` and pick a value, instead of hand-tuning it.
+
+    Only valid for Tikhonov reconstructions of thick (3D) samples.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    rule: Literal["otsu_cnr", "l_curve"] = Field(
+        default="otsu_cnr",
+        description="'otsu_cnr' maximizes local-variance contrast; 'l_curve' finds the trade-off corner",
+    )
+    search_min: float = Field(
+        default=-6.0,
+        description="lower log10 bound of the sweep, interpreted per search_scale",
+    )
+    search_max: float = Field(
+        default=2.0,
+        description="upper log10 bound of the sweep, interpreted per search_scale",
+    )
+    num_samples: PositiveInt = Field(default=25, description="regularization strengths to try")
+    search_scale: Literal["relative", "absolute"] = Field(
+        default="relative",
+        description="'relative' reads the search bounds as log10(lambda / |H|^2max); 'absolute' as log10(lambda)",
+    )
+    report_path: Optional[str] = Field(
+        default=None,
+        description="write the full sweep (scores, norms, chosen index) to this JSON path; null = no report",
+    )
+
+    @model_validator(mode="after")
+    def _validate_search(self):
+        if not self.search_min < self.search_max:
+            raise ValueError(f"search_min must be less than search_max, got {self.search_min} and {self.search_max}")
+        # Curvature is a second derivative; the L-curve rule cannot run on fewer.
+        if self.num_samples < 3:
+            raise ValueError(f"num_samples must be at least 3, got {self.num_samples}")
+        return self
+
+
+@dataclass
+class AutoRegResult:
+    """Outcome of a regularization sweep, and the evidence behind it.
+
+    Attributes
+    ----------
+    regularization_strength : float
+        The pick, in the absolute units the setting takes.
+    index : int
+        Index of the pick within the swept arrays.
+    rule : str
+        Rule that chose it.
+    regularization_strengths : np.ndarray
+        Every strength that was scored, absolute units, ascending.
+    transfer_function_peak_squared : float
+        Peak ``|H|^2`` of the transfer function the sweep scored against.
+    lambda_over_h2max : float
+        ``regularization_strength / transfer_function_peak_squared``: how far the
+        filter attenuates its own peak, and the scale-free way to compare picks.
+    crop : tuple[int, int, int]
+        ``(y0, x0, size)`` of the scored crop within the full frame.
+    scores : np.ndarray
+        ``otsu_cnr`` score per strength; empty when the rule was ``l_curve``.
+    residual_norms : np.ndarray
+        ``||Hx - y||`` per strength; empty when the rule was ``otsu_cnr``.
+    solution_norms : np.ndarray
+        ``||x||`` per strength; empty when the rule was ``otsu_cnr``.
+    warnings : list[str]
+        Non-fatal problems found while selecting, e.g. a pick on the sweep edge.
+    """
+
+    regularization_strength: float
+    index: int
+    rule: str
+    regularization_strengths: np.ndarray
+    transfer_function_peak_squared: float
+    lambda_over_h2max: float
+    crop: tuple[int, int, int]
+    scores: np.ndarray = field(default_factory=lambda: np.array([]))
+    residual_norms: np.ndarray = field(default_factory=lambda: np.array([]))
+    solution_norms: np.ndarray = field(default_factory=lambda: np.array([]))
+    warnings: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        """JSON-serializable view, for ``report_path``."""
+
+        def _list(a):
+            return np.asarray(a).tolist()
+
+        return {
+            "rule": self.rule,
+            "regularization_strength": self.regularization_strength,
+            "index": self.index,
+            "lambda_over_h2max": self.lambda_over_h2max,
+            "transfer_function_peak_squared": self.transfer_function_peak_squared,
+            "crop": {"y0": self.crop[0], "x0": self.crop[1], "size": self.crop[2]},
+            "regularization_strengths": _list(self.regularization_strengths),
+            "scores": _list(self.scores),
+            "residual_norms": _list(self.residual_norms),
+            "solution_norms": _list(self.solution_norms),
+            "warnings": list(self.warnings),
+        }
+
+
+# --- otsu_cnr ---
+
+
+def _local_variance(volumes: Tensor, window_size: int = OTSU_WINDOW_SIZE) -> Tensor:
+    """Local variance map of each volume, computed slice-wise with a box filter.
+
+    ``E[X^2] - E[X]^2`` over a ``window_size`` square, then clipped at the 99th
+    percentile so a few hot voxels do not set the scale for the Otsu histogram.
+
+    Parameters
+    ----------
+    volumes : Tensor
+        ``(N, Z, Y, X)`` stack of reconstructions.
+    window_size : int
+        Side of the averaging window.
+
+    Returns
+    -------
+    Tensor
+        ``(N, Z, Y, X)`` local variances.
+    """
+    N, Z, Y, X = volumes.shape
+    padding = window_size // 2
+
+    flat = volumes.reshape(N * Z, 1, Y, X)
+    # "replicate" matches scipy.ndimage.uniform_filter(mode="nearest").
+    padded = F.pad(flat, [padding] * 4, mode="replicate")
+    padded_sq = F.pad(flat**2, [padding] * 4, mode="replicate")
+
+    mean_x = F.avg_pool2d(padded, kernel_size=window_size, stride=1)
+    mean_x2 = F.avg_pool2d(padded_sq, kernel_size=window_size, stride=1)
+
+    local_var = (mean_x2 - mean_x**2).clamp(min=0).reshape(N, Z, Y, X)
+
+    per_volume = local_var.reshape(N, -1).float()
+    # torch.quantile has a hard input-size limit; a strided sample of a variance
+    # map estimates its 99th percentile closely enough to clip by.
+    if per_volume.shape[1] > _QUANTILE_MAX_ELEMENTS:
+        stride = per_volume.shape[1] // _QUANTILE_MAX_ELEMENTS + 1
+        per_volume = per_volume[:, ::stride]
+    high = torch.quantile(per_volume, _LOCAL_VAR_CLIP_QUANTILE, dim=-1)
+
+    return torch.clamp(local_var, max=high.reshape(N, 1, 1, 1).expand_as(local_var))
+
+
+def _otsu_cnr(flat: Tensor) -> Tensor:
+    """Contrast-to-noise ratio across an Otsu threshold, batched.
+
+    Each row is min-max normalized, histogrammed into 256 bins, split at the
+    threshold maximizing between-class variance, and scored as
+    ``|mu_signal - mu_background| / sigma_background``.
+
+    Parameters
+    ----------
+    flat : Tensor
+        ``(N, M)`` stack of flattened images.
+
+    Returns
+    -------
+    Tensor
+        ``(N,)`` CNR values.
+    """
+    N = flat.shape[0]
+
+    vmin = flat.min(dim=-1, keepdim=True).values
+    vmax = flat.max(dim=-1, keepdim=True).values
+    normed = (flat - vmin) / (vmax - vmin).clamp(min=1e-12)
+
+    bin_edges = torch.linspace(0.0, 1.0, _OTSU_NUM_BINS + 1, device=flat.device, dtype=flat.dtype)
+    bin_centers = (bin_edges[:-1] + bin_edges[1:]) / 2
+
+    bin_idx = torch.bucketize(normed, bin_edges[1:-1])
+    hist = torch.zeros(N, _OTSU_NUM_BINS, device=flat.device, dtype=flat.dtype)
+    hist.scatter_add_(1, bin_idx, torch.ones_like(normed))
+
+    total = hist.sum(dim=-1, keepdim=True)
+    cum_count = torch.cumsum(hist, dim=-1)
+    cum_mean = torch.cumsum(hist * bin_centers.unsqueeze(0), dim=-1)
+    global_mean = cum_mean[:, -1:]
+
+    w0 = cum_count / total.clamp(min=1)
+    w1 = 1.0 - w0
+    mu0 = cum_mean / cum_count.clamp(min=1e-12)
+    mu1 = (global_mean - cum_mean) / (total - cum_count).clamp(min=1e-12)
+
+    between_var = w0 * w1 * (mu0 - mu1) ** 2
+    # The extreme bins split nothing off, so exclude them as candidates.
+    between_var[:, 0] = 0
+    between_var[:, -1] = 0
+
+    thresholds = bin_centers[torch.argmax(between_var, dim=-1)]
+
+    signal_mask = (normed > thresholds.unsqueeze(1)).to(flat.dtype)
+    bg_mask = 1.0 - signal_mask
+
+    n_signal = signal_mask.sum(dim=-1).clamp(min=1)
+    n_bg = bg_mask.sum(dim=-1).clamp(min=1)
+
+    mu_signal = (normed * signal_mask).sum(dim=-1) / n_signal
+    mu_bg = (normed * bg_mask).sum(dim=-1) / n_bg
+    bg_sq = (normed**2 * bg_mask).sum(dim=-1) / n_bg
+    sigma_bg = torch.sqrt((bg_sq - mu_bg**2).clamp(min=0)).clamp(min=1e-12)
+
+    return torch.abs(mu_signal - mu_bg) / sigma_bg
+
+
+def otsu_cnr_scores(recons: Tensor, window_size: int = OTSU_WINDOW_SIZE) -> Tensor:
+    """Score every reconstruction in a sweep by Otsu CNR of its local variance.
+
+    All reconstructions are scored on the *same* z slice — the one whose local
+    variance is largest averaged over the sweep — so the scores stay comparable.
+    Picking a slice per reconstruction would let the metric move for two reasons
+    at once.
+
+    Parameters
+    ----------
+    recons : Tensor
+        ``(N, Z, Y, X)`` reconstructions, one per regularization strength.
+    window_size : int
+        Local-variance window.
+
+    Returns
+    -------
+    Tensor
+        ``(N,)`` scores; higher is better.
+    """
+    local_var = _local_variance(recons, window_size)
+    best_z = torch.argmax(local_var.var(dim=(2, 3)).mean(dim=0))
+    return _otsu_cnr(local_var[:, best_z].reshape(recons.shape[0], -1))
+
+
+# --- l_curve ---
+
+
+def compute_l_curve_norms(
+    data_zyx: Tensor,
+    transfer_function: Tensor,
+    recons: Tensor,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Residual and solution norms for every reconstruction in a sweep.
+
+    ``residual = ||real(ifft(fft(x) * H)) - y||`` and ``solution = ||x||``, the
+    two axes of an L-curve.
+
+    Parameters
+    ----------
+    data_zyx : Tensor
+        ``(Z, Y, X)`` measurement, preprocessed exactly as the reconstruction was.
+    transfer_function : Tensor
+        ``(Z, Y, X)`` forward operator.
+    recons : Tensor
+        ``(N, Z, Y, X)`` reconstructions.
+
+    Returns
+    -------
+    tuple[np.ndarray, np.ndarray]
+        ``(residual_norms, solution_norms)``, each ``(N,)``.
+    """
+    predicted = torch.fft.ifftn(
+        torch.fft.fftn(recons, dim=(-3, -2, -1)) * transfer_function.unsqueeze(0),
+        dim=(-3, -2, -1),
+    ).real
+    residual = predicted - data_zyx.unsqueeze(0)
+
+    residual_norms = torch.linalg.vector_norm(residual, dim=(-3, -2, -1)).cpu().numpy()
+    solution_norms = torch.linalg.vector_norm(recons, dim=(-3, -2, -1)).cpu().numpy()
+    return residual_norms, solution_norms
+
+
+def find_l_curve_corner(residual_norms: np.ndarray, solution_norms: np.ndarray) -> int:
+    """Index of the L-curve corner, by curvature on range-normalized log axes.
+
+    Both log axes are scaled to ``[0, 1]`` first so curvature is
+    scale-independent and the two bends of an L become comparably sharp
+    (Hansen 1992). The bends have opposite signed curvature, so peaks are
+    sought in ``|kappa|``: with two prominent peaks the midpoint between them is
+    returned, with one the centre of its plateau.
+
+    Parameters
+    ----------
+    residual_norms, solution_norms : np.ndarray
+        ``(N,)`` arrays from :func:`compute_l_curve_norms`.
+
+    Returns
+    -------
+    int
+        Index into the sweep.
+    """
+    if len(residual_norms) < 3:
+        return 0
+
+    x_raw = np.log(residual_norms)
+    y_raw = np.log(solution_norms)
+
+    def _normalize(a):
+        span = a.max() - a.min()
+        return (a - a.min()) / span if span > 1e-12 else a - a.min()
+
+    x = uniform_filter1d(_normalize(x_raw), size=3)
+    y = uniform_filter1d(_normalize(y_raw), size=3)
+
+    t = np.arange(len(x))
+    dx, dy = np.gradient(x, t), np.gradient(y, t)
+    ddx, ddy = np.gradient(dx, t), np.gradient(dy, t)
+
+    denominator = np.maximum((dx**2 + dy**2) ** 1.5, 1e-12)
+    abs_curvature = np.abs((dx * ddy - dy * ddx) / denominator)
+
+    max_abs_curv = np.max(abs_curvature)
+    if max_abs_curv < 1e-12:
+        return int(np.argmax(abs_curvature))
+
+    peaks, properties = find_peaks(abs_curvature, prominence=0)
+    if len(peaks) == 0:
+        return int(np.argmax(abs_curvature))
+
+    prominences = properties["prominences"]
+    significant = prominences >= max_abs_curv * _L_CURVE_PROMINENCE_FRACTION
+
+    if significant.sum() >= 2:
+        # Two turning points: the corner of a real L sits between them.
+        top2 = np.argsort(prominences[significant])[-2:]
+        first, second = np.sort(peaks[significant][top2])
+        return (int(first) + int(second)) // 2
+
+    # One turning point: take the middle of the plateau around it, so a broad
+    # flat maximum does not resolve to whichever sample happens to be highest.
+    argmax_idx = int(np.argmax(abs_curvature))
+    in_plateau = abs_curvature >= max_abs_curv * _L_CURVE_PLATEAU_FRACTION
+
+    start = argmax_idx
+    while start > 0 and in_plateau[start - 1]:
+        start -= 1
+    end = argmax_idx
+    while end < len(abs_curvature) - 1 and in_plateau[end + 1]:
+        end += 1
+
+    return (start + end) // 2
+
+
+# --- crop selection ---
+
+
+def select_crop(zyx_data: Tensor, crop_size: int = CROP_SIZE) -> tuple[int, int, int]:
+    """Locate the most structured square yx crop, on a grid of candidates.
+
+    Variance stands in for structure: empty regions score near zero, so this
+    lands on sample rather than background. Returns the full frame when it is
+    already at or below ``crop_size``.
+
+    Parameters
+    ----------
+    zyx_data : Tensor
+        ``(Z, Y, X)`` volume.
+    crop_size : int
+        Side of the square crop.
+
+    Returns
+    -------
+    tuple[int, int, int]
+        ``(y0, x0, size)``.
+    """
+    _, Y, X = zyx_data.shape
+    size = min(crop_size, Y, X)
+    if size >= Y and size >= X:
+        return 0, 0, size
+
+    # Half-overlapping candidates, plus the last valid start in each axis so the
+    # far edge of the frame is reachable when the stride does not divide it.
+    step = max(size // 2, 1)
+
+    def _starts(extent):
+        last = extent - size
+        return sorted({*range(0, last + 1, step), last})
+
+    y_starts = torch.tensor(_starts(Y))
+    x_starts = torch.tensor(_starts(X))
+
+    # Every candidate's variance from one pair of integral images, rather than
+    # re-reducing overlapping windows: a full frame has thousands of candidates.
+    # float64 because the running sums of a 16-bit camera's counts over millions
+    # of pixels leave float32 far behind.
+    plane = zyx_data.double()
+    sums = torch.cumsum(torch.cumsum(plane.sum(dim=0), dim=0), dim=1)
+    squares = torch.cumsum(torch.cumsum((plane**2).sum(dim=0), dim=0), dim=1)
+    sums = F.pad(sums, (1, 0, 1, 0))
+    squares = F.pad(squares, (1, 0, 1, 0))
+
+    def _window_totals(integral):
+        top, bottom = y_starts.unsqueeze(1), (y_starts + size).unsqueeze(1)
+        left, right = x_starts.unsqueeze(0), (x_starts + size).unsqueeze(0)
+        return integral[bottom, right] - integral[top, right] - integral[bottom, left] + integral[top, left]
+
+    count = zyx_data.shape[0] * size * size
+    mean = _window_totals(sums) / count
+    variance = _window_totals(squares) / count - mean**2
+
+    flat = int(torch.argmax(variance))
+    return int(y_starts[flat // len(x_starts)]), int(x_starts[flat % len(x_starts)]), size
+
+
+def _inverse_filter(transfer_function: Tensor, strength: float, apodization_rolloff: float) -> Tensor:
+    """Build the inverse filter the 3D models build, apodization included.
+
+    Kept in step with ``phase_thick_3d`` and ``isotropic_fluorescent_thick_3d``:
+    the sweep has to score the reconstruction that will actually be produced, and
+    ``apodization_rolloff`` reshapes the filter after regularization.
+    """
+    inverse_filter = tikhonov_regularized_inverse_filter(transfer_function, strength)
+    if apodization_rolloff > 0:
+        window = sampling.raised_cosine_window(
+            inverse_filter.shape[-2], apodization_rolloff, device=inverse_filter.device
+        )[:, None] * sampling.raised_cosine_window(
+            inverse_filter.shape[-1], apodization_rolloff, device=inverse_filter.device
+        )
+        inverse_filter = inverse_filter * window
+    return inverse_filter
+
+
+# --- the sweep ---
+
+
+def preprocess_measurement(zyx_data: Tensor, contrast: str, z_padding: int) -> Tensor:
+    """Apply the same preprocessing the model applies before its inverse filter.
+
+    The L-curve residual is only meaningful against the data the reconstruction
+    actually saw, so this has to track the models. Phase pads then intensity
+    normalizes (:func:`waveorder.models.phase_thick_3d.apply_inverse_transfer_function`);
+    fluorescence only pads
+    (:func:`waveorder.models.isotropic_fluorescent_thick_3d.apply_inverse_transfer_function`).
+
+    Parameters
+    ----------
+    zyx_data : Tensor
+        ``(Z, Y, X)`` raw measurement.
+    contrast : {"phase", "fluorescence"}
+        Which model will reconstruct this.
+    z_padding : int
+        Slices padded onto each end of z.
+
+    Returns
+    -------
+    Tensor
+        ``(Z + 2 * z_padding, Y, X)`` preprocessed measurement.
+    """
+    padded = util.pad_zyx_along_z(zyx_data, z_padding)
+    if contrast == "phase":
+        return util.inten_normalization_3D(padded)
+    if contrast == "fluorescence":
+        return padded
+    raise ValueError(f"contrast must be 'phase' or 'fluorescence', got {contrast!r}")
+
+
+def select_regularization(
+    zyx_data: Tensor,
+    transfer_function: Tensor,
+    settings: AutoRegularizationSettings,
+    *,
+    contrast: Literal["phase", "fluorescence"],
+    z_padding: int = 0,
+    crop: tuple[int, int, int] = (0, 0, 0),
+    apodization_rolloff: float = 0.0,
+) -> AutoRegResult:
+    """Sweep regularization strengths and pick one.
+
+    ``zyx_data`` and ``transfer_function`` must already agree in shape: pass the
+    cropped volume together with a transfer function computed at that crop's
+    shape.
+
+    Parameters
+    ----------
+    zyx_data : Tensor
+        ``(Z, Y, X)`` raw measurement to score against, already cropped.
+    transfer_function : Tensor
+        ``(Z + 2 * z_padding, Y, X)`` forward operator for that crop. For phase
+        this is the real potential transfer function; for fluorescence, the OTF.
+    settings : AutoRegularizationSettings
+        Rule and sweep configuration.
+    contrast : {"phase", "fluorescence"}
+        Selects the preprocessing, which differs between the two models.
+    z_padding : int
+        Slices padded onto each end of z, from the transfer function settings.
+    crop : tuple[int, int, int]
+        ``(y0, x0, size)`` of ``zyx_data`` within the full frame, recorded in the
+        result for provenance.
+    apodization_rolloff : float
+        Passed through to the inverse filter, so the sweep scores the same
+        reconstruction the model will produce. By default 0.0 (no apodization).
+
+    Returns
+    -------
+    AutoRegResult
+        The pick and the sweep behind it.
+    """
+    messages: list[str] = []
+
+    measurement = preprocess_measurement(zyx_data, contrast, z_padding)
+    if measurement.shape != transfer_function.shape:
+        raise ValueError(
+            f"transfer function shape {tuple(transfer_function.shape)} does not match the "
+            f"preprocessed data shape {tuple(measurement.shape)}; compute the transfer "
+            f"function at the cropped shape"
+        )
+
+    # The crop's own peak anchors the sweep: |H|^2max is set by the optics and the
+    # pixel size, not by the frame size, so it is the full frame's peak too.
+    h2max = float((transfer_function.abs() ** 2).max())
+    if h2max <= 0:
+        raise ValueError("transfer function is identically zero; check the optical settings")
+
+    powers = np.linspace(settings.search_min, settings.search_max, settings.num_samples)
+    anchor = h2max if settings.search_scale == "relative" else 1.0
+    strengths = (10.0**powers) * anchor
+
+    measurement_fft = torch.fft.fftn(measurement, dim=(-3, -2, -1))
+    recons = torch.stack(
+        [
+            torch.real(
+                torch.fft.ifftn(
+                    measurement_fft * _inverse_filter(transfer_function, float(strength), apodization_rolloff),
+                    dim=(-3, -2, -1),
+                )
+            )
+            for strength in strengths
+        ]
+    )
+
+    scores = np.array([])
+    residual_norms = np.array([])
+    solution_norms = np.array([])
+
+    if settings.rule == "otsu_cnr":
+        unpadded = recons[:, z_padding : recons.shape[1] - z_padding] if z_padding else recons
+        scores = otsu_cnr_scores(unpadded, OTSU_WINDOW_SIZE).cpu().numpy()
+        index = int(np.argmax(scores))
+    elif settings.rule == "l_curve":
+        residual_norms, solution_norms = compute_l_curve_norms(measurement, transfer_function, recons)
+        index = find_l_curve_corner(residual_norms, solution_norms)
+    else:
+        raise ValueError(f"unknown rule {settings.rule!r}")
+
+    if index in (0, len(powers) - 1):
+        edge = "lower" if index == 0 else "upper"
+        messages.append(
+            f"the {settings.rule} pick landed on the {edge} end of the sweep "
+            f"(10^{powers[index]:g}), so the true optimum may lie outside the search bounds"
+        )
+
+    strength = float(strengths[index])
+    return AutoRegResult(
+        regularization_strength=strength,
+        index=index,
+        rule=settings.rule,
+        regularization_strengths=strengths,
+        transfer_function_peak_squared=h2max,
+        lambda_over_h2max=strength / h2max,
+        crop=crop,
+        scores=scores,
+        residual_norms=residual_norms,
+        solution_norms=solution_norms,
+        warnings=messages,
+    )
+
+
+def warn_all(result: AutoRegResult) -> None:
+    """Re-emit a result's collected messages as :class:`UserWarning`."""
+    for message in result.warnings:
+        warnings.warn(message, UserWarning, stacklevel=2)


### PR DESCRIPTION
Add an optional `auto_regularization` block to `apply_inverse`. When a config carries one, `wo rec` sweeps `regularization_strength` after computing the transfer function, picks a value by one of two rules, writes it into a sibling `<config>_autoreg.yml`, and reconstructs from that. There is no new CLI flag: the block is the trigger, as an `lr` key is for `optimization:`.

Try it:

    cd docs/examples/cli
    bash phase_3d_autoreg.sh

which simulates a phantom and reconstructs it with the sweep on, using `configs/phase_3d_autoreg.yml`, and prints:

    Choosing phase regularization_strength with the 'otsu_cnr' rule...
        regularization_strength = 1.129e-07
        lambda / |H|^2max       = 0.0001
        sweep index             = 2 of 9
        scored crop             = 256x256 at (y=0, x=0), t=0

Alongside the reconstruction it leaves two artifacts: `configs/phase_3d_autoreg_autoreg.yml`, the config with the pick frozen in and the block spent, so rerunning it reproduces the reconstruction without sweeping again; and `autoreg_report.json`, every strength, score and norm from the sweep. The output zarr is bit-identical to reconstructing with that lambda written by hand, since auto-regularization only resolves the config and then hands it to the unchanged reconstruction path.

To enable it on an existing config:

    apply_inverse:
      reconstruction_algorithm: Tikhonov
      regularization_strength: 0.001          # the sweep overwrites this
      auto_regularization:
        rule: otsu_cnr
        search_range: [-6.0, 2.0]
        num_samples: 25
        search_scale: relative
        report_path: ./autoreg_report.json

The options
-----------

- `rule` — which criterion picks the value. `otsu_cnr` (default) maximizes contrast-to-noise of an Otsu split of the local-variance map, scored on one shared z slice so the sweep stays comparable. `l_curve` takes the corner of the residual/solution trade-off, from curvature on range-normalized log axes. Both are ported from the CZ Biohub weight-search scripts.

- `search_range` — log10 bounds of the sweep, read according to `search_scale`. Default `[-6.0, 2.0]`.

- `num_samples` — how many strengths to try across that range, evenly spaced in log10. At least 3, since `l_curve`'s curvature is a second derivative. Default 25.

- `search_scale` — `relative` (default) reads `search_range` as log10(lambda / |H|^2max); `absolute` reads it as log10(lambda). Relative is the default because lambda only means something against |H|^2max, which sets how far the filter attenuates its own peak, and that value spans ~6 decades between modalities (1.3e-6 for a brightfield phase CTF, 1.0 for a normalized fluorescence OTF), so absolute decades do not port between configs. |H|^2max is set by the optics and the pixel size rather than the frame size, which is what lets the sweep score a 256x256 crop and still emit a strength suited to the full frame.

- `report_path` — where to write the sweep as JSON: every strength with its score or its two norms, the chosen index, lambda/|H|^2max, the scored crop, and any warnings. `null` (default) writes nothing.

Everything else the sweep needs is fixed rather than exposed: the 256x256 max-variance scoring crop, the local-variance window, and the timepoint, which is the first entry of the config's own `time_indices`.

The sweep rebuilds the inverse filter rather than calling the model per value, so it applies `apodization_rolloff` the same way the models do; a test on an undersampled configuration, where the window actually bites, pins that.

`l_curve` is why this is a sweep rather than a use of the existing `optimization:` machinery: its criterion is a property of the whole trace of norms, not of any single reconstruction, so it cannot be phrased as a loss.

Scope
-----

3D Tikhonov: `phase:` or `fluorescence:` without `birefringence:`. Three cases drop the block while parsing, each with a visible
`AutoRegularizationIgnoredWarning`: thin (2D) reconstructions, which regularize a singular system rather than a single filter; joint birefringence+phase, which shares one `regularization_strength` between the phase filter and the vector singular system; and non-Tikhonov algorithms. These warn rather than raise because the napari plugin unwraps `Optional[Model]` fields and always submits a populated block (`plugin/tab_recon.py::get_pydantic_kwargs`), so rejecting on a block's presence would break every 2D reconstruction started from the GUI. The warning has its own `filterwarnings` carve-out, as `PixelSizeMismatchWarning` does, because `cli/main.py` suppresses `UserWarning`.

Neither rule is an oracle
-------------------------

The module docstring says so too. On real brightfield phase data, L-curves from a band-limited operator are frequently not L-shaped (the residual floors well above zero), and the `otsu_cnr` pick moves with the scoring crop. So a pick landing on a sweep endpoint warns, the crop and lambda/|H|^2max are always echoed, and `report_path` exists for review.

Verification
------------

A swept reconstruction at lambda_i is bit-identical to `apply_inverse_transfer_function(regularization_strength=lambda_i)` for both models, with and without z padding, so the sweep scores the production reconstruction. Both rule ports are pinned against their sources: `otsu_cnr` agrees with `batched_otsu_cnr` to 0.000e+00 on a recorded fixture and on real 2048x2048 data, and `find_l_curve_corner` reproduces the reference index on L-shaped, near-linear and noisy curves. The crop-versus-full-frame |H|^2max claim above was measured at 0.000000 decades on a 2048x2048 frame and 0.005 decades across 128/256/512/1024 for both models. On real data a 2048x2048x16 fluorescence reconstruction takes 18.4 s with the sweep against 16.9 s without, at unchanged peak memory.

Adds 19 unit tests (30 parametrized cases), 8 settings tests and a CLI smoke test alongside `test_optimization_cli`. `phase_3d_autoreg.yml` is generated from the settings model by `test_generate_example_settings`, so it cannot drift, and `phase_3d_autoreg.sh` runs in CI with the other CLI examples.

Note: `wo rec` cannot read big-endian (`>u2`) zarrs, as the zarrs codec pipeline raises "Non-native byte order not supported", with or without this change. Unrelated, but worth an issue.